### PR TITLE
add: `save-PSPs` feature into the `presigned-pause.just`

### DIFF
--- a/presigned-pause.just
+++ b/presigned-pause.just
@@ -236,3 +236,30 @@ zip-PSPs:
  echo "unzip $ZIPNAME"
  echo "================================================================"
  echo "Make sure again to not let any sensitive informations, into the current folder like the PSPs files."
+
+save-PSPs:
+ #!/bin/bash
+ # Navigate to the directory containing the JSON files
+ # Determine the VAULTNAME based on the taskPath.
+ echo "=================== Save PSPs in the same JSON file ============================="
+ # Ask for confirmation before proceeding
+ if which jq >/dev/null 2>&1; then
+    echo "jq is installed."
+ else
+    echo "jq is not installed, please install jq using homebrew. Using brew install jq"
+    exit
+ fi
+
+ read -p "Do you want to continue, this will save the psps into /tmp/psps.json (y/n): " confirm
+ if [[ $confirm != [yY] ]]; then
+     echo "Operation cancelled."
+     exit 1
+ fi
+
+ cd $taskPath/tx
+ # concatenate all files matching the pattern "ready-*.json" into /tmp/psps.json
+ jq -s '.' ready-*.json > /tmp/psps.json
+ echo "PSPs stored into the /tmp/psps.json file ✅"
+ echo "💡Reminder to remove the PSPs from the current folder."
+
+


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This is a small PR that adding the command `save-PSPs` into the Just file for the PSPs. 

https://github.com/user-attachments/assets/46a4a218-920c-4ef7-b75e-7a881d801933

As `op-defender` is taking in input a array of PSPs in JSON format as per the documentation here:
https://github.com/ethereum-optimism/monitorism/blob/main/op-defender/psp_executor/README.md#1-usage

I think would be nice to be capable to use the same `just` file with the same commands for sake of consistency and speed, after the PSPs are merged and simulated. 

I will update the internal documentation for `op-defender` and the PresignedPause runbook. 

**Tests**

I have performed this tests locally. 

**Metadata**

This is part of https://github.com/ethereum-optimism/security-pod/issues/147
