### PR TITLE
Add validate commands for local testing of signatures

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -178,8 +178,11 @@ congrats, you are done!
    environment variable, i.e. `export
    SIGNATURES="0x[SIGNATURE1][SIGNATURE2]..."`.
 3. Run the `just approve` command as described below to approve the transaction in each multisig.
+### Concatenate the signatures
 
-For example, if the quorum is 2 and you get the following outputs:
+1. Collect outputs from all participating signers.
+2. Concatenate all signatures and export it as the `SIGNATURES` environment variable. For example,
+   if the quorum is 2 and you get the following outputs:
 
 ``` shell
 Data:  0xDEADBEEF
@@ -193,17 +196,33 @@ Signer: 0xC0FFEE02
 Signature: BBBB
 ```
 
-Then you should run:
+Then you should run the following command prior to running `just validate` or `just execute`:
 
 ```shell
 export SIGNATURES="0xAAAABBBB"
+```
+
+### Validate the signatures
+
+If you wish to verify that the signatures are correct, you can use the `just validate-approval` command.
+You do not need to connect your ledger or provide an hd path to do so.
+
+1. Run `anvil --fork-url $ETH_RPC_URL` (you can use the same URL as in the `.env` file).
+2. Open a new terminal.
+3. Export the signatures.
+4. Run the following:
+
+```
 just \
    --dotenv-path .env \
    --justfile ../../../nested.just \
-   approve \
-   foundation \ # or council
-   0 # or 1 or ...
+    validate-approval \
+    foundation # or council
 ```
+
+###
+
+
 ### Execute the transaction
 
 Once the signatures have been submitted approving the transaction for all nested Safes run:

--- a/SINGLE.md
+++ b/SINGLE.md
@@ -147,15 +147,11 @@ congrats, you are done!
 
 ## [For Facilitator ONLY] How to execute
 
-### Execute the output
+### Concatenate the signatures
 
 1. Collect outputs from all participating signers.
 2. Concatenate all signatures and export it as the `SIGNATURES`
-   environment variable, i.e. `export
-   SIGNATURES="0x[SIGNATURE1][SIGNATURE2]..."`.
-3. Run `just execute 0 # or 1 or ...` to execute the transaction onchain.
-
-For example, if the quorum is 2 and you get the following outputs:
+   environment variable. For example, if the quorum is 2 and you get the following outputs:
 
 ``` shell
 Data:  0xDEADBEEF
@@ -169,10 +165,38 @@ Signer: 0xC0FFEE02
 Signature: BBBB
 ```
 
-Then you should run:
+Then you should run the following command prior to running `just validate` or `just execute`:
 
 ``` shell
 export SIGNATURES="0xAAAABBBB"
+```
+
+### Validate the signatures
+
+If you wish to verify that the signatures are correct, you can use the `just validate` command.
+You do not need to connect your ledger or provide an hd path to do so.
+
+1. Run `anvil --fork-url $ETH_RPC_URL` (you can use the same URL as in the `.env` file).
+2. Open a new terminal.
+3. Export the signatures.
+4. Run the following:
+
+```
+just \
+   --dotenv-path .env \
+   --justfile ../../../single.just \
+    validate
+```
+
+### Execute the transaction
+
+To execute the transaction:
+
+1. Export the signatures.
+2. Connect your ledger.
+3. Run the following:
+
+```
 just \
    --dotenv-path .env \
    --justfile ../../../single.just \

--- a/nested.just
+++ b/nested.just
@@ -13,7 +13,6 @@ export foundationSafe := "0x847B5c174615B1B7fDF770882256e2D3E95b9D92"
 export foundationOwner0 := "0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64"
 
 export ownerSafe := env_var('OWNER_SAFE')
-export randomPersonEoa := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
 simulate whichSafe hdPath='0':
   #!/usr/bin/env bash
@@ -102,11 +101,13 @@ execute hdPath='0':
     --sig "runJson(string)" \
     ${bundlePath}
 
-simulated-run hdPath='0':
+# Used to ensure that the signatures are valid without broadcasting them to the network
+# Before running this, open a new terminal and run `anvil --fork-url $ETH_RPC_URL`
+# After this script runs, you can use cast commands to manually validate the state diff.
+validate:
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
-  forge script NestedSignFromJson \
-    --fork-url ${rpcUrl} \
-    --sender ${randomPersonEoa} \
-    --sig "runJson(string)" \
-    ${bundlePath}
+  forge build
+  forge script --rpc-url http://127.0.0.1:8545 SignFromJson \
+    --sig "runJson(string)" ${bundlePath} \
+    --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/nested.just
+++ b/nested.just
@@ -14,6 +14,7 @@ export foundationOwner0 := "0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64"
 
 export ownerSafe := env_var('OWNER_SAFE')
 
+# Prints a tenderly simulation URL for the transaction
 simulate whichSafe hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
@@ -45,6 +46,7 @@ simulate whichSafe hdPath='0':
     ${bundlePath} \
     "${safe}"
 
+# Signs the transaction with the nested safe
 sign whichSafe hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
@@ -67,6 +69,28 @@ sign whichSafe hdPath='0':
     ${bundlePath} \
     "${safe}"
 
+# Used to ensure that the signatures are valid without broadcasting them to the network
+# Before running this, open a new terminal and run `anvil --fork-url $ETH_RPC_URL`
+# After this script runs, you can use cast commands to manually validate that the safe nonce has been incremented.
+validate-approval whichSafe:
+  #!/usr/bin/env bash
+  bundlePath=${taskPath}/${bundleName}.json
+    if [ t"{{whichSafe}}" == t"foundation" ]; then
+    safe="${foundationSafe}"
+    echo "Using foundation safe at ${safe}"
+  fi
+  if [ t"{{whichSafe}}" == t"council" ]; then
+    safe="${councilSafe}"
+    echo "Using council safe at ${safe}"
+  fi
+  forge script --rpc-url http://127.0.0.1:8545 SignFromJson \
+    --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+    --sig "approveJson(string,address,bytes)" \
+    ${bundlePath} \
+    ${safe} \
+    ${signatures}
+
+# Calls the approveHash function on a nested safe to approve the transaction
 approve whichSafe hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
@@ -80,7 +104,7 @@ approve whichSafe hdPath='0':
   fi
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
   forge script NestedSignFromJson \
-    --fork-url ${rpcUrl} \
+    --rpc-url ${rpcUrl} \
     --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
     --broadcast \
     --sender ${sender} \
@@ -89,25 +113,15 @@ approve whichSafe hdPath='0':
     ${safe} \
     ${signatures}
 
+# Calls directly to the owner safe (not the nested safes) to execute the transaction
 execute hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
   forge script NestedSignFromJson \
-    --fork-url ${rpcUrl} \
+    --rpc-url ${rpcUrl} \
     --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
     --broadcast \
     --sender ${sender} \
     --sig "runJson(string)" \
     ${bundlePath}
-
-# Used to ensure that the signatures are valid without broadcasting them to the network
-# Before running this, open a new terminal and run `anvil --fork-url $ETH_RPC_URL`
-# After this script runs, you can use cast commands to manually validate the state diff.
-validate:
-  #!/usr/bin/env bash
-  bundlePath=${taskPath}/${bundleName}.json
-  forge build
-  forge script --rpc-url http://127.0.0.1:8545 SignFromJson \
-    --sig "runJson(string)" ${bundlePath} \
-    --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

--- a/single.just
+++ b/single.just
@@ -10,6 +10,7 @@ export OWNER_SAFE := env_var_or_default('FOUNDATION_SAFE', '0x9BA6e03D8B90dE8673
 export foundationOwner0 := "0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64"
 export randomPersonEoa := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
+# Prints a tenderly simulation URL for the transaction
 simulate hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
@@ -28,6 +29,7 @@ simulate hdPath='0':
     --sig "signJson(string)" ${bundlePath} \
     --sender ${signer}
 
+# Signs the transaction with the nested safe
 sign hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
@@ -53,12 +55,13 @@ validate:
     --sig "runJson(string,bytes)" ${bundlePath} ${SIGNATURES} \
     --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
+# Submits signatures and executes the transaction
 execute hdPath='0':
   #!/usr/bin/env bash
   bundlePath=${taskPath}/${bundleName}.json
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
   forge build
-  forge script --fork-url ${ETH_RPC_URL} SignFromJson \
+  forge script --rpc-url ${ETH_RPC_URL} SignFromJson \
     --sig "runJson(string,bytes)" ${bundlePath} ${SIGNATURES} \
     --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" --broadcast \
     --sender ${sender}

--- a/single.just
+++ b/single.just
@@ -8,6 +8,7 @@ export taskPath := invocation_directory()
 # Accounts
 export OWNER_SAFE := env_var_or_default('FOUNDATION_SAFE', '0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A')
 export foundationOwner0 := "0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64"
+export randomPersonEoa := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
 simulate hdPath='0':
   #!/usr/bin/env bash
@@ -40,6 +41,17 @@ sign hdPath='0':
     --rpc-url ${rpcUrl} \
     --sig "signJson(string)" \
     ${bundlePath}
+
+# Used to ensure that the signatures are valid without broadcasting them to the network
+# Before running this, open a new terminal and run `anvil --fork-url $ETH_RPC_URL`
+# After this script runs, you can use cast commands to manually validate the state diff.
+validate:
+  #!/usr/bin/env bash
+  bundlePath=${taskPath}/${bundleName}.json
+  forge build
+  forge script --rpc-url http://127.0.0.1:8545 SignFromJson \
+    --sig "runJson(string,bytes)" ${bundlePath} ${SIGNATURES} \
+    --sender 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --broadcast --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 execute hdPath='0':
   #!/usr/bin/env bash


### PR DESCRIPTION
**Description**

Adds a new method for validating signatures on a persistent local network fork.

Benefits of this approach vs. simply removing `--broadcast`: 
1. Less of a potential for error leading to actually submitting the tx
2. allows for manual inspection of the network after execution (ie. the safe nonce can be observed to have incremented.