### PR TITLE
Update CODEOWNERS for /tasks/sep-dev-*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@
 /tasks/sep/mode-*   @sbvegan @mds1 @blmalone @maurelian @zchn
 /tasks/sep/base-*   @sbvegan @mds1 @blmalone @maurelian @zchn
 /tasks/sep/zora-*   @sbvegan @ZakAyesh @OPMattie
+/tasks/sep-dev-*    @ethereum-optimism/contract-reviewers
 
 /tasks/oeth         @maurelian @zchn @mds1
 


### PR DESCRIPTION
so that the reviewer requirement for /tasks/sep-dev-* is the same as /tasks/sep/ and security team does not need to review https://github.com/ethereum-optimism/superchain-ops/pull/192/files