### PR TITLE
Remove outdated Foundation Safe validation step

### DIFF
--- a/tasks/eth/004-add-superchainConfig/Validation.md
+++ b/tasks/eth/004-add-superchainConfig/Validation.md
@@ -188,14 +188,6 @@ And we do indeed see these entries:
   **After:** `0x000000000000000000000000566511a1a09561e2896f8c0fd77e8544e59bfdb0` <br/>
   **Meaning:** Implementation address is set to the new [`L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.2.0-rc.1/op-chain-ops/cmd/op-upgrade-extended-pause/main.go#L51-L53).
 
-### `0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a` (`SafeProxy`)
-
-- **Key:** `0x0000000000000000000000000000000000000000000000000000000000000005` <br/>
-  **After:** `0x0000000000000000000000000000000000000000000000000000000000000057` <br/>
-  **Meaning:** The Safe nonce is updated.<br/>
-  **Additional Note:** This number may be slightly different if other transactions have recently
-  been executed. The important thing is that it should increment by 1.
-
 ### `0xbeb5fc579115071764c7423a4f12edde41f106ed` (`OptimismPortalProxy`)
 
 - **Key:** `0x0000000000000000000000000000000000000000000000000000000000000035` <br/>

--- a/tasks/eth/004-add-superchainConfig/Validation.md
+++ b/tasks/eth/004-add-superchainConfig/Validation.md
@@ -186,7 +186,7 @@ And we do indeed see these entries:
 
 - **Key:** `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` <br/>
   **After:** `0x000000000000000000000000566511a1a09561e2896f8c0fd77e8544e59bfdb0` <br/>
-  **Meaning:** Implementation address is set to the new [`L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.2.0-rc.1/op-chain-ops/cmd/op-upgrade-extended-pause/main.go#L51-L53).
+  **Meaning:** Implementation address is set to the new [`L1StandardBridge`](https://github.com/ethereum-optimism/optimism/blob/856c08bf84d9aa829d1e764fc8e9a37d41960ba0/op-chain-ops/cmd/op-upgrade-extended-pause/main.go#L37).
 
 ### `0xbeb5fc579115071764c7423a4f12edde41f106ed` (`OptimismPortalProxy`)
 


### PR DESCRIPTION
This removes a step which validated the nonce change in the Foundation Safe which previously acted as the ProxyAdmin owner. It should have been removed when the runbook was updated for the nested 2 of 2 safe. This new Safe uses a different foundation Safe, so the `0x9ba...` address should not appear at all in the state diff.


It also fixes a link that pointed to the wrong location in the monorepo. 