### PR TITLE
mainnet/014: update to executed, remove executed ci checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,43 +168,6 @@ jobs:
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
 
-  just_simulate_eth-013-fp-upgrade-fjord:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - run:
-          name: just simulate eth/013-fp-upgrade-fjord
-          command: |
-            just install
-            cd tasks/eth/013-fp-upgrade-fjord
-            export SIMULATE_WITHOUT_LEDGER=1
-            just \
-              --dotenv-path .env \
-              --justfile ../../../nested.just \
-              simulate council
-            just \
-              --dotenv-path .env \
-              --justfile ../../../nested.just \
-              simulate foundation
-
-  just_simulate_eth-014-fjord-gas-config:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - run:
-          name: just simulate eth/014-fjord-gas-config
-          command: |
-            go install github.com/mikefarah/yq/v4@latest
-            just install
-            cd tasks/eth/014-fjord-gas-config
-            export SIMULATE_WITHOUT_LEDGER=1
-            just \
-            --dotenv-path $(pwd)/.env \
-            --justfile ../../../single.just \
-            simulate
-
   forge_fmt:
     docker:
       - image: <<pipeline.parameters.ci_builder_image>>
@@ -256,5 +219,3 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
-      - just_simulate_eth-013-fp-upgrade-fjord
-      - just_simulate_eth-014-fjord-gas-config

--- a/tasks/eth/014-fjord-gas-config/README.md
+++ b/tasks/eth/014-fjord-gas-config/README.md
@@ -1,6 +1,6 @@
 # Mainnet Gas Config Update for Fjord
 
-Status: READY TO SIGN
+Status: [EXECUTED](https://etherscan.io/tx/0x220c443aebcd9bb04d6eb79e975c6bbe710104feddf8c4fffa3f13eb3c338af9)
 
 ## Objective
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

014 got executed
removing both 013 and 014 ci checks.
