### PR TITLE
chore: Remove completed task from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,26 +155,6 @@ jobs:
             just simulate-council
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
-  just_simulate_sep-006-2-foundation-guardian-updates:
-    docker:
-    - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - run:
-          name: just simulate sep/006-2-foundation-guardian-updates
-          command: |
-            go install github.com/mikefarah/yq/v4@latest
-            just install
-            cd tasks/sep/006-2-foundation-guardian-updates
-            export SIMULATE_WITHOUT_LEDGER=1
-            just \
-              --dotenv-path .env \
-              --justfile ../../../nested.just \
-              simulate foundation
-            just \
-              --dotenv-path .env \
-              --justfile ../../../nested.just \
-              simulate council
   forge_test:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -221,4 +201,3 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
-      - just_simulate_sep-006-2-foundation-guardian-updates


### PR DESCRIPTION
## Overview

Removes the Foundation Guardian updates task from CI, as it has been completed and is causing CI to fail.