### PR TITLE
sep/027: recompute `approvedHashes` keys

### DIFF
--- a/tasks/sep/027-holocene-system-config-upgrade-and-init-multi-chain/VALIDATION.md
+++ b/tasks/sep/027-holocene-system-config-upgrade-and-init-multi-chain/VALIDATION.md
@@ -16,22 +16,22 @@ This task is executed by the nested 2/2 `ProxyAdminOwner` Safe. Refer to the
 for the expected state overrides and changes.
 
 The `approvedHashes` mapping **key** of the `ProxyAdminOwner` that should change during the simulation is
-- Council simulation: `0xa2178e2b0ce499a24051659b5ab4528cd4e41b7dff3b76fa6861750f7b154391`
-- Foundation simulation: `0x6baf11815ec9e3d4dc6cfa30c0e72dd31a00e45c9ca6d8a40e52f5cc78635009`
+- Council simulation: `0x7a680028073e956784e910c02dd0a0936604b29cd9f9c71c9d8e568533821e16`
+- Foundation simulation: `0xd30a77d4a810ba7768ba1bd52de1cbb869f7b641c57132e46544f044cd7e839a`
 
 calculated as explained in the nested validation doc:
 ```sh
 cast index address 0xf64bc17485f0B4Ea5F06A96514182FC4cB561977 8 # council
 # 0x56362ae34e37f50105bd722d564a267a69bbc15ede4cb7136e81afd747b41c4d
-cast index bytes32 0x28342fccf7308fc0967d8303fd5289550a30acff2de8754cf384b524ebe9ca0a 0x56362ae34e37f50105bd722d564a267a69bbc15ede4cb7136e81afd747b41c4d
-# 0xa2178e2b0ce499a24051659b5ab4528cd4e41b7dff3b76fa6861750f7b154391
+cast index bytes32 0x7b390cc232cd3a45f1100c184953b4e6a6556fe2af978d76b577a87a65345254 0x56362ae34e37f50105bd722d564a267a69bbc15ede4cb7136e81afd747b41c4d
+# 0x7a680028073e956784e910c02dd0a0936604b29cd9f9c71c9d8e568533821e16
 ```
 
 ```sh
 cast index address 0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B 8 # foundation
 # 0xc18fefc0a6b81265cf06017c3f1f91c040dc3227321d73c608cfbcf1c5253e5c
-cast index bytes32 0x28342fccf7308fc0967d8303fd5289550a30acff2de8754cf384b524ebe9ca0a 0xc18fefc0a6b81265cf06017c3f1f91c040dc3227321d73c608cfbcf1c5253e5c
-# 0x6baf11815ec9e3d4dc6cfa30c0e72dd31a00e45c9ca6d8a40e52f5cc78635009
+cast index bytes32 0x7b390cc232cd3a45f1100c184953b4e6a6556fe2af978d76b577a87a65345254 0xc18fefc0a6b81265cf06017c3f1f91c040dc3227321d73c608cfbcf1c5253e5c
+# 0xd30a77d4a810ba7768ba1bd52de1cbb869f7b641c57132e46544f044cd7e839a
 ```
 
 ## State Changes


### PR DESCRIPTION
Discovered when running through the validation. 