### PR TITLE
Add _nestedPostCheck to NestedSignFromJson base script

### DIFF
--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -52,7 +52,6 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
     function _nestedPostCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
         internal
         virtual
-        override
     {
         accesses; // Silences compiler warnings.
         simPayload;

--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -42,8 +42,20 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
         virtual
         override
     {
+        if (msg.sig == this.approveJson.selector) {
+            console.log("Skipping assertions on the approval call");
+            return;
+        }
+        _nestedPostCheck(accesses, simPayload);
+    }
+
+    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+        internal
+        virtual
+        override
+    {
         accesses; // Silences compiler warnings.
         simPayload;
-        require(false, "_postCheck not implemented");
+        require(false, "_nestedPostCheck not implemented");
     }
 }


### PR DESCRIPTION
Implemented the `_nestedPostCheck` function in the `NestedSignFromJson` base script.

This provides a robust fix to the failed simulation on approval calls.

Keeping in draft until #311 is merged to not break it.