### PR TITLE
updating 002-mmz-key-handover status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,23 +163,6 @@ jobs:
             just simulate-council
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
-
-  just_simulate_eth-mmz-002-key-handover:
-    docker:
-      - image: <<pipeline.parameters.ci_builder_image>>
-    steps:
-      - checkout
-      - run:
-          name: just simulate eth/mmz-002-key-handover
-          command: |
-            go install github.com/mikefarah/yq/v4@latest
-            just install
-            cd tasks/eth/mmz-002-key-handover
-            export SIMULATE_WITHOUT_LEDGER=1
-            just \
-            --dotenv-path $(pwd)/.env \
-            --justfile ../../../single.just \
-            simulate
             
   forge_build:
     docker:
@@ -241,4 +224,3 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
-      - just_simulate_eth-mmz-002-key-handover

--- a/tasks/eth/mmz-002-key-handover/README.md
+++ b/tasks/eth/mmz-002-key-handover/README.md
@@ -1,6 +1,6 @@
 # Mode, Metal, and Zora Mainnet's Key Handover Upgrade
 
-Status: DRAFT, NOT READY TO SIGN
+Status: [EXECUTED](https://etherscan.io/tx/0xf4e7778523991cf6c4b305970c2c9e71ef27f652e475bb42302d582fa613f5a3)
 
 ## Objective
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Conduit has executed the Key Handover for Mode, Metal, and Zora: https://etherscan.io/tx/0xf4e7778523991cf6c4b305970c2c9e71ef27f652e475bb42302d582fa613f5a3
