### PR TITLE
Disable optimizer in foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,8 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-optimizer = true
-optimizer_runs = 999999
 solc_version = "0.8.15"
 via_ir = true
 broadcast = 'records'


### PR DESCRIPTION
We do not benefit from using the optimizer in this repo, which should only contain forge scripts, not deployed contracts. Using it slows down compilation and thus dev cycles.
