### PR TITLE
Remove confusing additional echo statement

### DIFF
--- a/nested.just
+++ b/nested.just
@@ -30,7 +30,6 @@ simulate whichSafe hdPath='0':
   fi
   signer=$(cast call ${safe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
 
-  echo "signer: $signer"
   echo "safe: $safe"
   echo "Simulating call to {{whichSafe}} at ${safe}"
   if [ -z "$SIMULATE_WITHOUT_LEDGER" ]; then


### PR DESCRIPTION
Prior to this change, the output of running the nested simulation was, unclear about 
which account was being used to sign.

```
➜ just \
   --dotenv-path $(pwd)/.env \
   --justfile ../../../nested.just \
simulate foundation
Running script with assertions
Using script /Users/maurelian/projects/o/superchain-ops.1/tasks/eth/base-001-MCP-L1/NestedSignFromJson.s.sol
getting signer address for foundation...
signer: 0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64 # signer?
safe: 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A
Simulating call to foundation at 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A
Simulating with ledger account: 0x1084092Ac2f04c866806CF3d4a385Afa4F6A6C97  #signer?
```