### PR TITLE
feat: sepolia OPCM admin swap

### DIFF
--- a/tasks/sep/018-opcm-admin-swap/.env
+++ b/tasks/sep/018-opcm-admin-swap/.env
@@ -1,0 +1,3 @@
+ETH_RPC_URL="https://ethereum-sepolia.publicnode.com"
+OWNER_SAFE=0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B
+SAFE_NONCE=""

--- a/tasks/sep/018-opcm-admin-swap/README.md
+++ b/tasks/sep/018-opcm-admin-swap/README.md
@@ -1,0 +1,31 @@
+# Sepolia OPCM Admin Swap
+
+Status: DRAFT, NOT READY TO SIGN
+
+## Objective
+
+Changes the admin/owner address of the `OPContractsManager` proxy contract on Sepolia to be the
+`ProxyAdmin` contract on Sepolia instead of the 2/2 Safe. This configuration matches the setup on
+Ethereum and guarantees that we continue a consistent pattern of having the `ProxyAdmin` own
+`Proxy` contracts everywhere.
+
+## Simulation
+
+Please see the "Simulating and Verifying the Transaction" instructions in [SINGLE.md](../../../SINGLE.md).
+When simulating, ensure the logs say `Using script /your/path/to/superchain-ops/tasks/sep/018-opcm-admin-swap/SignFromJson.s.sol`.
+This ensures all safety checks are run. If the default `SignFromJson.s.sol` script is shown (without the full path), something is wrong and the safety checks will not run.
+
+## State Validation
+
+Please see the instructions for [validation](./VALIDATION.md).
+
+## Execution
+
+This upgrade changes the admin/owner of the `OPContractsManager` contract from the current value of
+`0xF564eEA7960EA244bfEbCBbB17858748606147bf` to the updated value of
+`0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc`, the current `ProxyAdmin` contract for OP Sepolia.
+This is the only modification made by this upgrade.
+
+The batch will be executed on chain ID `11155111`, and contains `1` transaction.
+
+See the input.json bundle for more details.

--- a/tasks/sep/018-opcm-admin-swap/SignFromJson.s.sol
+++ b/tasks/sep/018-opcm-admin-swap/SignFromJson.s.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
+import {Vm, VmSafe} from "forge-std/Vm.sol";
+import {console2 as console} from "forge-std/console2.sol";
+import {stdToml} from "forge-std/StdToml.sol";
+import {LibString} from "solady/utils/LibString.sol";
+import {GnosisSafe} from "safe-contracts/GnosisSafe.sol";
+import "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
+import {ISemver} from "@eth-optimism-bedrock/src/universal/ISemver.sol";
+
+interface IProxy {
+    function admin() external view returns (address);
+}
+
+contract SignFromJson is OriginalSignFromJson {
+    using LibString for string;
+
+    // Chains for this task.
+    string constant l1ChainName = "sepolia";
+    string constant l2ChainName = "op";
+
+    // Safe contract for this task.
+    GnosisSafe fndSafe = GnosisSafe(payable(vm.envAddress("OWNER_SAFE")));
+
+    IProxy constant opcmProxy = IProxy(0xF564eEA7960EA244bfEbCBbB17858748606147bf);
+    address constant proxyAdmin = 0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc;
+
+    Types.ContractSet proxies;
+
+    /// @notice Sets up the contract
+    function setUp() public {
+        proxies = _getContractSet();
+    }
+
+    function getCodeExceptions() internal pure override returns (address[] memory) {
+        address[] memory shouldHaveCodeExceptions = new address[](0);
+        return shouldHaveCodeExceptions;
+    }
+
+    function getAllowedStorageAccess() internal view override returns (address[] memory allowed) {
+        allowed = new address[](2);
+        allowed[0] = address(opcmProxy);
+        allowed[1] = address(fndSafe);
+    }
+
+    /// @notice Checks the correctness of the deployment
+    function _postCheck(Vm.AccountAccess[] memory accesses, SimulationPayload memory /* simPayload */ )
+        internal
+        override
+    {
+        console.log("Running post-deploy assertions");
+
+        checkStateDiff(accesses);
+        _checkOPContractsManager();
+
+        console.log("All assertions passed!");
+    }
+
+    /// @notice Reads the contract addresses from lib/superchain-registry/superchain/configs/${l1ChainName}/${l2ChainName}.toml
+    function _getContractSet() internal view returns (Types.ContractSet memory _proxies) {
+        string memory chainConfig;
+        string memory path = string.concat("/lib/superchain-registry/superchain/configs/", l1ChainName, "/superchain.toml");
+        try vm.readFile(string.concat(vm.projectRoot(), path)) returns (string memory data) {
+            chainConfig = data;
+        } catch {
+            revert(string.concat("Failed to read ", path));
+        }
+        _proxies.SuperchainConfig = stdToml.readAddress(chainConfig, "$.superchain_config_addr");
+    }
+
+    function _checkOPContractsManager() internal {
+        console.log("check OPContractsManager");
+
+        vm.prank(proxyAdmin);
+        require(opcmProxy.admin() == proxyAdmin, "opcm-100");
+        require(ISemver(address(opcmProxy)).version().eq("1.0.0-beta.20"), "opcm-200");
+    }
+}

--- a/tasks/sep/018-opcm-admin-swap/VALIDATION.md
+++ b/tasks/sep/018-opcm-admin-swap/VALIDATION.md
@@ -1,0 +1,26 @@
+# Validation
+
+This document can be used to validate the state diff resulting from the execution of the upgrade
+transaction.
+
+For each contract listed in the state diff, please verify that no contracts or state changes shown in the Tenderly diff are missing from this document. Additionally, please verify that for each contract:
+
+- The following state changes (and none others) are made to that contract. This validates that no unexpected state changes occur.
+- All addresses (in section headers and storage values) match the provided name, using the Etherscan and Superchain Registry links provided. This validates the bytecode deployed at the addresses contains the correct logic.
+- All key values match the semantic meaning provided, which can be validated using the storage layout links provided.
+
+## State Changes
+
+### `0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B` (Foundation Safe)
+
+- **Key**: `0x0000000000000000000000000000000000000000000000000000000000000005` <br/>
+  **Before**: `0x0000000000000000000000000000000000000000000000000000000000000017` <br/>
+  **After**: `0x0000000000000000000000000000000000000000000000000000000000000018`<br/>
+  **Meaning**: Foundation Safe nonce has incremented by 1.
+
+### `0xF564eEA7960EA244bfEbCBbB17858748606147bf` (`OPContractsManagerProxy`)
+
+- **Key**: `0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103` <br/>
+  **Before**: `0x000000000000000000000000dee57160aafcf04c34c887b5962d0a69676d3c8b` <br/>
+  **After**: `0x000000000000000000000000189abaaaa82dfc015a588a7dbad6f13b1d3485bc` <br/>
+  **Meaning**: Updates the `admin` of the `OPContractsManagerPRoxy` contract to be the `ProxyAdmin` for OP Sepolia. Slot key is the keccak hash of `eip1967.proxy.admin` minus 1. Verify that the new owner is correct as per [the OP Sepolia configuration within the superchain-registry repository](https://github.com/ethereum-optimism/superchain-registry/blob/2c96a89df841013a59269fa7adc12c77b870310e/superchain/configs/sepolia/op.toml#L52).

--- a/tasks/sep/018-opcm-admin-swap/input.json
+++ b/tasks/sep/018-opcm-admin-swap/input.json
@@ -1,0 +1,33 @@
+{
+  "chainId": 11155111,
+  "metadata": {
+    "name": "OPCM Admin Swap",
+    "description": "Changes the admin of the OPCM proxy to be the ProxyAdmin contract"
+  },
+  "transactions": [
+    {
+      "metadata": {
+        "name": "OPCM ownership transfer",
+        "description": "Transfers ownership of the OPCM proxy to the ProxyAdmin contract"
+      },
+      "to": "0xF564eEA7960EA244bfEbCBbB17858748606147bf",
+      "value": "0x0",
+      "data": "0x8f283970000000000000000000000000189abaaaa82dfc015a588a7dbad6f13b1d3485bc",
+      "contractMethod": {
+        "type": "function",
+        "name": "changeAdmin",
+        "inputs": [
+          {
+            "name": "_admin",
+            "type": "address"
+          }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "contractInputsValues": {
+        "_admin": "0x189aBAAaa82DfC015A588A7dbaD6F13b1D3485Bc"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a new task for swapping the OPCM proxy admin to be the ProxyAdmin contract for OP Sepolia. We decided that using the same ProxyAdmin everywhere was better than having a single contract where the owner was the Fake Foundation instead.