### PR TITLE
feat(docs): enhance setup instructions with shell code blocks

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -21,7 +21,7 @@
 ```shell
 cd superchain-ops
 git pull
-forge clean
+just clean
 just install
 cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
 ```

--- a/NESTED.md
+++ b/NESTED.md
@@ -18,9 +18,10 @@
 
 ### 1. Update repo:
 
-```
+```shell
 cd superchain-ops
 git pull
+forge clean
 just install
 cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
 ```

--- a/PRESIGNED-PAUSE.md
+++ b/PRESIGNED-PAUSE.md
@@ -49,10 +49,11 @@ repo and run `just install` at the root of the repo, this ceremony
 also requires a `presigner` tool, which can be installed by running
 the following command at the ceremony folder:
 
-```
+```shell
 cd superchain-ops
 git pull
 just install
+forge clean
 cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
 just \
    --dotenv-path $(pwd)/.env \

--- a/PRESIGNED-PAUSE.md
+++ b/PRESIGNED-PAUSE.md
@@ -53,7 +53,7 @@ the following command at the ceremony folder:
 cd superchain-ops
 git pull
 just install
-forge clean
+just clean
 cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
 just \
    --dotenv-path $(pwd)/.env \

--- a/SINGLE.md
+++ b/SINGLE.md
@@ -29,7 +29,7 @@ Fill this out with an appropriate value.
 cd superchain-ops
 git pull
 just install
-forge clean
+just clean
 cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
 ```
 

--- a/SINGLE.md
+++ b/SINGLE.md
@@ -29,6 +29,7 @@ Fill this out with an appropriate value.
 cd superchain-ops
 git pull
 just install
+forge clean
 cd tasks/<NETWORK_DIR>/<RUNBOOK_DIR>
 ```
 

--- a/justfile
+++ b/justfile
@@ -31,3 +31,6 @@ add-transaction bundlePath to sig *params:
   mv {{bundlePath}} ${backupBundlePath}
   mv ${newBundlePath} {{bundlePath}}
   echo "Old bundle backed up to ${backupBundlePath}."
+
+clean:
+  forge clean


### PR DESCRIPTION
Signers often run into the following error if a script has been removed since they last built:  

```
failed to read artifact source file for `/Users/maurelian/projects/o/superchain-ops/script/PresignPauseFromJson_eth_008.s.sol`
```

This is meant to address that.

