### PR TITLE
update: Sepolia prestate `op-program` tag

### DIFF
--- a/tasks/sep/013-fp-granite-prestate/NestedSignFromJson.s.sol
+++ b/tasks/sep/013-fp-granite-prestate/NestedSignFromJson.s.sol
@@ -38,8 +38,8 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     PermissionedDisputeGame currentPDG;
 
     // New dispute game implementations
-    FaultDisputeGame constant faultDisputeGame = FaultDisputeGame(0x19e9d5a58Cbc82120C8AB163bE2aE544ECF4B802);
-    PermissionedDisputeGame constant permissionedDisputeGame = PermissionedDisputeGame(0x7Ef30b65D49229Fc97D4B45bfcf3C435B179771f);
+    FaultDisputeGame constant faultDisputeGame = FaultDisputeGame(0x78F2B801730DBD937Fe2e209aFB3E1CdF3c460Bc);
+    PermissionedDisputeGame constant permissionedDisputeGame = PermissionedDisputeGame(0x4873712BdB5Fe5B3487Bf0A48FfF1Cdfba794CFD);
 
     // See https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/extra/addresses/sepolia/op.json#L12
     DisputeGameFactory constant dgfProxy = DisputeGameFactory(0x05F9613aDB30026FFd634f38e5C4dFd30a197Fa1);
@@ -143,7 +143,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
 
         require(address(faultDisputeGame) == address(dgfProxy.gameImpls(GameTypes.CANNON)), "check-100");
         require(address(permissionedDisputeGame) == address(dgfProxy.gameImpls(GameTypes.PERMISSIONED_CANNON)), "check-100");
-        require(faultDisputeGame.absolutePrestate().raw() == bytes32(0x0385c3f8ee78491001d92b90b07d0cf387b7b52ab9b83b4d87c994e92cf823ba));
-        require(permissionedDisputeGame.absolutePrestate().raw() == bytes32(0x0385c3f8ee78491001d92b90b07d0cf387b7b52ab9b83b4d87c994e92cf823ba));
+        require(faultDisputeGame.absolutePrestate().raw() == bytes32(0x030de10d9da911a2b180ecfae2aeaba8758961fc28262ce989458c6f9a547922));
+        require(permissionedDisputeGame.absolutePrestate().raw() == bytes32(0x030de10d9da911a2b180ecfae2aeaba8758961fc28262ce989458c6f9a547922));
     }
 }

--- a/tasks/sep/013-fp-granite-prestate/README.md
+++ b/tasks/sep/013-fp-granite-prestate/README.md
@@ -7,12 +7,12 @@ Status: READY TO SIGN
 Upgrades the `FaultDisputeGame` to a new implementation with the `ABSOLUTE_PRESTATE` set for the upcoming Granite
 hardfork. The `MIPS` VM, `PreimageOracle`, and `AnchorStateRegistry` from the existing deployment are re-used.
 
-The `ABSOLUTE_PRESTATE` for this release is that of the `op-program/v1.3.0-rc.2` tag. To reproduce it locally:
+The `ABSOLUTE_PRESTATE` for this release is that of the `op-program/v1.3.0-rc.3` tag. To reproduce it locally:
 
 ```sh
 git clone git@github.com:ethereum-optimism/optimism && \
   cd optimism && \
-  git checkout op-program/v1.3.0-rc.2 && \
+  git checkout op-program/v1.3.0-rc.3 && \
   make reproducible-prestate && \
   cat ./op-program/bin/prestate-proof.json | jq -r .pre
 ```
@@ -35,7 +35,7 @@ Please see the instructions for [validation](./VALIDATION.md).
 
 ## Execution
 
-This upgrade changes the `ABSOLUTE_PRESTATE` in the `FaultDisputeGame` and `PermissionedDisputeGame` to that of the `op-program/v1.3.0-rc.2` tag in preparation for the Granite hardfork.
+This upgrade changes the `ABSOLUTE_PRESTATE` in the `FaultDisputeGame` and `PermissionedDisputeGame` to that of the `op-program/v1.3.0-rc.3` tag in preparation for the Granite hardfork.
 
 The batch will be executed on chain ID `11155111`, and contains `2` transactions.
 
@@ -49,13 +49,13 @@ Upgrades the implementation of the `FaultDisputeGame` in the `DisputeGameFactory
 
 **Value:** `0 WEI`
 
-**Raw Input Data:** `0x14f6b1a3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000019e9d5a58cbc82120c8ab163be2ae544ecf4b802`
+**Raw Input Data:** `0x14f6b1a3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000078f2b801730dbd937fe2e209afb3e1cdf3c460bc`
 
 ### Inputs
 
-**\_gameType:** `0`
+**\_impl:** `0x78F2B801730DBD937Fe2e209aFB3E1CdF3c460Bc`
 
-**\_impl:** `0x19e9d5a58Cbc82120C8AB163bE2aE544ECF4B802`
+**\_gameType:** `0`
 
 ## Tx #2: Upgrade `PermissionedDisputeGame`
 
@@ -67,10 +67,10 @@ Upgrades the implementation of the `PermissionedDisputeGame` in the `DisputeGame
 
 **Value:** `0 WEI`
 
-**Raw Input Data:** `0x14f6b1a300000000000000000000000000000000000000000000000000000000000000010000000000000000000000007ef30b65d49229fc97d4b45bfcf3c435b179771f`
+**Raw Input Data:** `0x14f6b1a300000000000000000000000000000000000000000000000000000000000000010000000000000000000000004873712bdb5fe5b3487bf0a48fff1cdfba794cfd`
 
 ### Inputs
 
-**\_impl:** `0x7Ef30b65D49229Fc97D4B45bfcf3C435B179771f`
-
 **\_gameType:** `1`
+
+**\_impl:** `0x4873712BdB5Fe5B3487Bf0A48FfF1Cdfba794CFD`

--- a/tasks/sep/013-fp-granite-prestate/VALIDATION.md
+++ b/tasks/sep/013-fp-granite-prestate/VALIDATION.md
@@ -17,10 +17,10 @@ The only pertinent state changes (ignoring safe nonce updates) should be made to
 
 - **Key**: `0x4d5a9bd2e41301728d41c8e705190becb4e74abe869f75bdb405b63716a35f9e` <br/>
   **Before**: `0x000000000000000000000000864fbe13bb239521a8c837a0aa7c7122ee3eb0b2` <br/>
-  **After**: `0x0000000000000000000000007ef30b65d49229fc97d4b45bfcf3c435b179771f` <br/>
+  **After**: `0x0000000000000000000000004873712BdB5Fe5B3487Bf0A48FfF1Cdfba794CFD` <br/>
   **Meaning**: Updates the PERMISSIONED_CANNON game type implementation. Verify that the new implementation is set using `cast call 0x05f9613adb30026ffd634f38e5c4dfd30a197fa1 "gameImpls(uint32)(address)" 1`. Where `1` is the [`PERMISSIONED_CANNON` game type](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.4.0/packages/contracts-bedrock/src/dispute/lib/Types.sol#L31).
 
 - **Key**: `0xffdfc1249c027f9191656349feb0761381bb32c9f557e01f419fd08754bf5a1b` <br/>
   **Before**: `0x000000000000000000000000a4e392d63ae6096db5454fa178e2f8f99f8ef0ef` <br/>
-  **After**: `0x00000000000000000000000019e9d5a58cbc82120c8ab163be2ae544ecf4b802` <br/>
+  **After**: `0x00000000000000000000000078F2B801730DBD937Fe2e209aFB3E1CdF3c460Bc` <br/>
   **Meaning**: Updates the CANNON game type implementation. Verify that the new implementation is set using `cast call 0x05f9613adb30026ffd634f38e5c4dfd30a197fa1 "gameImpls(uint32)(address)" 0`. Where `0` is the [`CANNON` game type](https://github.com/ethereum-optimism/optimism/blob/op-contracts/v1.4.0/packages/contracts-bedrock/src/dispute/lib/Types.sol#L28).

--- a/tasks/sep/013-fp-granite-prestate/input.json
+++ b/tasks/sep/013-fp-granite-prestate/input.json
@@ -2,7 +2,7 @@
   "chainId": 11155111,
   "metadata": {
     "name": "Granite - Dispute Game Prestate Upgrade",
-    "description": "This upgrade changes the `ABSOLUTE_PRESTATE` in the `FaultDisputeGame` and `PermissionedDisputeGame` to that of the `op-program/v1.3.0-rc.2` tag in preparation for the Granite hardfork."
+    "description": "This upgrade changes the `ABSOLUTE_PRESTATE` in the `FaultDisputeGame` and `PermissionedDisputeGame` to that of the `op-program/v1.3.0-rc.3` tag in preparation for the Granite hardfork."
   },
   "transactions": [
     {
@@ -12,7 +12,7 @@
       },
       "to": "0x05f9613adb30026ffd634f38e5c4dfd30a197fa1",
       "value": "0x0",
-      "data": "0x14f6b1a3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000019e9d5a58cbc82120c8ab163be2ae544ecf4b802",
+      "data": "0x14f6b1a3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000078F2B801730DBD937Fe2e209aFB3E1CdF3c460Bc",
       "contractMethod": {
         "type": "function",
         "name": "setImplementation",
@@ -30,7 +30,7 @@
         "stateMutability": "nonpayable"
       },
       "contractInputsValues": {
-        "_impl": "0x19e9d5a58Cbc82120C8AB163bE2aE544ECF4B802",
+        "_impl": "0x78F2B801730DBD937Fe2e209aFB3E1CdF3c460Bc",
         "_gameType": "0"
       }
     },
@@ -41,7 +41,7 @@
       },
       "to": "0x05f9613adb30026ffd634f38e5c4dfd30a197fa1",
       "value": "0x0",
-      "data": "0x14f6b1a300000000000000000000000000000000000000000000000000000000000000010000000000000000000000007ef30b65d49229fc97d4b45bfcf3c435b179771f",
+      "data": "0x14f6b1a300000000000000000000000000000000000000000000000000000000000000010000000000000000000000004873712BdB5Fe5B3487Bf0A48FfF1Cdfba794CFD",
       "contractMethod": {
         "type": "function",
         "name": "setImplementation",
@@ -60,7 +60,7 @@
       },
       "contractInputsValues": {
         "_gameType": "1",
-        "_impl": "0x7Ef30b65D49229Fc97D4B45bfcf3C435B179771f"
+        "_impl": "0x4873712BdB5Fe5B3487Bf0A48FfF1Cdfba794CFD"
       }
     }
   ]


### PR DESCRIPTION
## Overview

Updates the `op-program` tag to `op-program/v1.3.0-rc.3` for the Sepolia prestate upgrade task.