### PR TITLE
task: add Sepolia 009 Presigned Pause Ceremony 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,31 @@ jobs:
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
 
+  just_simulate_sep_009-presigned-pause:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - run:
+          name: just simulate sepolia 009-presigned-pause
+          command: |
+            just install
+            cd tasks/sep/009-presigned-pause
+            just \
+              --dotenv-path .env \
+              --justfile ../../../presigned-pause.just \
+              install
+            forge build
+            export SIMULATE_WITHOUT_LEDGER=1
+            just \
+              --dotenv-path .env \
+              --justfile ../../../presigned-pause.just \
+              whoami 0
+            just \
+              --dotenv-path .env \
+              --justfile ../../../presigned-pause.just \
+              sign
+
   forge_test:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -202,3 +227,4 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
+      - just_simulate_sep_009-presigned-pause

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,11 +171,16 @@ jobs:
               --justfile ../../../presigned-pause.just \
               install
             forge build
+
             export SIMULATE_WITHOUT_LEDGER=1
+            export FOUNDRY_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76
+            export TEST_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76
+
             just \
               --dotenv-path .env \
               --justfile ../../../presigned-pause.just \
               whoami 0
+
             just \
               --dotenv-path .env \
               --justfile ../../../presigned-pause.just \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,36 +156,6 @@ jobs:
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
 
-  just_simulate_sep_009-presigned-pause:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - run:
-          name: just simulate sepolia 009-presigned-pause
-          command: |
-            just install
-            cd tasks/sep/009-presigned-pause
-            just \
-              --dotenv-path .env \
-              --justfile ../../../presigned-pause.just \
-              install
-            forge build
-
-            export SIMULATE_WITHOUT_LEDGER=1
-            export FOUNDRY_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76
-            export TEST_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76
-
-            just \
-              --dotenv-path .env \
-              --justfile ../../../presigned-pause.just \
-              whoami 0
-
-            just \
-              --dotenv-path .env \
-              --justfile ../../../presigned-pause.just \
-              sign
-
   forge_test:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -232,4 +202,3 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
-      - just_simulate_sep_009-presigned-pause

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cache/
 # ignore unwanted output from presigning runbooks
 tmp-*.json
 draft*signer*.json
+ready-*

--- a/PRESIGNED-PAUSE.md
+++ b/PRESIGNED-PAUSE.md
@@ -1,3 +1,28 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Objective](#objective)
+- [Approving the transaction](#approving-the-transaction)
+   - [1. Update repo and move to the appropriate folder for this rehearsal task](#1-update-repo-and-move-to-the-appropriate-folder-for-this-rehearsal-task)
+   - [2. Setup Ledger](#2-setup-ledger)
+   - [3. Sign the transactions](#3-sign-the-transactions)
+   - [3.1. Validate integrity of the simulation.](#31-validate-integrity-of-the-simulation)
+   - [3.2. Validate correctness of the state diff.](#32-validate-correctness-of-the-state-diff)
+   - [3.3. Extract the domain hash and the message hash to approve.](#33-extract-the-domain-hash-and-the-message-hash-to-approve)
+   - [4. Approve the signature on your ledger](#4-approve-the-signature-on-your-ledger)
+   - [5. Send the output to Facilitator(s)](#5-send-the-output-to-facilitators)
+- [[Before Ceremony] Instructions for the facilitator](#before-ceremony-instructions-for-the-facilitator)
+   - [1. Update input files](#1-update-input-files)
+   - [2. Prepare the transactions](#2-prepare-the-transactions)
+- [[After Ceremony] Instructions for the facilitator](#after-ceremony-instructions-for-the-facilitator)
+   - [1. Collect the signatures](#1-collect-the-signatures)
+   - [2. Merge the signatures](#2-merge-the-signatures)
+   - [3. Verify the signatures](#3-verify-the-signatures)
+   - [4. Simulate the transaction with signatures](#4-simulate-the-transaction-with-signatures)
+   - [5. Store and execute the transaction](#5-store-and-execute-the-transaction)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Superchain Presigned Pause
 
 ## Objective
@@ -213,6 +238,8 @@ values.
 ### 2. Prepare the transactions
 
 ```
+cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
+
 just \
    --dotenv-path .env \
    --justfile ../../../presigned-pause.just \
@@ -278,16 +305,16 @@ just \
    simulate-all
 ```
 
-The simulate command will output the Tenderly simulation link, new 
+The simulate command will output the Tenderly simulation link, new
 `ready-*` json files and a `.sh.b64` script for further execution.
 
-Files with prefix `ready-` are transactions fully signed and ready 
+Files with prefix `ready-` are transactions fully signed and ready
 to be executed.
 
-The additional file with extention `.sh.b64` is a oneliner script, 
+The additional file with extention `.sh.b64` is a oneliner script,
 which can be quickly executed from command line.
 
 ### 5. Store and execute the transaction
 
-Please refer to the [internal playbook](https://www.notion.so/oplabs/RB-111-Pre-signed-pause-8bce5b27728b447aa51ba12fcfff9e58?pvs=4#a227c38a09e14518b26095baa91f81c8) 
+Please refer to the [internal playbook](https://www.notion.so/oplabs/RB-111-Pre-signed-pause-8bce5b27728b447aa51ba12fcfff9e58?pvs=4#a227c38a09e14518b26095baa91f81c8)
 for how to store the presigned pause and executed it in emergency situations.

--- a/PRESIGNED-PAUSE.md
+++ b/PRESIGNED-PAUSE.md
@@ -97,6 +97,13 @@ just \
 
 The transactions to be signed are inside the `tx` folder named `draft-{nonce}.json`
 
+If you have an `ETH_RPC_URL` already set in your environment, unset it.
+This is required so the one in the `.env` file takes precedence.
+
+```shell
+unset ETH_RPC_URL
+```
+
 You can sign them by running the following commands:
 
 ```

--- a/PRESIGNED-PAUSE.md
+++ b/PRESIGNED-PAUSE.md
@@ -237,9 +237,30 @@ values.
 
 ### 2. Prepare the transactions
 
-```
-cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
+First, navigate into the task directory and create an empty `tx` folder.
+This is where the transactions to sign will be written.
 
+```shell
+cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
+mkdir tx
+```
+
+If you have an `ETH_RPC_URL` already set in your environment, unset it.
+This is required so the one in the `.env` file takes precedence.
+
+```shell
+unset ETH_RPC_URL
+```
+
+Now, prepare the transactions by running the following command.
+The `FOUNDRY_SENDER` and `TEST_SENDER` environment variables should be the same,
+and set to any address on the Safe that we are preparing the presigned pause for.
+An example address from the Sepolia Foundation Safe is used below:
+
+```shell
+SIMULATE_WITHOUT_LEDGER=1 \
+FOUNDRY_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76 \
+TEST_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76 \
 just \
    --dotenv-path .env \
    --justfile ../../../presigned-pause.just \

--- a/presigned-pause.just
+++ b/presigned-pause.just
@@ -71,7 +71,7 @@ prepare:
   set -x
   REPO_ROOT=`git rev-parse --show-toplevel`
   PATH="$REPO_ROOT/bin:$PATH"
-  echo creating 3 tx...
+  echo Preparing transactions to sign...
   echo
 
   export INPUT_JSON_PATH="${taskPath}/input.json"

--- a/tasks/sep/009-presigned-pause/.env
+++ b/tasks/sep/009-presigned-pause/.env
@@ -1,0 +1,8 @@
+ETH_RPC_URL=https://ethereum-sepolia.publicnode.com
+# This is actually the Foundation safe, but we leave it called the deputy
+# guardian module because we will soon need new presigned pauses using the
+# deputy guardian module, so this minimizes the diff.
+DEPUTY_GUARDIAN_MODULE_ADDR=0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B
+SUPERCHAIN_CONFIG_ADDR=0xC2Be75506d5724086DEB7245bd260Cc9753911Be
+PRESIGNER_SAFE=0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B
+PRESIGN_NONCES="16 17 18 19 20 21"

--- a/tasks/sep/009-presigned-pause/README.md
+++ b/tasks/sep/009-presigned-pause/README.md
@@ -1,0 +1,10 @@
+# Superchain Presigned Pause
+
+Status: SIGNED
+
+See [../../../PRESIGNED-PAUSE.md](../../../PRESIGNED-PAUSE.md) for the playbook.
+
+## Objective
+
+In [this Sepolia transaction](https://sepolia.etherscan.io/tx/0x3d2b9d3e6aaf9f436f05d47c7ae547a3202132ae927966d8fc95c6277d4246b0), we removed the `DeputyGuardianModule` in preparation for setting up the 1 of 1 Guardian Safe.
+This invalidated the presigned pauses from [008-presigned-pause](../008-presigned-pause/README.md).

--- a/tasks/sep/009-presigned-pause/README.md
+++ b/tasks/sep/009-presigned-pause/README.md
@@ -1,6 +1,6 @@
 # Superchain Presigned Pause
 
-Status: SIGNED
+Status: READY TO SIGN
 
 See [../../../PRESIGNED-PAUSE.md](../../../PRESIGNED-PAUSE.md) for the playbook.
 

--- a/tasks/sep/009-presigned-pause/README.md
+++ b/tasks/sep/009-presigned-pause/README.md
@@ -1,6 +1,6 @@
 # Superchain Presigned Pause
 
-Status: READY TO SIGN
+Status: SIGNED
 
 See [../../../PRESIGNED-PAUSE.md](../../../PRESIGNED-PAUSE.md) for the playbook.
 

--- a/tasks/sep/009-presigned-pause/input.json
+++ b/tasks/sep/009-presigned-pause/input.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "meta": {
+    "name": "Call SuperchainConfig.pause('presigned-20240514')"
+  },
+  "transactions": [
+    {
+      "to": "0xC2Be75506d5724086DEB7245bd260Cc9753911Be",
+      "value": "0",
+      "data": "0x6da66355000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000127072657369676e65642d32303234303531340000000000000000000000000000",
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "string",
+            "name": "_identifier",
+            "type": "string"
+          }
+        ],
+        "name": "pause",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "_identifier": "presigned-20240514"
+      }
+    }
+  ]
+}

--- a/tasks/sep/009-presigned-pause/tx/draft-16.json
+++ b/tasks/sep/009-presigned-pause/tx/draft-16.json
@@ -1,0 +1,10 @@
+{
+  "chain_id": "11155111",
+  "rpc_url": "https://ethereum-sepolia.publicnode.com",
+  "created_at": "2024-05-14T13:45:25-07:00",
+  "safe_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "safe_nonce": "16",
+  "target_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "script_name": "PresignPauseFromJson",
+  "data": ""
+}

--- a/tasks/sep/009-presigned-pause/tx/draft-17.json
+++ b/tasks/sep/009-presigned-pause/tx/draft-17.json
@@ -1,0 +1,10 @@
+{
+  "chain_id": "11155111",
+  "rpc_url": "https://ethereum-sepolia.publicnode.com",
+  "created_at": "2024-05-14T13:45:34-07:00",
+  "safe_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "safe_nonce": "17",
+  "target_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "script_name": "PresignPauseFromJson",
+  "data": ""
+}

--- a/tasks/sep/009-presigned-pause/tx/draft-18.json
+++ b/tasks/sep/009-presigned-pause/tx/draft-18.json
@@ -1,0 +1,10 @@
+{
+  "chain_id": "11155111",
+  "rpc_url": "https://ethereum-sepolia.publicnode.com",
+  "created_at": "2024-05-14T13:45:38-07:00",
+  "safe_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "safe_nonce": "18",
+  "target_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "script_name": "PresignPauseFromJson",
+  "data": ""
+}

--- a/tasks/sep/009-presigned-pause/tx/draft-19.json
+++ b/tasks/sep/009-presigned-pause/tx/draft-19.json
@@ -1,0 +1,10 @@
+{
+  "chain_id": "11155111",
+  "rpc_url": "https://ethereum-sepolia.publicnode.com",
+  "created_at": "2024-05-14T13:45:46-07:00",
+  "safe_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "safe_nonce": "19",
+  "target_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "script_name": "PresignPauseFromJson",
+  "data": ""
+}

--- a/tasks/sep/009-presigned-pause/tx/draft-20.json
+++ b/tasks/sep/009-presigned-pause/tx/draft-20.json
@@ -1,0 +1,10 @@
+{
+  "chain_id": "11155111",
+  "rpc_url": "https://ethereum-sepolia.publicnode.com",
+  "created_at": "2024-05-14T13:45:50-07:00",
+  "safe_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "safe_nonce": "20",
+  "target_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "script_name": "PresignPauseFromJson",
+  "data": ""
+}

--- a/tasks/sep/009-presigned-pause/tx/draft-21.json
+++ b/tasks/sep/009-presigned-pause/tx/draft-21.json
@@ -1,0 +1,10 @@
+{
+  "chain_id": "11155111",
+  "rpc_url": "https://ethereum-sepolia.publicnode.com",
+  "created_at": "2024-05-14T13:45:58-07:00",
+  "safe_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "safe_nonce": "21",
+  "target_addr": "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B",
+  "script_name": "PresignPauseFromJson",
+  "data": ""
+}


### PR DESCRIPTION
In [this Sepolia transaction](https://sepolia.etherscan.io/tx/0x3d2b9d3e6aaf9f436f05d47c7ae547a3202132ae927966d8fc95c6277d4246b0), we removed the `DeputyGuardianModule` in preparation for setting up the 1 of 1 Guardian Safe.
This invalidated the presigned pauses from [008-presigned-pause](../008-presigned-pause/README.md). 

This playbook is for generating new presigned pauses, which have the Sepolia Foundation Safe directly call the SuperchainConfig