### PR TITLE
tasks(sep-mcpL1): update status

### DIFF
--- a/tasks/sep/003-MCP-L1/README.md
+++ b/tasks/sep/003-MCP-L1/README.md
@@ -1,9 +1,6 @@
 # Sepolia MCP L1 Upgrade
 
-Status: DRAFT, NOT READY TO SIGN
-
-> [!IMPORTANT] !!! DO NOT SIGN using this playbook yet, as the associated governance proposal has
-> not yet passed.
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x8a2ace087c8a01dd79c63e1d472e91844626d0a38ee9f4410af7460431bde566)
 
 ## Objective
 


### PR DESCRIPTION
Updates the status of the MCP L1 upgrade on Sepolia. I found this transaction hash manually and based on the state changes it seems correct, but the reviewer should confirm before merging

I left the "governance vote" section alone since that is placeholder text and we don't need governance approval for testnet upgrades