### PR TITLE
WIP:Fix the `SCRIPT` PATH For the PresignedPause justfile 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,6 @@ jobs:
               install
             forge build
             export SIMULATE_WITHOUT_LEDGER=1
-            export SCRIPT=PresignPauseFromJson_eth_017
             export FOUNDRY_SENDER=0x3041BA32f451F5850c147805F5521AC206421623
             export TEST_SENDER=0x3041BA32f451F5850c147805F5521AC206421623
             just \

--- a/presigned-pause.just
+++ b/presigned-pause.just
@@ -77,7 +77,7 @@ prepare:
   set -x
   script=PresignPauseFromJson
   if [ -f "${taskPath}/PresignPauseFromJson.s.sol" ]; then
-    script="${taskPath}/PresignPauseFromJson.s.sol"
+    script="./PresignPauseFromJson.s.sol"
   fi
   echo "Using script ${script}"
   REPO_ROOT=`git rev-parse --show-toplevel`

--- a/presigned-pause.just
+++ b/presigned-pause.just
@@ -35,8 +35,8 @@ sign hdPath='0':
     #!/usr/bin/env bash
     set -x
     script=PresignPauseFromJson
-    if [ -n "$SCRIPT" ]; then
-      script=$SCRIPT
+    if [ -f "${taskPath}/PresignPauseFromJson.s.sol" ]; then
+      script="${taskPath}/PresignPauseFromJson.s.sol"
     fi
     echo "Using script ${script}"
     REPO_ROOT=`git rev-parse --show-toplevel`
@@ -76,8 +76,8 @@ prepare:
   #!/usr/bin/env bash
   set -x
   script=PresignPauseFromJson
-  if [ -n "$SCRIPT" ]; then
-    script=$SCRIPT
+  if [ -f "${taskPath}/PresignPauseFromJson.s.sol" ]; then
+    script="${taskPath}/PresignPauseFromJson.s.sol"
   fi
   echo "Using script ${script}"
   REPO_ROOT=`git rev-parse --show-toplevel`
@@ -122,8 +122,8 @@ merge:
 verify:
   #!/usr/bin/env bash
   script=PresignPauseFromJson
-  if [ -n "$SCRIPT" ]; then
-    script=$SCRIPT
+  if [ -f "${taskPath}/PresignPauseFromJson.s.sol" ]; then
+    script="${taskPath}/PresignPauseFromJson.s.sol"
   fi
   echo "Using script ${script}"
   REPO_ROOT=`git rev-parse --show-toplevel`
@@ -141,8 +141,8 @@ verify:
 simulate-all:
   #!/usr/bin/env bash
   script=PresignPauseFromJson
-  if [ -n "$SCRIPT" ]; then
-    script=$SCRIPT
+  if [ -f "${taskPath}/PresignPauseFromJson.s.sol" ]; then
+    script="${taskPath}/PresignPauseFromJson.s.sol"
   fi
   echo "Using script ${script}"
   REPO_ROOT=`git rev-parse --show-toplevel`

--- a/tasks/eth/017-presigned-pause/PresignPauseFromJson.s.sol
+++ b/tasks/eth/017-presigned-pause/PresignPauseFromJson.s.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.15;
 
-import {PresignPauseFromJson as OriginalPresignPauseFromJson} from "./PresignPauseFromJson.s.sol";
+import {PresignPauseFromJson as OriginalPresignPauseFromJson} from "script/PresignPauseFromJson.s.sol";
 import {console} from "forge-std/console.sol";
 
-/// @title PresignPauseFromJson_eth_017
-/// @notice This script is intended for one time use, and can be deleted after the tasks/eth/017-presign-pause runbook is completed.
-contract PresignPauseFromJson_eth_017 is OriginalPresignPauseFromJson {
+/// @title PresignPauseFromJson for the task 017
+contract PresignPauseFromJson is OriginalPresignPauseFromJson {
     address guardianSafe = vm.envAddress("GUARDIAN_SAFE_ADDR");
 
     /// @notice Adds the new DeputyGuardianModule to the guardianSafe to the simulation state.
@@ -21,21 +20,34 @@ contract PresignPauseFromJson_eth_017 is OriginalPresignPauseFromJson {
     }
 
     /// @notice Inserts the DeputyGuardianModule into the Guardian Safe's modules list
-    function _addGuardianSafeOverrides() internal view returns (SimulationStateOverride memory override_) {
-        address deputyGuardianModule = vm.envAddress("DEPUTY_GUARDIAN_MODULE_ADDR");
+    function _addGuardianSafeOverrides()
+        internal
+        view
+        returns (SimulationStateOverride memory override_)
+    {
+        address deputyGuardianModule = vm.envAddress(
+            "DEPUTY_GUARDIAN_MODULE_ADDR"
+        );
         override_.contractAddress = guardianSafe;
         override_.overrides = new SimulationStorageOverride[](2);
         // Ensure the sentinel module (`address(0x01)`) is pointing to the `DeputyGuardianModule`
         // This is `modules[0x1]`, so the key can be derived from
         // `cast index address 0x0000000000000000000000000000000000000001 1`.
         override_.overrides[0] = SimulationStorageOverride({
-            key: keccak256(abi.encode(bytes32(uint256(1)), bytes32(uint256(1)))),
+            key: keccak256(
+                abi.encode(bytes32(uint256(1)), bytes32(uint256(1)))
+            ),
             value: bytes32(uint256(uint160(deputyGuardianModule)))
         });
 
         // Ensure the DeputyGuardianModule is pointing to the sentinel module.
         override_.overrides[1] = SimulationStorageOverride({
-            key: keccak256(abi.encode(bytes32(uint256(uint160(deputyGuardianModule))), bytes32(uint256(1)))),
+            key: keccak256(
+                abi.encode(
+                    bytes32(uint256(uint160(deputyGuardianModule))),
+                    bytes32(uint256(1))
+                )
+            ),
             value: bytes32(uint256(1))
         });
     }

--- a/tasks/eth/017-presigned-pause/tx/draft-100.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-100.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:20+02:00",
+  "created_at": "2024-09-07T12:10:20+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "100",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-101.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-101.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:23+02:00",
+  "created_at": "2024-09-07T12:10:23+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "101",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-102.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-102.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:25+02:00",
+  "created_at": "2024-09-07T12:10:28+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "102",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-103.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-103.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:31+02:00",
+  "created_at": "2024-09-07T12:10:31+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "103",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-104.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-104.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:34+02:00",
+  "created_at": "2024-09-07T12:10:33+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "104",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-95.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-95.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:03+02:00",
+  "created_at": "2024-09-07T12:10:02+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "95",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-96.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-96.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:03+02:00",
+  "created_at": "2024-09-07T12:10:07+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "96",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-97.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-97.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:08+02:00",
+  "created_at": "2024-09-07T12:10:10+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "97",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-98.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-98.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:12+02:00",
+  "created_at": "2024-09-07T12:10:13+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "98",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }

--- a/tasks/eth/017-presigned-pause/tx/draft-99.json
+++ b/tasks/eth/017-presigned-pause/tx/draft-99.json
@@ -1,10 +1,10 @@
 {
   "chain_id": "1",
   "rpc_url": "https://ethereum.publicnode.com",
-  "created_at": "2024-09-05T18:59:17+02:00",
+  "created_at": "2024-09-07T12:10:18+02:00",
   "safe_addr": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
   "safe_nonce": "99",
   "target_addr": "0xc6901F65369FC59fC1B4D6D6bE7A2318Ff38dB5B",
-  "script_name": "PresignPauseFromJson_eth_017",
+  "script_name": "./PresignPauseFromJson.s.sol",
   "data": ""
 }


### PR DESCRIPTION


<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR modify the usage of the script used (`PresignPauseFromJson`) during the usage of the `presigned-pause.just`

Now, this will create custom script into the task directory directly exactly like the other standard tasks that are using the `single.just` (cf screenshot of the single tasks here):


<img width="285" alt="8e0b904ce15536ded555393bfc93270a2fc3cabd9ac47fe2b67cca2d13c4070f" src="https://github.com/user-attachments/assets/4a1549a9-8a8b-4347-9102-c17fe461ac97">


For now, if we need to overrides a PresignedPause task we have to create the file at the into `script/` that is not ideal and  would need to be removed after the task (i.e task [eth_017](https://github.com/ethereum-optimism/superchain-ops/pull/314/files) or task [eth_008](https://github.com/ethereum-optimism/superchain-ops/pull/220/files)) to clean up the repository..

Now, with this PR we can use the script directly into the same folder like this:
<img width="395" alt="image" src="https://github.com/user-attachments/assets/0e4babb7-89e9-4368-86d3-e6e9d646a23f">
  

**Tests**

I have test using the `prepare` and `sign` using the `SIMULATE_WITHOUT_LEDGER` with the CLI like this: 
```bash
SIMULATE_WITHOUT_LEDGER=1 \
FOUNDRY_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76 \
TEST_SENDER=0xF0871b2F75ecD07e2D709b7a2cc0AF6848c1cE76 \
just \
   --dotenv-path .env \
   --justfile ../../../presigned-pause.just \
   sign
```

I just slightly modified the import like in the `single` task like below of the `017-presigned-pause/PresignPauseFromJson.s.sol`

```solidity
import {PresignPauseFromJson as OriginalPresignPauseFromJson} from "script/PresignPauseFromJson.s.sol";
```
**Additional context**
Merge this PR after the current ceremonies.