### PR TITLE
Rename DeployHelloWorld to DeployRehearsal1

### DIFF
--- a/script/DeployRehearsal1.s.sol
+++ b/script/DeployRehearsal1.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.0;
 import {Script} from "forge-std/Script.sol";
 import {HelloWorld} from "../src/HelloWorld.sol";
 
-contract DeployHelloWorld is Script {
+contract DeployRehearsal1 is Script {
     function run(address auth) public returns (HelloWorld helloWorld) {
         // Deploy HelloWorld.sol
         vm.startBroadcast();

--- a/security-council-rehearsals/templates/r1-hello-council/justfile
+++ b/security-council-rehearsals/templates/r1-hello-council/justfile
@@ -51,7 +51,7 @@ deploy-contracts hdPath='0':
   cd ../..
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
   forge build
-  forge script DeployHelloWorld --rpc-url ${ETH_RPC_URL} \
+  forge script DeployRehearsal1 --rpc-url ${ETH_RPC_URL} \
     --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" --broadcast \
     --sig 'run(address)' $COUNCIL_SAFE \
     --sender ${sender}


### PR DESCRIPTION
**Description**

Follows the rehearsal deploy script convention set in #262. 

Note: There are no deploy scripts for R2, and R3 does not exist (for reasons I don't clearly recall at this point). So this covers all rehearsal deploy scripts, and helps prepare for #239. 