### PR TITLE
set the README of the task 014-fallback-permissioned-game to `CANCELLED`.

### DIFF
--- a/tasks/sep/014-fallback-permissioned-game/README.md
+++ b/tasks/sep/014-fallback-permissioned-game/README.md
@@ -1,6 +1,6 @@
 # Deputy Guardian - Fall back to `PermissionedDisputeGame`
 
-Status: READY TO SIGN
+Status: CANCELLED
 
 ## Objective
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR set the README of the task 014-fallback-permissioned-game to `CANCELLED` on Sepolia as we decided to not go through this process. 
