### PR TITLE
Fixes to 005 runbook

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -177,7 +177,7 @@ congrats, you are done!
 2. Concatenate all signatures and export it as the `SIGNATURES`
    environment variable, i.e. `export
    SIGNATURES="0x[SIGNATURE1][SIGNATURE2]..."`.
-3. Run `just approve 0 # or 1 or ...` to execute the transaction onchain.
+3. Run the `just approve` command as described below to approve the transaction in each multisig.
 
 For example, if the quorum is 2 and you get the following outputs:
 
@@ -196,11 +196,13 @@ Signature: BBBB
 Then you should run:
 
 ```shell
+export SIGNATURES="0xAAAABBBB"
 just \
    --dotenv-path .env \
    --justfile ../../../nested.just \
    approve \
-   foundation  # or council \ 0 or 1 or ...
+   foundation \ # or council
+   0 # or 1 or ...
 ```
 ### Execute the transaction
 

--- a/SINGLE.md
+++ b/SINGLE.md
@@ -108,7 +108,7 @@ just \
    --dotenv-path .env \
    --justfile ../../../single.just \
    sign \
-   tasks/<NETWORK_DIR>/<RUNBOOK_DIR> # 0 or 1 or ...
+   0 # or 1 or ...
 ```
 
 > [!IMPORTANT] This is the most security critical part of the
@@ -176,5 +176,6 @@ export SIGNATURES="0xAAAABBBB"
 just \
    --dotenv-path .env \
    --justfile ../../../single.just \
-    execute 0 # or 1 or ...
+    execute \
+    0 # or 1 or ...
 ```

--- a/tasks/eth/005-protocol-versions-ecotone/README.md
+++ b/tasks/eth/005-protocol-versions-ecotone/README.md
@@ -8,9 +8,6 @@ This is the playbook for updating the required and recommended protocol versions
 
 This transaction should be sent on **Mar 11, 2024**, two and a half days prior to the Ecotone Mainnet activation on `Mar 14 00:00:01 UTC`.
 
-Both versions are currently set to 3.1.0 (Regolith), as they were never updated since the deployment of `ProtocolVersions` for Canyon or Delta.
-[Task-003](../003-protocol-versions-delta/) is scheduled to update these versions to 5.0.0, and this task will then upgrade them to 6.0.0.
-
 ## Signing and execution
 
 Please see the signing and execution instructions in [SINGLE.md](../../../SINGLE.md).
@@ -20,7 +17,7 @@ Please see the signing and execution instructions in [SINGLE.md](../../../SINGLE
 Now click on the "State" tab. Verify that:
 
 * For the `ProtocolVersions` Proxy at `0x8062AbC286f5e7D9428a0Ccb9AbD71e50d93b935` both the
-  recommended and required storage slots are updated from the encoded form of `3.1.0` to `6.0.0`.
+  recommended and required storage slots are updated from the encoded form of `5.0.0` to `6.0.0`.
   * key `0x4aaefe95bd84fd3f32700cf3b7566bc944b73138e41958b5785826df2aecace0`
     * before: `0x0000000000000000000000000000000000000005000000000000000000000000`
     * after : `0x0000000000000000000000000000000000000006000000000000000000000000`
@@ -34,7 +31,7 @@ as well as an `ExecutionSuccess` event by the multisig.
 
 ![](./images/tenderly-state.png)
 
-You can verify the correctness of the storage slots with `chisel`.
+You can verify the correctness of the storage slots with `chisel --use 0.8.15  --evm-version london`.
 Just start it up and enter the slot definitions as found in the contract source code.
 ```
 ➜ bytes32(uint256(keccak256("protocolversion.required")) - 1)


### PR DESCRIPTION
Fixes: 

1. Some outdated text in the 005 runbook
2. Some typos in the SINGLE and NESTED documents