### PR TITLE
chore: set the status to `SIGNED`.

### DIFF
--- a/tasks/eth/base-002-fp-upgrade/README.md
+++ b/tasks/eth/base-002-fp-upgrade/README.md
@@ -1,6 +1,6 @@
 # Base Mainnet Fault Proofs Upgrade
 
-Status: [READY TO SIGN]
+Status: [SIGNED]
 
 ## Objective
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Update the status of `base-002-fp-upgrade` to **SIGNED** for now and should be set  to **EXECUTED** after execution. 