### PR TITLE
3-of-3 Proxy Admin Owner Support: Chain governor able to sign for nested safes

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -59,6 +59,16 @@ just \
    foundation # 0 or 1 or ...
 ```
 
+For the Chain Governor:
+
+```shell
+just \
+   --dotenv-path $(pwd)/.env \
+   --justfile ../../../nested.just \
+   simulate \
+   chain-governor # 0 or 1 or ...
+```
+
 You will see a "Simulation link" from the output.
 
 Paste this URL in your browser. A prompt may ask you to choose a
@@ -136,6 +146,16 @@ just \
    foundation # 0 or 1 or ...
 ```
 
+or
+
+```shell
+just \
+   --dotenv-path $(pwd)/.env \
+   --justfile ../../../nested.just \
+   sign \
+   chain-governor # 0 or 1 or ...
+```
+
 > [!WARNING]
 > This is the most security critical part of the playbook: make sure the
 > domain hash and message hash in the following two places match:
@@ -202,7 +222,7 @@ just \
    --dotenv-path $(pwd)/.env \
    --justfile ../../../nested.just \
    approve \
-   foundation \ # or council
+   foundation \ # or council or chain-governor
    0 # or 1 or ...
 ```
 

--- a/nested.just
+++ b/nested.just
@@ -9,6 +9,7 @@ export taskPath := invocation_directory()
 export councilSafe := env_var("COUNCIL_SAFE")
 export foundationSafe := env_var("FOUNDATION_SAFE")
 export ownerSafe := env_var('OWNER_SAFE')
+export chainGovernorSafe := env_var('CHAIN_GOVERNOR_SAFE')
 export randomPersonEoa := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
 simulate whichSafe hdPath='0':
@@ -27,6 +28,9 @@ simulate whichSafe hdPath='0':
   fi
   if [ "{{whichSafe}}" == "council" ]; then
     safe="{{councilSafe}}"
+  fi
+  if [ "{{whichSafe}}" == "chain-governor" ]; then
+    safe="{{chainGovernorSafe}}"
   fi
   signer=$(cast call ${safe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
 
@@ -65,6 +69,9 @@ sign whichSafe hdPath='0':
     safe="{{councilSafe}}"
     echo "Using council safe at ${safe}"
   fi
+  if [ "{{whichSafe}}" == "chain-governor" ]; then
+    safe="{{chainGovernorSafe}}"
+  fi
   echo "getting signer address..."
   signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
   echo "Signing with: ${signer}"
@@ -95,6 +102,9 @@ approve whichSafe hdPath='0':
   if [ "{{whichSafe}}" == "council" ]; then
     safe="{{councilSafe}}"
     echo "Using council safe at ${safe}"
+  fi
+  if [ "{{whichSafe}}" == "chain-governor" ]; then
+    safe="{{chainGovernorSafe}}"
   fi
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
 

--- a/nested.just
+++ b/nested.just
@@ -9,7 +9,7 @@ export taskPath := invocation_directory()
 export councilSafe := env_var("COUNCIL_SAFE")
 export foundationSafe := env_var("FOUNDATION_SAFE")
 export ownerSafe := env_var('OWNER_SAFE')
-export chainGovernorSafe := env_var('CHAIN_GOVERNOR_SAFE')
+export chainGovernorSafe := env_var_or_default('CHAIN_GOVERNOR_SAFE', '')
 export randomPersonEoa := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
 
 simulate whichSafe hdPath='0':
@@ -30,6 +30,10 @@ simulate whichSafe hdPath='0':
     safe="{{councilSafe}}"
   fi
   if [ "{{whichSafe}}" == "chain-governor" ]; then
+    if [ -z "{{chainGovernorSafe}}" ]; then
+      echo "Error: CHAIN_GOVERNOR_SAFE is not set for chain-governor." >&2
+      exit 1
+    fi
     safe="{{chainGovernorSafe}}"
   fi
   signer=$(cast call ${safe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
@@ -70,6 +74,10 @@ sign whichSafe hdPath='0':
     echo "Using council safe at ${safe}"
   fi
   if [ "{{whichSafe}}" == "chain-governor" ]; then
+    if [ -z "{{chainGovernorSafe}}" ]; then
+      echo "Error: CHAIN_GOVERNOR_SAFE is not set for chain-governor." >&2
+      exit 1
+    fi
     safe="{{chainGovernorSafe}}"
   fi
   echo "getting signer address..."
@@ -104,6 +112,10 @@ approve whichSafe hdPath='0':
     echo "Using council safe at ${safe}"
   fi
   if [ "{{whichSafe}}" == "chain-governor" ]; then
+    if [ -z "{{chainGovernorSafe}}" ]; then
+      echo "Error: CHAIN_GOVERNOR_SAFE is not set for chain-governor." >&2
+      exit 1
+    fi
     safe="{{chainGovernorSafe}}"
   fi
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
As per the title, we want to add the ability for the L1 ProxyAdmin owner to be a 3-of-3 safe as well as a 2-of-2 safe. Some chains require an additional wallet in their L1PAO.