### PR TITLE
fix: account checks using old and new balances instead of final balance

### DIFF
--- a/src/JsonTxBuilderBase.sol
+++ b/src/JsonTxBuilderBase.sol
@@ -72,7 +72,7 @@ abstract contract JsonTxBuilderBase is CommonBase {
             }
 
             require(
-                accountAccess.oldBalance == accountAccess.account.balance,
+                accountAccess.oldBalance == accountAccess.newBalance,
                 string.concat("Unexpected balance change: ", vm.toString(accountAccess.account))
             );
             require(

--- a/tasks/eth/006-MCP-L1/NestedSignFromJson.s.sol
+++ b/tasks/eth/006-MCP-L1/NestedSignFromJson.s.sol
@@ -399,7 +399,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
                 string.concat("Account has no code: ", vm.toString(accountAccess.account))
             );
             require(
-                accountAccess.oldBalance == accountAccess.account.balance,
+                accountAccess.oldBalance == accountAccess.newBalance,
                 string.concat("Unexpected balance change: ", vm.toString(accountAccess.account))
             );
             require(


### PR DESCRIPTION
related to foundry vm issues during delegate call (wrong accessor)