### PR TITLE
Bump to latest eip712sign version

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ install-eip712sign:
   PATH="$REPO_ROOT/bin:$PATH"
   cd $REPO_ROOT
   mkdir -p bin || true
-  GOBIN="$REPO_ROOT/bin" go install github.com/base-org/eip712sign@v0.0.8
+  GOBIN="$REPO_ROOT/bin" go install github.com/base-org/eip712sign@v0.0.10
 
 # Bundle path should be provided including the .json file extension.
 add-transaction bundlePath to sig *params:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Bump to https://github.com/base-org/eip712sign/releases/tag/v0.0.10, which fixes signing with ledgers with the latest firmware version, and also supports Ledger Flex.

**Tests**

Tested locally.

**Additional context**

Signers were having trouble after updating to the latest ledger firmware. Upstreamed a fix to go-ethereum here: https://github.com/ethereum/go-ethereum/pull/31004/files.