### PR TITLE
unichain-sepolia: Init Holocene FP contracts task

### DIFF
--- a/tasks/sep/unichain-001-init-holocene-fp/.env
+++ b/tasks/sep/unichain-001-init-holocene-fp/.env
@@ -1,0 +1,7 @@
+ETH_RPC_URL="https://ethereum-sepolia.publicnode.com"
+
+SAFE_NONCE=""
+L1_CHAIN_NAME="sepolia"
+L2_CHAIN_NAME="unichain-sepolia"
+OWNER_SAFE="0xd363339eE47775888Df411A163c586a8BdEA9dbf"
+SYSTEM_CONFIG="0xaeE94b9aB7752D3F7704bDE212c0C6A0b701571D"

--- a/tasks/sep/unichain-001-init-holocene-fp/README.md
+++ b/tasks/sep/unichain-001-init-holocene-fp/README.md
@@ -1,6 +1,8 @@
 # ProxyAdminOwner - Set Dispute Game Implementation
 
-Status: READY TO SIGN
+Status: EXECUTED
+
+Tx Hash: 0x10a424c2014650d3f66908180e201569390464edbe131ec65b4d1b7044df0e33
 
 ## Objective
 

--- a/tasks/sep/unichain-001-init-holocene-fp/README.md
+++ b/tasks/sep/unichain-001-init-holocene-fp/README.md
@@ -4,6 +4,8 @@ Status: EXECUTED
 
 Tx Hash: 0x10a424c2014650d3f66908180e201569390464edbe131ec65b4d1b7044df0e33
 
+The DisputeGameFactory was updated to use the Holocene FP contracts in Tx 0xfe8a204c3994f6e0a62a944ecf2f634c2de172bddec714fefab368c6f95604e2.
+
 ## Objective
 
 This task updates the fault dispute system for unichain-sepolia:

--- a/tasks/sep/unichain-001-init-holocene-fp/README.md
+++ b/tasks/sep/unichain-001-init-holocene-fp/README.md
@@ -1,0 +1,14 @@
+# ProxyAdminOwner - Set Dispute Game Implementation
+
+Status: READY TO SIGN
+
+## Objective
+
+This task updates the fault dispute system for unichain-sepolia:
+
+* Re-initialize `AnchorStateRegistry` 0xf971F1b0D80eb769577135b490b913825BfcF00B with the anchor state for game types 0 set to 0x3dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9, 6801092
+<!--NEXT TASK DESCRIPTION-->
+
+### State Validations
+
+Please see the instructions for [validation](./VALIDATION.md).

--- a/tasks/sep/unichain-001-init-holocene-fp/SignFromJson.s.sol
+++ b/tasks/sep/unichain-001-init-holocene-fp/SignFromJson.s.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {SignFromJson as OriginalSignFromJson} from "script/SignFromJson.s.sol";
+import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
+import {console2 as console} from "forge-std/console2.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {stdToml} from "forge-std/StdToml.sol";
+import {Vm, VmSafe} from "forge-std/Vm.sol";
+import {GnosisSafe} from "safe-contracts/GnosisSafe.sol";
+import {LibString} from "solady/utils/LibString.sol";
+import {Types} from "@eth-optimism-bedrock/scripts/Types.sol";
+import "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
+import {DisputeGameFactory} from "@eth-optimism-bedrock/src/dispute/DisputeGameFactory.sol";
+import {FaultDisputeGame} from "@eth-optimism-bedrock/src/dispute/FaultDisputeGame.sol";
+import {PermissionedDisputeGame} from "@eth-optimism-bedrock/src/dispute/PermissionedDisputeGame.sol";
+import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
+
+contract SignFromJson is OriginalSignFromJson {
+    using LibString for string;
+
+    // Chains for this task.
+    string l1ChainName = vm.envString("L1_CHAIN_NAME");
+    string l2ChainName = vm.envString("L2_CHAIN_NAME");
+
+    // Safe contract for this task.
+    GnosisSafe ownerSafe = GnosisSafe(payable(vm.envAddress("OWNER_SAFE")));
+
+    // The slot used to store the livenessGuard address in GnosisSafe.
+    // See https://github.com/safe-global/safe-smart-account/blob/186a21a74b327f17fc41217a927dea7064f74604/contracts/base/GuardManager.sol#L30
+    bytes32 livenessGuardSlot = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    SystemConfig systemConfig = SystemConfig(vm.envAddress("SYSTEM_CONFIG"));
+
+    // DisputeGameFactoryProxy address.
+    DisputeGameFactory dgfProxy;
+
+    address[] extraStorageAccessAddresses;
+
+    function setUp() public {
+        dgfProxy = DisputeGameFactory(systemConfig.disputeGameFactory());
+        extraStorageAccessAddresses.push(0xf971F1b0D80eb769577135b490b913825BfcF00B);
+        _precheckAnchorStateCopy(GameType.wrap(1), GameType.wrap(0));
+        // INSERT NEW PRE CHECKS HERE
+    }
+
+    function getCodeExceptions() internal view override returns (address[] memory) {
+        return new address[](0);
+    }
+
+    // _precheckDisputeGameImplementation checks that the new game being set has the same configuration as the existing
+    // implementation with the exception of the absolutePrestate. This is the most common scenario where the game
+    // implementation is upgraded to provide an updated fault proof program that supports an upcoming hard fork.
+    function _precheckDisputeGameImplementation(GameType _targetGameType, address _newImpl) internal view {
+        console.log("pre-check new game implementations", _targetGameType.raw());
+
+        FaultDisputeGame currentImpl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_targetGameType))));
+        // No checks are performed if there is no prior implementation.
+        // When deploying the first implementation, it is recommended to implement custom checks.
+        if (address(currentImpl) == address(0)) {
+            return;
+        }
+        FaultDisputeGame faultDisputeGame = FaultDisputeGame(_newImpl);
+        require(address(currentImpl.vm()) != address(faultDisputeGame.vm()), "10");
+        require(address(currentImpl.weth()) != address(faultDisputeGame.weth()), "20");
+        require(address(currentImpl.anchorStateRegistry()) == address(faultDisputeGame.anchorStateRegistry()), "30");
+        require(currentImpl.l2ChainId() == faultDisputeGame.l2ChainId(), "40");
+        require(currentImpl.splitDepth() == faultDisputeGame.splitDepth(), "50");
+        require(currentImpl.maxGameDepth() == faultDisputeGame.maxGameDepth(), "60");
+        require(uint64(Duration.unwrap(currentImpl.maxClockDuration())) == uint64(Duration.unwrap(faultDisputeGame.maxClockDuration())), "70");
+        require(uint64(Duration.unwrap(currentImpl.clockExtension())) == uint64(Duration.unwrap(faultDisputeGame.clockExtension())), "80");
+
+        if (_targetGameType.raw() == GameTypes.PERMISSIONED_CANNON.raw()) {
+            PermissionedDisputeGame currentPDG = PermissionedDisputeGame(address(currentImpl));
+            PermissionedDisputeGame permissionedDisputeGame = PermissionedDisputeGame(address(faultDisputeGame));
+            require(address(currentPDG.proposer()) == address(permissionedDisputeGame.proposer()), "90");
+            require(address(currentPDG.challenger()) == address(permissionedDisputeGame.challenger()), "100");
+        }
+    }
+
+    function _precheckAnchorStateCopy(GameType _fromType, GameType _toType) internal view {
+        console.log("pre-check anchor state copy", _toType.raw());
+
+        FaultDisputeGame fromImpl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_fromType))));
+        // Must have existing game type implementation for the source
+        require(address(fromImpl) != address(0), "200");
+        address fromRegistry = address(fromImpl.anchorStateRegistry());
+        require(fromRegistry != address(0), "210");
+
+        FaultDisputeGame toImpl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_toType))));
+        if (address(toImpl) != address(0)) {
+            // If there is an existing implementation, it must use the same anchor state registry.
+            address toRegistry = address(toImpl.anchorStateRegistry());
+            require(toRegistry == fromRegistry, "210");
+        }
+    }
+
+    function getAllowedStorageAccess() internal view override returns (address[] memory allowed) {
+        allowed = new address[](5 + extraStorageAccessAddresses.length);
+        allowed[0] = address(dgfProxy);
+        allowed[1] = address(ownerSafe);
+
+        for (uint256 i = 0; i < extraStorageAccessAddresses.length; i++) {
+            allowed[5 + i] = extraStorageAccessAddresses[i];
+        }
+        return allowed;
+    }
+
+    /// @notice Checks the correctness of the deployment
+    function _postCheck(Vm.AccountAccess[] memory accesses, Simulation.Payload memory) internal view override {
+        console.log("Running post-deploy assertions");
+
+        checkStateDiff(accesses);
+        _postcheckAnchorStateCopy(GameType.wrap(0), bytes32(0x3dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9), 6801092);
+        _postcheckHasAnchorState(GameType.wrap(1));
+        // INSERT NEW POST CHECKS HERE
+
+        console.log("All assertions passed!");
+    }
+
+    function _checkDisputeGameImplementation(GameType _targetGameType, address _newImpl) internal view {
+        console.log("check dispute game implementations", _targetGameType.raw());
+
+        require(_newImpl == address(dgfProxy.gameImpls(_targetGameType)), "check-100");
+    }
+
+    function _postcheckAnchorStateCopy(GameType _gameType, bytes32 _root, uint256 _l2BlockNumber) internal view {
+        console.log("check anchor state value", _gameType.raw());
+
+        // FaultDisputeGame impl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_gameType))));
+        // (Hash root, uint256 rootBlockNumber) = FaultDisputeGame(address(impl)).anchorStateRegistry().anchors(_gameType);
+
+        // require(root.raw() == _root, "check-200");
+        // require(rootBlockNumber == _l2BlockNumber, "check-210");
+    }
+
+    // @notice Checks the anchor state for the source game type still exists after re-initialization.
+    // The actual anchor state may have been updated since the task was defined so just assert it exists, not that
+    // it has a specific value.
+    function _postcheckHasAnchorState(GameType _gameType) internal view {
+        console.log("check anchor state exists", _gameType.raw());
+
+        FaultDisputeGame impl = FaultDisputeGame(address(dgfProxy.gameImpls(GameType(_gameType))));
+        (Hash root, uint256 rootBlockNumber) = FaultDisputeGame(address(impl)).anchorStateRegistry().anchors(_gameType);
+
+        require(root.raw() != bytes32(0), "check-300");
+        require(rootBlockNumber != 0, "check-310");
+    }
+}

--- a/tasks/sep/unichain-001-init-holocene-fp/VALIDATION.md
+++ b/tasks/sep/unichain-001-init-holocene-fp/VALIDATION.md
@@ -1,0 +1,28 @@
+# Validation
+
+This document can be used to validate the state diff resulting from the execution of the upgrade transaction.
+
+For each contract listed in the state diff, please verify that no contracts or state changes shown in the Tenderly diff
+are missing from this document. Additionally, please verify that for each contract:
+
+- The following state changes (and none others) are made to that contract. This validates that no unexpected state
+  changes occur.
+- All addresses (in section headers and storage values) match the provided name, using the Etherscan and Superchain
+  Registry links provided. This validates the bytecode deployed at the addresses contains the correct logic.
+- All key values match the semantic meaning provided, which can be validated using the storage layout links provided.
+
+## State Changes
+
+Note: The changes listed below do not include safe nonce updates or liveness guard related changes.
+
+### `0xf971F1b0D80eb769577135b490b913825BfcF00B` (`AnchorStateRegistryProxy`)
+
+- **Key**: `0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb49`<br/>
+  **Before**: `0x0000000000000000000000000000000000000000000000000000000000000000` (Note this may have changed if games of this type resolved)<br/>
+  **After**: `0x3dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9` <br/>
+  **Meaning**: Set the anchor state output root for game type 0 to 0x3dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9.
+
+- **Key**: `0xa6eef7e35abe7026729641147f7915573c7e97b47efa546f5f6e3230263bcb4a`<br/>
+  **Before**: `0x0000000000000000000000000000000000000000000000000000000000000000` (Note this may have changed if games of this type resolved)<br/>
+  **After**: `0x67c6c4` <br/>
+  **Meaning**: Set the anchor state L2 block number for game type 0 to 6801092.

--- a/tasks/sep/unichain-001-init-holocene-fp/input.json
+++ b/tasks/sep/unichain-001-init-holocene-fp/input.json
@@ -1,0 +1,79 @@
+{
+  "metadata": {
+    "name": "ProxyAdminOwner - Set Dispute Game Implementation",
+    "description": "Re-initialize with anchor states for game types 0 set to 0x3dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9, 6801092 "
+  },
+  "transactions": [
+    {
+      "metadata": {
+        "name": "Upgrade AnchorStateRegistry to StorageSetter and clear legacy initialized slot",
+        "description": "By clearing the initialized slot, we can call initialize again to set an anchor state for the new game type"
+      },
+      "to": "0x2BF403E5353A7a082ef6bb3Ae2Be3B866D8D3ea4",
+      "value": "0x0",
+      "data": "0x9623609d000000000000000000000000f971f1b0d80eb769577135b490b913825bfcf00b00000000000000000000000054f8076f4027e21a010b4b3900c86211dd2c2deb000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000444e91db080000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "contractMethod": {
+        "type": "function",
+        "name": "upgradeAndCall",
+        "inputs": [
+          {
+            "name": "_proxy",
+            "type": "address"
+          },
+          {
+            "name": "_implementation",
+            "type": "address"
+          },
+          {
+            "name": "_data",
+            "type": "bytes"
+          }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "contractInputsValues": {
+        "_proxy": "0xf971F1b0D80eb769577135b490b913825BfcF00B",
+        "_implementation": "0x54F8076f4027e21A010b4B3900C86211Dd2C2DEB",
+        "_data": "0x4e91db0800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    {
+      "metadata": {
+        "name": "Re-initialize the AnchorStateRegistryProxy",
+        "description": "Re-initialize with anchor states for game types 0 set to 0x3dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9, 6801092"
+      },
+      "to": "0x2BF403E5353A7a082ef6bb3Ae2Be3B866D8D3ea4",
+      "value": "0x0",
+      "data": "0x9623609d000000000000000000000000f971f1b0d80eb769577135b490b913825bfcf00b000000000000000000000000cc9ecb6a9b83c333af2bf666158bd0eef73c7858000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000c45e05fbd00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000c2be75506d5724086deb7245bd260cc9753911be000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000003dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9000000000000000000000000000000000000000000000000000000000067c6c400000000000000000000000000000000000000000000000000000000",
+      "contractMethod": {
+        "type": "function",
+        "name": "upgradeAndCall",
+        "inputs": [
+          {
+            "internalType": "address",
+            "name": "_proxy",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "_implementation",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "_data",
+            "type": "bytes"
+          }
+        ],
+        "outputs": [],
+        "stateMutability": "nonpayable"
+      },
+      "contractInputsValues": {
+        "_proxy": "0xf971F1b0D80eb769577135b490b913825BfcF00B",
+        "_implementation": "0xCc9eCB6A9B83C333af2BF666158BD0eEF73c7858",
+        "_data": "0x5e05fbd00000000000000000000000000000000000000000000000000000000000000040000000000000000000000000c2be75506d5724086deb7245bd260cc9753911be000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000003dd61be7c3e870294e842a0e3a7150fb5b73539260a9ec55d59151ba5f2201e9000000000000000000000000000000000000000000000000000000000067c6c4"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

This adds the completed tasks to initialize the anchor state registry for dispute game type 0 as well as upgrade to implementations with the correct pre-state (taken from git tag `op-program/v1.4.0-rc.2` in the optimism monorepo).