### PR TITLE
docs: Fix Typo in "Setup" Section of Doc Update mcp-l1.md

### DIFF
--- a/runbooks/mcp-l1.md
+++ b/runbooks/mcp-l1.md
@@ -95,7 +95,7 @@ repo setup instructions for each.
 
 There are three just recipes in this file:
 
-- `simulate` - to simulate the transactions in the the `input.json` bundle
+- `simulate` - to simulate the transactions in the `input.json` bundle
 - `sign` - to sign the transactions in the `input.json` bundle
 - `execute` - to execute the transactions in the `input.json` bundle
 


### PR DESCRIPTION
**Description**

<img width="570" alt="Снимок экрана 2024-12-22 в 21 06 04" src="https://github.com/user-attachments/assets/a87d4f42-9d81-4e91-9496-88f66ca07f7b" />

While reviewing the documentation under `Setup > Familiarize yourself with the single.just file (superchain-ops repo)`, I noticed a small typo where the phrase "the the" is repeated:  

> simulate - to simulate the transactions in the the input.json bundle  

**Thanks for OP!**