### PR TITLE
012: update task to executed status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,23 +168,6 @@ jobs:
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
 
-  just_simulate_eth-012-proto-ver-required:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - run:
-          name: just simulate eth/012-proto-ver-required
-          command: |
-            go install github.com/mikefarah/yq/v4@latest
-            just install
-            cd tasks/eth/012-proto-ver-required
-            export SIMULATE_WITHOUT_LEDGER=1
-            just \
-            --dotenv-path $(pwd)/.env \
-            --justfile ../../../single.just \
-            simulate
-
   just_simulate_eth-013-fp-upgrade-fjord:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -273,6 +256,5 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
-      - just_simulate_eth-012-proto-ver-required
       - just_simulate_eth-013-fp-upgrade-fjord
       - just_simulate_eth-014-fjord-gas-config

--- a/tasks/eth/012-proto-ver-required/README.md
+++ b/tasks/eth/012-proto-ver-required/README.md
@@ -1,6 +1,6 @@
 # Mainnet Required Protocol Version Update (7.0.0 - Fjord)
 
-Status: READY TO SIGN
+Status: [EXECUTED](https://etherscan.io/tx/0xea0bb21ac896ddc9fefe9ed2e7ebaf892a7bca3b56ba3d7c272d694e4c83e8e4)
 
 ## Objective
 

--- a/tasks/eth/012-proto-ver-required/SignFromJson.s.sol
+++ b/tasks/eth/012-proto-ver-required/SignFromJson.s.sol
@@ -31,10 +31,9 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     function getAllowedStorageAccess() internal view override returns (address[] memory allowed) {
-        allowed = new address[](3);
+        allowed = new address[](2);
         allowed[0] = foundationUpgradesSafe;
         allowed[1] = proxies.ProtocolVersions;
-        allowed[2] = proxies.SystemConfig;
     }
 
     /// @notice Checks the correctness of the deployment


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

* Update README to EXECUTED status with link to transaction
* remove CI test
* remove unnecessary allowed state diff. Doesn't really have any effect now, but it should never have been there...

