### PR TITLE
Run task simulations in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,17 @@ jobs:
           name: Check nonce overrides
           command: bash ./script/utils/check-nonce-overrides.sh
 
+  simulate_non_terminal_tasks:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Simulate non-terminal tasks
+          command: bash ./script/utils/simulate-tasks.sh
+
   # TODO: remove/replace when there are real consumers of the RPC URLs
   example_mainnet_job:
     circleci_ip_ranges: true
@@ -236,3 +247,5 @@ workflows:
       - just_simulate_sc_rehearsal_1
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
+
+      - simulate_non_terminal_tasks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,4 +248,4 @@ workflows:
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
 
-      - simulate_non_terminal_tasks
+      # - simulate_non_terminal_tasks

--- a/script/utils/check-task-statuses.sh
+++ b/script/utils/check-task-statuses.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-VALID_STATUSES=("DRAFT, NOT READY TO SIGN" "CONTINGENCY TASK, SIGN AS NEEDED" "READY TO SIGN" "SIGNED" "EXECUTED" "CANCELLED")
+source  ./script/utils/get-valid-statuses.sh
 errors=() # We collect all errors then print them at the end.
 
 # Function to check status and hyperlinks for a single file.
@@ -43,7 +43,7 @@ check_status_and_hyperlinks() {
 }
 
 # Find README.md files for all tasks and process them.
-files=$(find ./tasks -type f -path './tasks/*/*/README.md')
+# files read from ./script/utils/get-valid-statuses.sh
 for file in $files; do
   check_status_and_hyperlinks "$file"
 done

--- a/script/utils/get-valid-statuses.sh
+++ b/script/utils/get-valid-statuses.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+NON_TERMINAL_STATUSES=("DRAFT, NOT READY TO SIGN" "CONTINGENCY TASK, SIGN AS NEEDED" "READY TO SIGN")
+TERMINAL_STATUSES=("SIGNED" "EXECUTED" "CANCELLED")
+VALID_STATUSES=( "${NON_TERMINAL_STATUSES[@]}" "${TERMINAL_STATUSES[@]}" )
+
+# Find README.md files for all tasks and process them.
+files=$(find ./tasks -type f -path './tasks/*/*/README.md')
+
+# Filters:
+# Name of a file to exclude from searching for non-terminal tasks.
+FOLDER_WITH_NO_TASKS="templates"
+# Name of a file in a task directiory that specifies that the task is a nested safe task.
+IF_THIS_ITS_NESTED="NestedSignFromJson.s.sol"

--- a/script/utils/simulate-tasks.sh
+++ b/script/utils/simulate-tasks.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -euo pipefail
+
+source  ./script/utils/get-valid-statuses.sh
+
+single_tasks_to_simulate=()
+nested_tasks_to_simulate=()
+
+# Find README.md files for all tasks and process them.
+# Files read from ./script/utils/get-valid-statuses.sh.
+# Exclude tasks defined in folder FOLDER_WITH_NO_TASKS.
+filtered_files=$(echo "$files" | grep -v "/${FOLDER_WITH_NO_TASKS}/")
+
+search_non_terminal_tasks(){
+  local directory
+  for file in $filtered_files; do
+    # Ensure it's a regular file.
+    if [[ -f "$file" ]]; then
+      # Read file content and search for any status in the NON_TERMINAL_STATUSES array.
+      for status in "${NON_TERMINAL_STATUSES[@]}"; do
+        if grep -q "$status" "$file"; then
+          directory=$(dirname "$file")
+          # Specify if a task is safe or nested.
+          if [[ -f "$directory/$IF_THIS_ITS_NESTED" ]]; then
+            nested_tasks_to_simulate+=("${file%/README.md}")
+          else
+            single_tasks_to_simulate+=("${file%/README.md}")
+          fi
+          break
+        fi
+      done
+    fi
+  done
+}
+
+search_non_terminal_tasks
+
+if [ ${#single_tasks_to_simulate[@]} -eq 0 ]; then
+    echo "No single tasks"
+else
+    echo "Simulating single tasks..."
+    # Prepared acording to ./SINGLE.md
+
+    export SIMULATE_WITHOUT_LEDGER=1
+
+    # Option 1: call simulation command here
+    for task in "${single_tasks_to_simulate[@]}"; do
+      current_dir=$(pwd)
+      cd "$task"
+      echo "Simulating task: $task"
+      just --dotenv-path $(pwd)/.env --justfile ../../../single.just simulate 0
+      cd "$current_dir"
+    done
+
+    # Option 2: read directly from ./SINGLE.md file
+    # md_file="./SINGLE.md"
+    # for task in "${single_tasks_to_simulate[@]}"; do
+    #   current_dir=$(pwd)
+    #   cd "$task"
+    #   echo "Simulating task: $task"
+    #   awk '
+    #     /```shell/ {block_count++; if (block_count == 2) in_block=1; next}
+    #     /```/ {if (in_block) exit; in_block=0}
+    #     in_block {print}
+    #   ' "$md_file" > extracted.sh
+    #   SIMULATE_WITHOUT_LEDGER=1
+    #   bash extracted.sh
+    #   cd "$current_dir"
+    # done
+fi
+
+
+if [ ${#nested_tasks_to_simulate[@]} -eq 0 ]; then
+    echo "No nested tasks"
+else
+    echo "Simulating nested tasks..."
+    # Prepared acording to ./NESTED.md
+    
+    export SIMULATE_WITHOUT_LEDGER=1
+
+    for task in "${nested_tasks_to_simulate[@]}"; do
+      current_dir=$(pwd)
+      cd "$task"
+      echo "Simulating task: $task"
+
+      just --dotenv-path $(pwd)/.env --justfile ../../../nested.just simulate council
+      just --dotenv-path $(pwd)/.env --justfile ../../../nested.just approve council
+
+      just --dotenv-path $(pwd)/.env --justfile ../../../nested.just simulate foundation
+      just --dotenv-path $(pwd)/.env --justfile ../../../nested.just approve foundation
+
+      just --dotenv-path $(pwd)/.env --justfile ../../../nested.just simulate chain-governor
+      just --dotenv-path $(pwd)/.env --justfile ../../../nested.just approve chain-governor
+
+      cd "$current_dir"
+    done
+fi
+


### PR DESCRIPTION
**Description**

Added a new script: `simulate-tasks.sh`. It loops through all tasks, searches for all non-terminal tasks, and executes simulations for these tasks.

Non-terminal tasks are defined in a new script: `get-valid-statuses.sh`.

Changed check-task-statuses.sh so that it uses `get-valid-statuses.sh` to get `VALID_STATUSES`.

Modified `./.circleci/config.yml`. Added a new job that calls `simulate-tasks.sh` and added this new job to the workflow.

**Tests**

Tests will be added after the draft is completed.

**Additional context**

**Metadata**

- Fixes #[https://github.com/ethereum-optimism/superchain-ops/issues/337]
