### PR TITLE
Add ability to re-initialize AnchorStateRegistry with additional game types

### DIFF
--- a/tasks/sep/fp-recovery/005-set-game-implementation/README.md
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/README.md
@@ -52,15 +52,8 @@ just copy-anchor-state <fromGameType> <toGameTypes>
 where `<fromGameType>` is the existing game type to load the current game type from and `<toGameTypes>` is the game
 types to copy the anchor state to. The anchor state to set is taken _at the time the just command is run_. The task is
 then created with a fixed anchor state to set which may roll back later updates to the game type on-chain if games 
-resolve after the `just` command is run to add the transaction to the task definition.
-
-**Important**: Re-initializing the `AnchorStateRegistry` removes all existing anchor
-states so all supported game types must be listed. The `<fromGameType>` is automatically included. Thus while only two
-game types are in use, the permissionless `CANNON` game type can be added based on the `PERMISSIONED` game type with:
-
-```
-just copy-anchor-state 1 0
-```
+resolve after the `just` command is run to add the transaction to the task definition. However this only affects the 
+game types in `<toGameTypes>`, other anchor states are left unchanged.
 
 #### Removing All Transactions
 

--- a/tasks/sep/fp-recovery/005-set-game-implementation/README.md
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/README.md
@@ -50,7 +50,11 @@ just copy-anchor-state <fromGameType> <toGameTypes>
 ```
 
 where `<fromGameType>` is the existing game type to load the current game type from and `<toGameTypes>` is the game
-types to copy the anchor state to.  **Important**: Re-initializing the `AnchorStateRegistry` removes all existing anchor
+types to copy the anchor state to. The anchor state to set is taken _at the time the just command is run_. The task is
+then created with a fixed anchor state to set which may roll back later updates to the game type on-chain if games 
+resolve after the `just` command is run to add the transaction to the task definition.
+
+**Important**: Re-initializing the `AnchorStateRegistry` removes all existing anchor
 states so all supported game types must be listed. The `<fromGameType>` is automatically included. Thus while only two
 game types are in use, the permissionless `CANNON` game type can be added based on the `PERMISSIONED` game type with:
 

--- a/tasks/sep/fp-recovery/005-set-game-implementation/README.md
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/README.md
@@ -30,11 +30,35 @@ supported game type such as enabling permissionless games.
 ### Adding Transactions
 
 The batch can be created with an arbitrary number of transactions to set the implementation of multiple game types in a
-single batch. For each game type to set, run:
+single batch. 
+
+#### Set Game Implementation
+
+For each game type to set, run:
 
 ```
 just set-implementation <gameType> <newImplAddr>
 ```
+
+#### Re-initialize AnchorStateRegistry
+
+To add a new game type to the AnchorStateRegistry, it needs to be re-initialized to set an initial anchor state for the
+new game type. To add the transactions required for this run:
+
+```
+just copy-anchor-state <fromGameType> <toGameTypes>
+```
+
+where `<fromGameType>` is the existing game type to load the current game type from and `<toGameTypes>` is the game
+types to copy the anchor state to.  **Important**: Re-initializing the `AnchorStateRegistry` removes all existing anchor
+states so all supported game types must be listed. The `<fromGameType>` is automatically included. Thus while only two
+game types are in use, the permissionless `CANNON` game type can be added based on the `PERMISSIONED` game type with:
+
+```
+just copy-anchor-state 1 0
+```
+
+#### Removing All Transactions
 
 To remove all added transactions, run `just clean`. Note that you need to run `just prep <l1> <l2>` again after clean.
 

--- a/tasks/sep/fp-recovery/005-set-game-implementation/README.md
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/README.md
@@ -69,6 +69,16 @@ just clean prep sepolia op
 just set-implementation 0 <cannon-game-impl>
 just set-implementation 1 <permissioned-game-impl>
 ```
+#### Example - Adding Permissionless Dispute Game
+
+To prepare the task to set an implementation for `CANNON` (0) and copy the `PERMISSIONED` anchor state to be its initial
+anchor state run:
+
+```bash
+just clean prep sepolia op
+just set-implementation 0 <cannon-game-impl>
+just copy-anchor-state 1 0
+```
 
 ### Generated Documentation
 

--- a/tasks/sep/fp-recovery/005-set-game-implementation/justfile
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/justfile
@@ -37,6 +37,7 @@ prep l1='' l2='':
   CONFIG_TOML=$(curl -s --show-error --fail "${CONFIG_URL}")
   SYSTEM_CONFIG=$(echo "${CONFIG_TOML}" | yq -p toml .addresses.SystemConfigProxy)
   OWNER_SAFE=$(echo "${CONFIG_TOML}" | yq -p toml .addresses.ProxyAdminOwner)
+  PROXY_ADMIN=$(echo "${CONFIG_TOML}" | yq -p toml .addresses.ProxyAdmin)
 
   cat >> out/.env << EOF
   SAFE_NONCE=""
@@ -44,6 +45,7 @@ prep l1='' l2='':
   L2_CHAIN_NAME="{{l2}}"
   SYSTEM_CONFIG="${SYSTEM_CONFIG}"
   OWNER_SAFE="${OWNER_SAFE}"
+  PROXY_ADMIN="${PROXY_ADMIN}"
   EOF
 
 # Generate the `input.json` with the game type and implementation to set.
@@ -92,5 +94,109 @@ set-implementation gameType='' implAddr='':
 
   # Update the README
   INFO="* Set implementation for game type {{gameType}} to {{implAddr}} in \`DisputeGameFactory\` ${DGF_ADDR}: \`setImplementation({{gameType}}, {{implAddr}})\`"
+  sed -e "s|<!--NEXT TASK DESCRIPTION-->|${INFO}\n<!--NEXT TASK DESCRIPTION-->|" out/README.md > out/README.md.tmp
+  mv out/README.md.tmp out/README.md
+
+copy-anchor-state fromGameType='' toGameTypes='':
+  #!/usr/bin/env bash
+  set -euo pipefail
+  . out/.env
+  export ETH_RPC_URL # Make available to cast since the .env file is in the out subdir.
+
+  DGF_ADDR=$(cast call "${SYSTEM_CONFIG}" "disputeGameFactory()(address)")
+
+  # Find the anchor state registry for the source game.
+  SOURCE_IMPL=$(cast call "${DGF_ADDR}" 'gameImpls(uint32)(address)' '{{fromGameType}}')
+  REGISTRY_PROXY=$(cast call "${SOURCE_IMPL}" 'anchorStateRegistry()(address)' "${SOURCE_IMPL}")
+  REGISTRY_IMPL=$(cast call "${REGISTRY_PROXY}" 'implementation()(address)')
+  SUPERCHAIN_CONFIG=$(cast call "${REGISTRY_PROXY}" 'superchainConfig()(address)')
+
+  # Load the current anchor state
+  ANCHOR_JSON=$(cast call -j "${REGISTRY_PROXY}" 'anchors(uint32)(bytes32,uint256)' '{{fromGameType}}')
+  ANCHOR_ROOT=$(echo "${ANCHOR_JSON}" | jq -r '.[0]')
+  ANCHOR_BLOCK=$(echo "${ANCHOR_JSON}" | jq -r '.[1]')
+
+  STORAGE_SETTER_ADDR="0x54F8076f4027e21A010b4B3900C86211Dd2C2DEB"
+  UPGRADE_AND_CALL_SIG="upgradeAndCall(address,address,bytes)"
+  RESET_CALL=$(cast calldata "setBytes32(bytes32,bytes32)" 0x0000000000000000000000000000000000000000000000000000000000000000 0x0000000000000000000000000000000000000000000000000000000000000000)
+  ENCODED_RESET_CALL=$(cast calldata "${UPGRADE_AND_CALL_SIG}" "${REGISTRY_PROXY}" "${STORAGE_SETTER_ADDR}" "${RESET_CALL}")
+
+  GAME_TYPES_WITH_COMMAS=""
+  ANCHORS=""
+  for GAME_TYPE in {{fromGameType}} {{toGameTypes}} # Make sure we restore the source game type too
+  do
+    ANCHORS="${ANCHORS}, ($GAME_TYPE, (${ANCHOR_ROOT}, ${ANCHOR_BLOCK}))"
+    GAME_TYPES_WITH_COMMAS="${GAME_TYPES_WITH_COMMAS}, ${GAME_TYPE}"
+  done
+  ANCHORS="${ANCHORS#, }"
+  GAME_TYPES_WITH_COMMAS="${GAME_TYPES_WITH_COMMAS#, }"
+
+  INIT_CALL=$(cast calldata "initialize((uint32,(bytes32,uint256))[],address)" "[${ANCHORS}]" "${SUPERCHAIN_CONFIG}")
+  ENCODED_UPGRADE_AND_INIT_CALL=$(cast calldata "${UPGRADE_AND_CALL_SIG}" "${REGISTRY_PROXY}" "${REGISTRY_IMPL}" "${INIT_CALL}")
+
+  TX_DESC="Re-initialize with anchor states for game types ${GAME_TYPES_WITH_COMMAS} set to ${ANCHOR_ROOT}, ${ANCHOR_BLOCK}"
+  TXS=$(jq "(.[0].data = \"${ENCODED_RESET_CALL}\") |
+                  (.[0].to = \"${PROXY_ADMIN}\") |
+                  (.[0].contractInputsValues._proxy = \"${REGISTRY_PROXY}\") |
+                  (.[0].contractInputsValues._implementation = \"${STORAGE_SETTER_ADDR}\") |
+                  (.[0].contractInputsValues._data = \"${RESET_CALL}\") |
+                  (.[1].data = \"${ENCODED_UPGRADE_AND_INIT_CALL}\") |
+                  (.[1].to = \"${PROXY_ADMIN}\") |
+                  (.[1].metadata.description = \"${TX_DESC}\") |
+                  (.[1].contractInputsValues._proxy = \"${REGISTRY_PROXY}\") |
+                  (.[1].contractInputsValues._implementation = \"${REGISTRY_IMPL}\") |
+                  (.[1].contractInputsValues._data = \"${INIT_CALL}\")
+                  " ./templates/tx/setAnchorState.json)
+  jq --argjson tx "${TXS}" --arg desc "${TX_DESC} " '(.metadata.description += $desc) | (.transactions += $tx)' ./out/input.json > ./out/input.tmp.json
+  mv ./out/input.tmp.json ./out/input.json
+
+  # Allow state access for the AnchorStateRegistry
+
+  sed \
+    -e "s|// INSERT NEW PRE CHECKS HERE|extraStorageAccessAddresses.push(${REGISTRY_PROXY});\n        // INSERT NEW PRE CHECKS HERE|" \
+    out/NestedSignFromJson.s.sol > out/NestedSignFromJson.s.sol.tmp
+  mv out/NestedSignFromJson.s.sol.tmp out/NestedSignFromJson.s.sol
+
+  # Add pre and post checks
+  for GAME_TYPE in {{fromGameType}} {{toGameTypes}}
+  do
+      sed \
+        -e "s|// INSERT NEW PRE CHECKS HERE|_precheckAnchorStateCopy(GameType.wrap({{fromGameType}}), GameType.wrap(${GAME_TYPE}));\n        // INSERT NEW PRE CHECKS HERE|" \
+        -e "s|// INSERT NEW POST CHECKS HERE|_postcheckAnchorStateCopy(GameType.wrap(${GAME_TYPE}), bytes32(${ANCHOR_ROOT}), ${ANCHOR_BLOCK});\n        // INSERT NEW POST CHECKS HERE|" \
+        out/NestedSignFromJson.s.sol > out/NestedSignFromJson.s.sol.tmp
+      mv out/NestedSignFromJson.s.sol.tmp out/NestedSignFromJson.s.sol
+  done
+
+  # Update the validation instructions
+  ANCHORS_SLOT="1"
+  echo >> out/VALIDATION.md # Add blank line
+  echo "### \`${REGISTRY_PROXY}\` (\`AnchorStateRegistryProxy\`)" >> out/VALIDATION.md
+  for GAME_TYPE in {{fromGameType}} {{toGameTypes}}
+  do
+      STORAGE_SLOT1=$(cast index uint32 "${GAME_TYPE}" "${ANCHORS_SLOT}")
+      BEFORE1=$(cast storage "${REGISTRY_PROXY}" "${STORAGE_SLOT1}")
+      AFTER1="${ANCHOR_ROOT}"
+
+      # Block number storage slot is one after the anchor state root slot
+      STORAGE_SLOT1_BASE10=$(echo "${STORAGE_SLOT1}" | cast 2d)
+      STORAGE_SLOT2=$(echo "${STORAGE_SLOT1_BASE10} + 1" | BC_LINE_LENGTH=0 bc | cast 2h -i 10)
+      BEFORE2=$(cast storage "${REGISTRY_PROXY}" "${STORAGE_SLOT2}")
+      AFTER2=$(cast 2h "${ANCHOR_BLOCK}")
+      cat >> out/VALIDATION.md << EOF
+
+  - **Key**: \`${STORAGE_SLOT1}\`<br/>
+    **Before**: \`${BEFORE1}\` (Note this may have changed if games of this type resolved)<br/>
+    **After**: \`${AFTER1}\` <br/>
+    **Meaning**: Set the anchor state output root for game type ${GAME_TYPE} to ${ANCHOR_ROOT}.
+
+  - **Key**: \`${STORAGE_SLOT2}\`<br/>
+    **Before**: \`${BEFORE2}\` (Note this may have changed if games of this type resolved)<br/>
+    **After**: \`${AFTER2}\` <br/>
+    **Meaning**: Set the anchor state L2 block number for game type ${GAME_TYPE} to ${ANCHOR_BLOCK}.
+  EOF
+  done
+
+  # Update the README
+  INFO="* Re-initialize \`AnchorStateRegistry\` ${REGISTRY_PROXY} with the anchor state for game types ${GAME_TYPES_WITH_COMMAS} set to ${ANCHOR_ROOT}, ${ANCHOR_BLOCK}"
   sed -e "s|<!--NEXT TASK DESCRIPTION-->|${INFO}\n<!--NEXT TASK DESCRIPTION-->|" out/README.md > out/README.md.tmp
   mv out/README.md.tmp out/README.md

--- a/tasks/sep/fp-recovery/005-set-game-implementation/justfile
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/justfile
@@ -124,7 +124,7 @@ copy-anchor-state fromGameType='' toGameTypes='':
 
   GAME_TYPES_WITH_COMMAS=""
   ANCHORS=""
-  for GAME_TYPE in {{fromGameType}} {{toGameTypes}} # Make sure we restore the source game type too
+  for GAME_TYPE in {{toGameTypes}}
   do
     ANCHORS="${ANCHORS}, ($GAME_TYPE, (${ANCHOR_ROOT}, ${ANCHOR_BLOCK}))"
     GAME_TYPES_WITH_COMMAS="${GAME_TYPES_WITH_COMMAS}, ${GAME_TYPE}"
@@ -159,11 +159,12 @@ copy-anchor-state fromGameType='' toGameTypes='':
   mv out/NestedSignFromJson.s.sol.tmp out/NestedSignFromJson.s.sol
 
   # Add pre and post checks
-  for GAME_TYPE in {{fromGameType}} {{toGameTypes}}
+  for GAME_TYPE in {{toGameTypes}}
   do
       sed \
         -e "s|// INSERT NEW PRE CHECKS HERE|_precheckAnchorStateCopy(GameType.wrap({{fromGameType}}), GameType.wrap(${GAME_TYPE}));\n        // INSERT NEW PRE CHECKS HERE|" \
         -e "s|// INSERT NEW POST CHECKS HERE|_postcheckAnchorStateCopy(GameType.wrap(${GAME_TYPE}), bytes32(${ANCHOR_ROOT}), ${ANCHOR_BLOCK});\n        // INSERT NEW POST CHECKS HERE|" \
+        -e "s|// INSERT NEW POST CHECKS HERE|_postcheckHasAnchorState(GameType.wrap({{fromGameType}}));\n        // INSERT NEW POST CHECKS HERE|" \
         out/NestedSignFromJson.s.sol > out/NestedSignFromJson.s.sol.tmp
       mv out/NestedSignFromJson.s.sol.tmp out/NestedSignFromJson.s.sol
   done
@@ -172,7 +173,7 @@ copy-anchor-state fromGameType='' toGameTypes='':
   ANCHORS_SLOT="1"
   echo >> out/VALIDATION.md # Add blank line
   echo "### \`${REGISTRY_PROXY}\` (\`AnchorStateRegistryProxy\`)" >> out/VALIDATION.md
-  for GAME_TYPE in {{fromGameType}} {{toGameTypes}}
+  for GAME_TYPE in {{toGameTypes}}
   do
       STORAGE_SLOT1=$(cast index uint32 "${GAME_TYPE}" "${ANCHORS_SLOT}")
       BEFORE1=$(cast storage "${REGISTRY_PROXY}" "${STORAGE_SLOT1}")

--- a/tasks/sep/fp-recovery/005-set-game-implementation/justfile
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/justfile
@@ -100,6 +100,7 @@ set-implementation gameType='' implAddr='':
 copy-anchor-state fromGameType='' toGameTypes='':
   #!/usr/bin/env bash
   set -euo pipefail
+  unset ETH_RPC_URL
   . out/.env
   export ETH_RPC_URL # Make available to cast since the .env file is in the out subdir.
 

--- a/tasks/sep/fp-recovery/005-set-game-implementation/templates/NestedSignFromJson.s.sol
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/templates/NestedSignFromJson.s.sol
@@ -82,7 +82,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     // implementation with the exception of the absolutePrestate. This is the most common scenario where the game
     // implementation is upgraded to provide an updated fault proof program that supports an upcoming hard fork.
     function _precheckDisputeGameImplementation(GameType _targetGameType, address _newImpl) internal view {
-        console.log("pre-check new game implementations");
+        console.log("pre-check new game implementations", _targetGameType.raw());
 
         FaultDisputeGame currentImpl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_targetGameType))));
         // No checks are performed if there is no prior implementation.
@@ -109,7 +109,7 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     function _precheckAnchorStateCopy(GameType _fromType, GameType _toType) internal view {
-        console.log("pre-check anchor state copy");
+        console.log("pre-check anchor state copy", _toType.raw());
 
         FaultDisputeGame fromImpl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_fromType))));
         // Must have existing game type implementation for the source
@@ -151,18 +151,31 @@ contract NestedSignFromJson is OriginalNestedSignFromJson {
     }
 
     function _checkDisputeGameImplementation(GameType _targetGameType, address _newImpl) internal view {
-        console.log("check dispute game implementations");
+        console.log("check dispute game implementations", _targetGameType.raw());
 
         require(_newImpl == address(dgfProxy.gameImpls(_targetGameType)), "check-100");
     }
 
     function _postcheckAnchorStateCopy(GameType _gameType, bytes32 _root, uint256 _l2BlockNumber) internal view {
-        console.log("check anchor state");
+        console.log("check anchor state value", _gameType.raw());
 
         FaultDisputeGame impl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_gameType))));
         (Hash root, uint256 rootBlockNumber) = FaultDisputeGame(address(impl)).anchorStateRegistry().anchors(_gameType);
 
         require(root.raw() == _root, "check-200");
-        require(rootBlockNumber == _l2BlockNumber, "check-220");
+        require(rootBlockNumber == _l2BlockNumber, "check-210");
+    }
+
+    // @notice Checks the anchor state for the source game type still exists after re-initialization.
+    // The actual anchor state may have been updated since the task was defined so just assert it exists, not that
+    // it has a specific value.
+    function _postcheckHasAnchorState(GameType _gameType) internal view {
+        console.log("check anchor state exists", _gameType.raw());
+
+        FaultDisputeGame impl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_gameType))));
+        (Hash root, uint256 rootBlockNumber) = FaultDisputeGame(address(impl)).anchorStateRegistry().anchors(_gameType);
+
+        require(root.raw() != bytes32(0), "check-300");
+        require(rootBlockNumber != 0, "check-310");
     }
 }

--- a/tasks/sep/fp-recovery/005-set-game-implementation/templates/VALIDATION.md
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/templates/VALIDATION.md
@@ -13,5 +13,4 @@ are missing from this document. Additionally, please verify that for each contra
 
 ## State Changes
 
-The only pertinent state changes (ignoring safe nonce updates) should be made to the `DisputeGameFactoryProxy` game type
-implementations.
+Note: The changes listed below do not include safe nonce updates or liveness guard related changes.

--- a/tasks/sep/fp-recovery/005-set-game-implementation/templates/tx/setAnchorState.json
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/templates/tx/setAnchorState.json
@@ -1,0 +1,73 @@
+[
+  {
+    "metadata": {
+      "name": "Upgrade AnchorStateRegistry to StorageSetter and clear legacy initialized slot",
+      "description": "By clearing the initialized slot, we can call initialize again to set an anchor state for the new game type"
+    },
+    "to": "<ProxyAdmin>",
+    "value": "0x0",
+    "data": "<upgradeAndCall(...)>",
+    "contractMethod": {
+      "type": "function",
+      "name": "upgradeAndCall",
+      "inputs": [
+        {
+          "name": "_proxy",
+          "type": "address"
+        },
+        {
+          "name": "_implementation",
+          "type": "address"
+        },
+        {
+          "name": "_data",
+          "type": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    "contractInputsValues": {
+      "_proxy": "<AnchorStateRegistryProxy>",
+      "_implementation": "<AnchorStateRegistry>",
+      "_data": "setBytes32(bytes32,bytes32) 0x0000000000000000000000000000000000000000000000000000000000000000 0x0000000000000000000000000000000000000000000000000000000000000000"
+    }
+  },
+  {
+    "metadata": {
+      "name": "Re-initialize the AnchorStateRegistryProxy",
+      "description": ""
+    },
+    "to": "<ProxyAdmin>",
+    "value": "0x0",
+    "data": "<upgradeAndCall(...)>",
+    "contractMethod": {
+      "type": "function",
+      "name": "upgradeAndCall",
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_proxy",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_implementation",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "_data",
+          "type": "bytes"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    "contractInputsValues": {
+      "_proxy": "<AnchorStateRegistryProxy>",
+      "_implementation": "<AnchorStateRegistry>",
+      "_data": "<initialize((uint32,(bytes32,uint256))[],address) [(0, (root, l2BlockNum)), (1, (root, l2BlockNum))], SuperChainConfigAddr>"
+    }
+  }
+]


### PR DESCRIPTION
**Description**

Adds an additional transaction template to https://github.com/ethereum-optimism/superchain-ops/pull/363 that re-initializes the `AnchorStateRegistry` to add an initial anchor state for new game types.  The initial anchor state to use is taken from the current anchor state for another game type (at the time the `just` command is run so it's static in the resulting task definition).

This allows creating a task to enable permissionless fault proofs on a chain that previously only deployed permissioned games.