### PR TITLE
Update base-org/contracts dependency

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,7 @@ remappings = [
   '@eth-optimism-bedrock/=lib/optimism/packages/contracts-bedrock/',
   '@rari-capital/solmate/=lib/solmate',
   '@eth-optimism-superchain-registry/=lib/superchain-registry/',
-  '@solady=lib/optimism/packages/contracts-bedrock/lib/solady/src',
+  '@solady/=lib/optimism/packages/contracts-bedrock/lib/solady/src/',
   'ds-test/=lib/optimism/packages/contracts-bedrock/lib/forge-std/lib/ds-test/src',
   'forge-std/=lib/forge-std/src/',
 ]

--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.15;
 
 import {JsonTxBuilderBase} from "src/JsonTxBuilderBase.sol";
 import {NestedMultisigBuilder} from "@base-contracts/script/universal/NestedMultisigBuilder.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
+import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
@@ -12,13 +14,13 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
     address globalSignerSafe; // Hack to avoid passing signerSafe as an input to many functions.
 
     /// @dev Signs the approveHash transaction from the Nested Safe to the System Owner Safe.
-    function signJson(string memory _path, address _signerSafe) public {
+    function signJson(string memory _path, IGnosisSafe _signerSafe) public {
         _loadJson(_path);
         sign(_signerSafe);
     }
 
     /// @dev Submits signatures to call approveHash on the System Owner Safe.
-    function approveJson(string memory _path, address _signerSafe, bytes memory _signatures) public {
+    function approveJson(string memory _path, IGnosisSafe _signerSafe, bytes memory _signatures) public {
         _loadJson(_path);
         approve(_signerSafe, _signatures);
     }
@@ -37,19 +39,30 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
         return vm.envAddress("OWNER_SAFE");
     }
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+    function _postSign(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal
         virtual
         override
     {
-        if (msg.sig == this.approveJson.selector) {
-            console.log("Skipping assertions on the approval call");
-            return;
-        }
         _nestedPostCheck(accesses, simPayload);
     }
 
-    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+    function _postRun(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
+        internal
+        virtual
+        override
+    {
+        _nestedPostCheck(accesses, simPayload);
+    }
+
+    function _postCheck()
+        internal
+        virtual
+        override
+    {
+    }
+
+    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal
         virtual
     {

--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -3,24 +3,22 @@ pragma solidity ^0.8.15;
 
 import {JsonTxBuilderBase} from "src/JsonTxBuilderBase.sol";
 import {NestedMultisigBuilder} from "@base-contracts/script/universal/NestedMultisigBuilder.sol";
-import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
-import {IGnosisSafe} from "@eth-optimism-bedrock/scripts/interfaces/IGnosisSafe.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
 import {Vm} from "forge-std/Vm.sol";
 
-contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
+abstract contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
     address globalSignerSafe; // Hack to avoid passing signerSafe as an input to many functions.
 
     /// @dev Signs the approveHash transaction from the Nested Safe to the System Owner Safe.
-    function signJson(string memory _path, IGnosisSafe _signerSafe) public {
+    function signJson(string memory _path, address _signerSafe) public {
         _loadJson(_path);
         sign(_signerSafe);
     }
 
     /// @dev Submits signatures to call approveHash on the System Owner Safe.
-    function approveJson(string memory _path, IGnosisSafe _signerSafe, bytes memory _signatures) public {
+    function approveJson(string memory _path, address _signerSafe, bytes memory _signatures) public {
         _loadJson(_path);
         approve(_signerSafe, _signatures);
     }
@@ -37,29 +35,5 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
 
     function _ownerSafe() internal view override returns (address) {
         return vm.envAddress("OWNER_SAFE");
-    }
-
-    function _postSign(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-        override
-    {
-        _postCheck(accesses, simPayload);
-    }
-
-    function _postRun(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-        override
-    {
-        _postCheck(accesses, simPayload);
-    }
-
-    function _postCheck() internal virtual override {}
-
-    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) internal virtual {
-        accesses; // Silences compiler warnings.
-        simPayload;
-        require(false, "_postCheck not implemented");
     }
 }

--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -55,12 +55,7 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
         _nestedPostCheck(accesses, simPayload);
     }
 
-    function _postCheck()
-        internal
-        virtual
-        override
-    {
-    }
+    function _postCheck() internal virtual override {}
 
     function _nestedPostCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal

--- a/script/NestedSignFromJson.s.sol
+++ b/script/NestedSignFromJson.s.sol
@@ -44,7 +44,7 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
         virtual
         override
     {
-        _nestedPostCheck(accesses, simPayload);
+        _postCheck(accesses, simPayload);
     }
 
     function _postRun(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
@@ -52,17 +52,14 @@ contract NestedSignFromJson is NestedMultisigBuilder, JsonTxBuilderBase {
         virtual
         override
     {
-        _nestedPostCheck(accesses, simPayload);
+        _postCheck(accesses, simPayload);
     }
 
     function _postCheck() internal virtual override {}
 
-    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-    {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) internal virtual {
         accesses; // Silences compiler warnings.
         simPayload;
-        require(false, "_nestedPostCheck not implemented");
+        require(false, "_postCheck not implemented");
     }
 }

--- a/script/PresignPauseFromJson.s.sol
+++ b/script/PresignPauseFromJson.s.sol
@@ -20,7 +20,13 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
         allowed[1] = _ownerSafe(); // The nonce is updated in the  Foundation Operations Safe (FOS).
     }
 
-    function _simulationOverrides() internal view virtual override returns (Simulation.StateOverride[] memory overrides_) {
+    function _simulationOverrides()
+        internal
+        view
+        virtual
+        override
+        returns (Simulation.StateOverride[] memory overrides_)
+    {
         // If SIMULATE_WITHOUT_LEDGER is set, we add an override to allow the script to run using the same
         // test address as defined in presigned-pause.just. This is necessary because the presigner tool requires
         // access to the private key of the address that will sign the transaction. Therefore we must insert a test
@@ -36,7 +42,12 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
 
     /// @notice Overrides the MultisigBuilder's _addOverrides function to prevent creating multiple separate state
     ///         overrides for the owner safe when using SIMULATE_WITHOUT_LEDGER.
-    function _safeOverrides(IGnosisSafe _safe, address _owner) internal view override returns (Simulation.StateOverride memory override_) {
+    function _safeOverrides(IGnosisSafe _safe, address _owner)
+        internal
+        view
+        override
+        returns (Simulation.StateOverride memory override_)
+    {
         if (vm.envOr("SIMULATE_WITHOUT_LEDGER", false) || vm.envOr("SIMULATE_WITHOUT_LEDGER", uint256(0)) == 1) {
             override_;
         } else {
@@ -70,12 +81,7 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
         _postCheck(accesses, simPayload);
     }
 
-    function _postCheck()
-        internal
-        virtual
-        override
-    {
-    }
+    function _postCheck() internal virtual override {}
 
     /// @notice This function is called after the simulation of the transactions is done.
     ///     It checks that the transactions only write to the nonce of the PRESIGNER_SAFE contract and the paused slot of

--- a/script/PresignPauseFromJson.s.sol
+++ b/script/PresignPauseFromJson.s.sol
@@ -33,7 +33,7 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
         // address into the owners list.
         if (vm.envOr("SIMULATE_WITHOUT_LEDGER", false) || vm.envOr("SIMULATE_WITHOUT_LEDGER", uint256(0)) == 1) {
             console.log("Adding override for test sender");
-            IGnosisSafe safe = IGnosisSafe(_ownerSafe());
+            address safe = _ownerSafe();
             uint256 nonce = _getNonce(safe);
             overrides_ = new Simulation.StateOverride[](1);
             overrides_[0] = Simulation.overrideSafeThresholdOwnerAndNonce(safe, vm.envAddress("TEST_SENDER"), nonce);
@@ -42,7 +42,7 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
 
     /// @notice Overrides the MultisigBuilder's _addOverrides function to prevent creating multiple separate state
     ///         overrides for the owner safe when using SIMULATE_WITHOUT_LEDGER.
-    function _safeOverrides(IGnosisSafe _safe, address _owner)
+    function _safeOverrides(address _safe, address _owner)
         internal
         view
         override
@@ -65,24 +65,6 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
         return vm.envAddress("PRESIGNER_SAFE");
     }
 
-    function _postSign(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-        override
-    {
-        _postCheck(accesses, simPayload);
-    }
-
-    function _postRun(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-        override
-    {
-        _postCheck(accesses, simPayload);
-    }
-
-    function _postCheck() internal virtual override {}
-
     /// @notice This function is called after the simulation of the transactions is done.
     ///     It checks that the transactions only write to the nonce of the PRESIGNER_SAFE contract and the paused slot of
     ///     the SuperchainConfig contract.
@@ -90,6 +72,7 @@ contract PresignPauseFromJson is MultisigBuilder, JsonTxBuilderBase {
         internal
         view
         virtual
+        override
     {
         checkStateDiff(accesses);
         for (uint256 i; i < accesses.length; i++) {

--- a/script/SignFromJson.s.sol
+++ b/script/SignFromJson.s.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.8.15;
 
 import {JsonTxBuilderBase} from "src/JsonTxBuilderBase.sol";
 import {MultisigBuilder} from "@base-contracts/script/universal/MultisigBuilder.sol";
-import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
 import {Vm} from "forge-std/Vm.sol";
 
-contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
+abstract contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
     function signJson(string memory _path) public {
         _loadJson(_path);
         sign();
@@ -27,29 +26,5 @@ contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
     // todo: allow passing this as a script argument.
     function _ownerSafe() internal view override returns (address) {
         return vm.envAddress("OWNER_SAFE");
-    }
-
-    function _postSign(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-        override
-    {
-        _postCheck(accesses, simPayload);
-    }
-
-    function _postRun(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-        override
-    {
-        _postCheck(accesses, simPayload);
-    }
-
-    function _postCheck() internal virtual override {}
-
-    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) internal virtual {
-        accesses; // Silences compiler warnings.
-        simPayload;
-        require(false, "_postCheck not implemented");
     }
 }

--- a/script/SignFromJson.s.sol
+++ b/script/SignFromJson.s.sol
@@ -45,17 +45,9 @@ contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
         _postCheck(accesses, simPayload);
     }
 
-    function _postCheck()
-        internal
-        virtual
-        override
-    {
-    }
+    function _postCheck() internal virtual override {}
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
-        internal
-        virtual
-    {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload) internal virtual {
         accesses; // Silences compiler warnings.
         simPayload;
         require(false, "_postCheck not implemented");

--- a/script/SignFromJson.s.sol
+++ b/script/SignFromJson.s.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.15;
 
 import {JsonTxBuilderBase} from "src/JsonTxBuilderBase.sol";
 import {MultisigBuilder} from "@base-contracts/script/universal/MultisigBuilder.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {console} from "forge-std/console.sol";
@@ -28,10 +29,32 @@ contract SignFromJson is MultisigBuilder, JsonTxBuilderBase {
         return vm.envAddress("OWNER_SAFE");
     }
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+    function _postSign(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal
         virtual
         override
+    {
+        _postCheck(accesses, simPayload);
+    }
+
+    function _postRun(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
+        internal
+        virtual
+        override
+    {
+        _postCheck(accesses, simPayload);
+    }
+
+    function _postCheck()
+        internal
+        virtual
+        override
+    {
+    }
+
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
+        internal
+        virtual
     {
         accesses; // Silences compiler warnings.
         simPayload;

--- a/security-council-rehearsals/templates/r1-hello-council/SignFromJson.s.sol
+++ b/security-council-rehearsals/templates/r1-hello-council/SignFromJson.s.sol
@@ -6,12 +6,13 @@ pragma solidity ^0.8.15;
 // which is one level above the current location in
 // repo_root/security-council-rehearsals/<rehearsal-dir>/SignFromJson.s.sol
 import {SignFromJson as OriginalSignFromJson} from "../../script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
 
 contract SignFromJson is OriginalSignFromJson {
     // Since after _postCheck hook `require(false)`, the transaction will revert
     // contract extending `SignFromJson` must implement its own `_postCheck` method, thus enforcing a more robust implementation pattern.
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal
         virtual
         override

--- a/security-council-rehearsals/templates/r2-remove-signer/SignFromJson.s.sol
+++ b/security-council-rehearsals/templates/r2-remove-signer/SignFromJson.s.sol
@@ -6,12 +6,13 @@ pragma solidity ^0.8.15;
 // which is one level above the current location in
 // repo_root/security-council-rehearsals/<rehearsal-dir>/SignFromJson.s.sol
 import {SignFromJson as OriginalSignFromJson} from "../../script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
 
 contract SignFromJson is OriginalSignFromJson {
     // Since after _postCheck hook `require(false)`, the transaction will revert
     // contract extending SignFromJson must implement its own _postCheck method, thus enforcing a more robust implementation pattern.
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal
         virtual
         override

--- a/security-council-rehearsals/templates/r4-jointly-upgrade/NestedSignFromJson.s.sol
+++ b/security-council-rehearsals/templates/r4-jointly-upgrade/NestedSignFromJson.s.sol
@@ -6,12 +6,13 @@ pragma solidity ^0.8.15;
 // which is one level above the current location in
 //  repo_root/security-council-rehearsals/<rehearsal-dir>/NestedSignFromJson.s.sol
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "../../script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
 
 contract NestedSignFromJson is OriginalNestedSignFromJson {
     // Since after _postCheck hook `require(false)`, the transaction will revert
     // contract extending NestedSignFromJson must implement its own _postCheck method, thus enforcing a more robust implementation pattern.
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory simPayload)
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory simPayload)
         internal
         virtual
         override

--- a/tasks/eth/009-fp-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/eth/009-fp-upgrade/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
 import {ProtocolVersion, ProtocolVersions} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
@@ -121,7 +122,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
         _proxies.SuperchainConfig = stdJson.readAddress(addressesJson, "$.superchain_config_addr");
     }
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory) internal view override {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
         console.log("Running post-deploy assertions");
         checkSemvers();
         checkStateDiff(accesses);

--- a/tasks/eth/010-1-guardian-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/eth/010-1-guardian-upgrade/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
@@ -119,7 +120,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         override
     {

--- a/tasks/eth/010-2-sc-changes/SignFromJson.s.sol
+++ b/tasks/eth/010-2-sc-changes/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
@@ -269,7 +270,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         override
     {

--- a/tasks/eth/011-proto-ver+ownership-transfers/SignFromJson.s.sol
+++ b/tasks/eth/011-proto-ver+ownership-transfers/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {ProtocolVersions, ProtocolVersion} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
@@ -41,7 +42,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/012-proto-ver-required/SignFromJson.s.sol
+++ b/tasks/eth/012-proto-ver-required/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {ProtocolVersions, ProtocolVersion} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
@@ -37,7 +38,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/013-fp-upgrade-fjord/NestedSignFromJson.s.sol
+++ b/tasks/eth/013-fp-upgrade-fjord/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
@@ -55,7 +56,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
         allowed[4] = livenessGuard;
     }
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory) internal view override {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
         console.log("Running post-deploy assertions");
         checkStateDiff(accesses);
         checkDGFProxy();

--- a/tasks/eth/014-fjord-gas-config/SignFromJson.s.sol
+++ b/tasks/eth/014-fjord-gas-config/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {ProtocolVersions, ProtocolVersion} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
@@ -37,7 +38,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/015-fallback-permissioned-game/SignFromJson.s.sol
+++ b/tasks/eth/015-fallback-permissioned-game/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -55,7 +56,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/016-granite-protocol-versions/SignFromJson.s.sol
+++ b/tasks/eth/016-granite-protocol-versions/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {ProtocolVersions, ProtocolVersion} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
@@ -37,7 +38,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/017-presigned-pause/PresignPauseFromJson.s.sol
+++ b/tasks/eth/017-presigned-pause/PresignPauseFromJson.s.sol
@@ -3,51 +3,34 @@ pragma solidity ^0.8.15;
 
 import {PresignPauseFromJson as OriginalPresignPauseFromJson} from "script/PresignPauseFromJson.s.sol";
 import {console} from "forge-std/console.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 
 /// @title PresignPauseFromJson for the task 017
 contract PresignPauseFromJson is OriginalPresignPauseFromJson {
     address guardianSafe = vm.envAddress("GUARDIAN_SAFE_ADDR");
 
     /// @notice Adds the new DeputyGuardianModule to the guardianSafe to the simulation state.
-    function _addMultipleGenericOverrides()
-        internal
-        view
-        override
-        returns (SimulationStateOverride[] memory overrides_)
-    {
-        overrides_ = new SimulationStateOverride[](1);
+    function _simulationOverrides() internal view override returns (Simulation.StateOverride[] memory overrides_) {
+        overrides_ = new Simulation.StateOverride[](1);
         overrides_[0] = _addGuardianSafeOverrides();
     }
 
     /// @notice Inserts the DeputyGuardianModule into the Guardian Safe's modules list
-    function _addGuardianSafeOverrides()
-        internal
-        view
-        returns (SimulationStateOverride memory override_)
-    {
-        address deputyGuardianModule = vm.envAddress(
-            "DEPUTY_GUARDIAN_MODULE_ADDR"
-        );
+    function _addGuardianSafeOverrides() internal view returns (Simulation.StateOverride memory override_) {
+        address deputyGuardianModule = vm.envAddress("DEPUTY_GUARDIAN_MODULE_ADDR");
         override_.contractAddress = guardianSafe;
-        override_.overrides = new SimulationStorageOverride[](2);
+        override_.overrides = new Simulation.StorageOverride[](2);
         // Ensure the sentinel module (`address(0x01)`) is pointing to the `DeputyGuardianModule`
         // This is `modules[0x1]`, so the key can be derived from
         // `cast index address 0x0000000000000000000000000000000000000001 1`.
-        override_.overrides[0] = SimulationStorageOverride({
-            key: keccak256(
-                abi.encode(bytes32(uint256(1)), bytes32(uint256(1)))
-            ),
+        override_.overrides[0] = Simulation.StorageOverride({
+            key: keccak256(abi.encode(bytes32(uint256(1)), bytes32(uint256(1)))),
             value: bytes32(uint256(uint160(deputyGuardianModule)))
         });
 
         // Ensure the DeputyGuardianModule is pointing to the sentinel module.
-        override_.overrides[1] = SimulationStorageOverride({
-            key: keccak256(
-                abi.encode(
-                    bytes32(uint256(uint160(deputyGuardianModule))),
-                    bytes32(uint256(1))
-                )
-            ),
+        override_.overrides[1] = Simulation.StorageOverride({
+            key: keccak256(abi.encode(bytes32(uint256(uint160(deputyGuardianModule))), bytes32(uint256(1)))),
             value: bytes32(uint256(1))
         });
     }

--- a/tasks/eth/018-granite-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/eth/018-granite-upgrade/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -106,7 +107,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/019-permissionless-games+upgrade-dgm/SignFromJson.s.sol
+++ b/tasks/eth/019-permissionless-games+upgrade-dgm/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -64,7 +65,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/020-set-gas-target/SignFromJson.s.sol
+++ b/tasks/eth/020-set-gas-target/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -25,7 +26,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/base-001-MCP-L1/NestedSignFromJson.s.sol
+++ b/tasks/eth/base-001-MCP-L1/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {Constants, ResourceMetering} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
@@ -354,7 +355,7 @@ contract NestedSignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/base-002-fp-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/eth/base-002-fp-upgrade/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
 import {ProtocolVersion, ProtocolVersions} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
@@ -138,7 +139,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
         allowed[4] = address(foundationSafe);
     }
 
-    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory) internal view override {
+    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
         console.log("Running post-deploy assertions");
         checkSemvers();
         checkStateDiff(accesses);

--- a/tasks/eth/base-002-fp-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/eth/base-002-fp-upgrade/NestedSignFromJson.s.sol
@@ -139,7 +139,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
         allowed[4] = address(foundationSafe);
     }
 
-    function _nestedPostCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
         console.log("Running post-deploy assertions");
         checkSemvers();
         checkStateDiff(accesses);

--- a/tasks/eth/metal-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/eth/metal-001-MCP-L1/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {Constants, ResourceMetering} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
@@ -345,7 +346,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/mmz-002-key-handover/SignFromJson.s.sol
+++ b/tasks/eth/mmz-002-key-handover/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
@@ -32,7 +33,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/mode-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/eth/mode-001-MCP-L1/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {Constants, ResourceMetering} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
@@ -345,7 +346,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/eth/zora-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/eth/zora-001-MCP-L1/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {Constants, ResourceMetering} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
@@ -345,7 +346,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/oeth/002-update-l2pao-to-aliased-l1pao/SignFromJson.s.sol
+++ b/tasks/oeth/002-update-l2pao-to-aliased-l1pao/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Predeploys} from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
 import {AddressAliasHelper} from "@eth-optimism-bedrock/src/vendor/AddressAliasHelper.sol";
 import {console2 as console} from "forge-std/console2.sol";
@@ -59,7 +60,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         override
     {

--- a/tasks/opsep/001-update-l2pao-to-aliased-l1pao/SignFromJson.s.sol
+++ b/tasks/opsep/001-update-l2pao-to-aliased-l1pao/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Predeploys} from "@eth-optimism-bedrock/src/libraries/Predeploys.sol";
 import {AddressAliasHelper} from "@eth-optimism-bedrock/src/vendor/AddressAliasHelper.sol";
 import {console2 as console} from "forge-std/console2.sol";
@@ -55,7 +56,7 @@ contract SignFromJson is OriginalSignFromJson {
     /// @notice Checks the correctness of the deployment
     function _postCheck(
         Vm.AccountAccess[] memory accesses,
-        SimulationPayload memory /* simPayload */
+        Simulation.Payload memory /* simPayload */
     ) internal override {
         console.log("Running post-deploy assertions");
 

--- a/tasks/sep-dev-0/004-fp-granite/SignFromJson.s.sol
+++ b/tasks/sep-dev-0/004-fp-granite/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
@@ -50,7 +51,7 @@ contract NestedSignFromJson is OriginalSignFromJson {
         allowed[2] = livenessGuard;
     }
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory) internal view override {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
         console.log("Running post-deploy assertions");
         checkStateDiff(accesses);
         checkDGFProxy();

--- a/tasks/sep/006-1-guardian-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/sep/006-1-guardian-upgrade/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
@@ -111,7 +112,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         override
     {

--- a/tasks/sep/006-2-sc-changes/SignFromJson.s.sol
+++ b/tasks/sep/006-2-sc-changes/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Proxy} from "@eth-optimism-bedrock/src/universal/Proxy.sol";
 import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
@@ -247,7 +248,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         override
     {

--- a/tasks/sep/009-fpac-upgrade/NestedSignFromJson.s.sol
+++ b/tasks/sep/009-fpac-upgrade/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Constants, ResourceMetering} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
 import {ProtocolVersion, ProtocolVersions} from "@eth-optimism-bedrock/src/L1/ProtocolVersions.sol";
 import {ISemver} from "@eth-optimism-bedrock/src/universal/ISemver.sol";
@@ -95,7 +96,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/010-op-l2-predeploy-upgrade-from-l1/NestedSignFromJson.s.sol
+++ b/tasks/sep/010-op-l2-predeploy-upgrade-from-l1/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -21,7 +22,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     function setUp() public {}
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/012-fp-fjord-upgrade-fix/NestedSignFromJson.s.sol
+++ b/tasks/sep/012-fp-fjord-upgrade-fix/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -124,7 +125,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/013-fp-granite-prestate/NestedSignFromJson.s.sol
+++ b/tasks/sep/013-fp-granite-prestate/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -125,7 +126,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/014-fallback-permissioned-game/SignFromJson.s.sol
+++ b/tasks/sep/014-fallback-permissioned-game/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -55,7 +56,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/015-upgrade-deputy-guardian-module/SignFromJson.s.sol
+++ b/tasks/sep/015-upgrade-deputy-guardian-module/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -64,7 +65,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/016-fp-audit-fix/NestedSignFromJson.s.sol
+++ b/tasks/sep/016-fp-audit-fix/NestedSignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {NestedSignFromJson as OriginalNestedSignFromJson} from "script/NestedSignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -99,7 +100,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/base-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/sep/base-001-MCP-L1/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {Constants, ResourceMetering} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
 import {L1StandardBridge} from "@eth-optimism-bedrock/src/L1/L1StandardBridge.sol";
@@ -345,7 +346,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/base-002-fp-upgrade/SignFromJson.s.sol
+++ b/tasks/sep/base-002-fp-upgrade/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {AnchorStateRegistry} from "@eth-optimism-bedrock/src/dispute/AnchorStateRegistry.sol";
 import {GameTypes, Hash} from "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 import {DelayedWETH} from "@eth-optimism-bedrock/src/dispute/weth/DelayedWETH.sol";
@@ -118,7 +119,7 @@ contract SignFromJson is OriginalSignFromJson {
         _proxies.DelayedWETH = vm.envAddress("DELAYED_WETH_PROXY");
     }
 
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory) internal view override {
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
         console.log("Running post-deploy assertions");
         checkSemvers();
         checkStateDiff(accesses);

--- a/tasks/sep/base-003-fp-granite-prestate/SignFromJson.s.sol
+++ b/tasks/sep/base-003-fp-granite-prestate/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -162,7 +163,7 @@ contract SignFromJson is OriginalSignFromJson {
     /// @notice Checks the correctness of the deployment
     function _postCheck(
         Vm.AccountAccess[] memory accesses,
-        SimulationPayload memory /* simPayload */
+        Simulation.Payload memory /* simPayload */
     ) internal view override {
         console.log("Running post-deploy assertions");
 

--- a/tasks/sep/base-004-fp-audit-fixes/SignFromJson.s.sol
+++ b/tasks/sep/base-004-fp-audit-fixes/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {console2 as console} from "forge-std/console2.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -103,7 +104,7 @@ contract SignFromJson is OriginalSignFromJson {
     /// @notice Checks the correctness of the deployment
     function _postCheck(
         Vm.AccountAccess[] memory accesses,
-        SimulationPayload memory /* simPayload */
+        Simulation.Payload memory /* simPayload */
     ) internal view override {
         console.log("Running post-deploy assertions");
 

--- a/tasks/sep/fp-recovery/001-blacklist-game/SignFromJson.s.sol
+++ b/tasks/sep/fp-recovery/001-blacklist-game/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -78,7 +79,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/fp-recovery/002-fallback-permissioned-game/SignFromJson.s.sol
+++ b/tasks/sep/fp-recovery/002-fallback-permissioned-game/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -68,7 +69,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/fp-recovery/003-enable-permissionless-game/SignFromJson.s.sol
+++ b/tasks/sep/fp-recovery/003-enable-permissionless-game/SignFromJson.s.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {OptimismPortal2, IDisputeGame} from "@eth-optimism-bedrock/src/L1/OptimismPortal2.sol";
 import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
@@ -69,7 +70,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/fp-recovery/004-recover-bonds/SignFromJson.s.sol
+++ b/tasks/sep/fp-recovery/004-recover-bonds/SignFromJson.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.15;
 
 import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {Vm, VmSafe} from "forge-std/Vm.sol";
 import {console2 as console} from "forge-std/console2.sol";
 
@@ -28,7 +29,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory /* accesses */, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory /* accesses */, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/metal-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/sep/metal-001-MCP-L1/SignFromJson.s.sol
@@ -343,7 +343,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/mmz-002-key-handover/SignFromJson.s.sol
+++ b/tasks/sep/mmz-002-key-handover/SignFromJson.s.sol
@@ -32,7 +32,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/mode-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/sep/mode-001-MCP-L1/SignFromJson.s.sol
@@ -343,7 +343,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override

--- a/tasks/sep/zora-001-MCP-L1/SignFromJson.s.sol
+++ b/tasks/sep/zora-001-MCP-L1/SignFromJson.s.sol
@@ -343,7 +343,7 @@ contract SignFromJson is OriginalSignFromJson {
     }
 
     /// @notice Checks the correctness of the deployment
-    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory /* simPayload */ )
         internal
         view
         override


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

We did a big cleanup of the `*MultisigBuilder` contracts in base-org/contracts#97.

This PR bumps the base-org/contracts dependency to pick up these changes, and makes all the required updates for the scripts.

**Tests**

I tested one of the tasks before and after this change to ensure that the same data-to-sign was produced, as well as the same output / assertions.