### PR TITLE
feat: clean up simulation code and fix bug on address checks

### DIFF
--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -6,32 +6,25 @@ import {NestedMultisigBuilder} from "@base-contracts/script/universal/NestedMult
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
-    address globalSignerSafe; // Hack to avoid passing signerSafe as an input to many functions.
-
     /// @dev Signs the approveHash transaction from the Nested Safe to the System Owner Safe.
     function signJson(string memory _path, address _signerSafe) public {
         _loadJson(_path);
         sign(_signerSafe);
-        globalSignerSafe = _signerSafe;
-        _postCheckWithSim();
     }
 
     /// @dev Submits signatures to call approveHash on the System Owner Safe.
     function approveJson(string memory _path, address _signerSafe, bytes memory _signatures) public {
         _loadJson(_path);
         approve(_signerSafe, _signatures);
-        globalSignerSafe = _signerSafe;
-        _postCheckWithSim();
     }
 
     /// @dev Executes the transaction from the System Owner Safe.
     function runJson(string memory _path) public {
         _loadJson(_path);
         run();
-        // globalSignerSafe = _signerSafe; // TODO how to handle this one?
-        // _postCheckWithSim();
     }
 
     function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
@@ -42,10 +35,9 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
         return vm.envAddress("OWNER_SAFE");
     }
 
-    function _postCheck() internal view virtual override {}
-
-    // A thorough postCheck would apply the needed state overrides and run the simulation, then
-    // execute those assertions against the resulting state. Using `vm.store` changes state therefore
-    // the postCheck methods cannot be `view`, which is why we have this alternate version.
-    function _postCheckWithSim() internal virtual {}
+    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) internal view virtual override {
+        accesses; // Silences compiler warnings.
+        simPayload;
+        require(false, "NestedSignFromJson::_postCheck not implemented"); // Force user to implement post-check assertions.
+    }
 }

--- a/script/SignFromInputJson.s.sol
+++ b/script/SignFromInputJson.s.sol
@@ -6,6 +6,7 @@ import {MultisigBuilder} from "@base-contracts/script/universal/MultisigBuilder.
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 contract SignFromInputJson is MultisigBuilder, JsonTxBuilderBase {
     function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
@@ -18,5 +19,9 @@ contract SignFromInputJson is MultisigBuilder, JsonTxBuilderBase {
         return vm.envAddress("OWNER_SAFE");
     }
 
-    function _postCheck() internal view override {}
+    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) internal pure override {
+        accesses; // Silences compiler warnings.
+        simPayload;
+        require(false, "SignFromInputJson::_postCheck not implemented"); // Force user to implement post-check assertions.
+    }
 }

--- a/script/SignFromJson.s.sol
+++ b/script/SignFromJson.s.sol
@@ -6,18 +6,17 @@ import {MultisigBuilder} from "@base-contracts/script/universal/MultisigBuilder.
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
+import {Vm} from "forge-std/Vm.sol";
 
 contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
     function signJson(string memory _path) public {
         _loadJson(_path);
         sign();
-        _postCheck();
     }
 
     function runJson(string memory _path, bytes memory _signatures) public {
         _loadJson(_path);
         run(_signatures);
-        _postCheck();
     }
 
     function _buildCalls() internal view override returns (IMulticall3.Call3[] memory) {
@@ -29,5 +28,9 @@ contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
         return vm.envAddress("OWNER_SAFE");
     }
 
-    function _postCheck() internal view virtual override {}
+    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload) internal pure virtual override {
+        accesses; // Silences compiler warnings.
+        simPayload;
+        require(false, "SignFromJson::_postCheck not implemented"); // Force user to implement post-check assertions.
+    }
 }


### PR DESCRIPTION
This is in draft until https://github.com/base-org/contracts/pull/72 gets merged. At that point we can update our `base-org/contracts` submodule commit on this PR. Until then, this will not compile, but you can test it locally by checkout out this PR, `cd lib/base-contracts`, then checking out the base commit from that PR

Changes:
- No more hacky simulation approach since it's natively handled by the base contracts repo.
- Fixes bug in address check that ensures all addresses written to storage have code.
- Forces implementer to implement the `_postCheck` method by having a default that reverts. (Note that we use `require(false, "messsage")` instead of `revert("message")` because with the latter solidity is smart enough to detect and warn about unreachable code, so using the former prevents that).