### PR TITLE
CI Test Task Templates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,20 @@ jobs:
           command: |
             forge --version
             forge test -vvv
+  task_test:
+    docker:
+      - image: <<pipeline.parameters.ci_builder_image>>
+    steps:
+      - checkout
+      - run:
+          name: task test
+          command: |
+            forge --version
+            forge build
+            forge script src/fps/example/template/GasConfigTemplate.sol --sig "run(string)" src/fps/example/task-00/mainnetConfig.toml --rpc-url mainnet -vvv
+            forge script src/fps/example/template/DisputeGameUpgradeTemplate.sol --sig "run(string)" src/fps/example/task-01/mainnetConfig.toml --rpc-url mainnet -vvv
+            forge script src/fps/example/template/SetGameTypeTemplate.sol --sig "run(string)" src/fps/example/task-02/mainnetConfig.toml --rpc-url mainnet -vvvvv
+            forge script src/fps/example/template/GasConfigTemplate.sol --sig "run(string)" src/fps/example/task-03/mainnetConfig.toml --rpc-url mainnet -vvvvv
 
   print_versions:
     docker:
@@ -275,6 +289,7 @@ workflows:
       - forge_build
       - forge_fmt
       - forge_test
+      - task_test
       # RPC endpoint checks.
       - check_sepolia_rpc_endpoints
       - check_mainnet_rpc_endpoints


### PR DESCRIPTION
**Add CI Tests for New Task Templates**

Add a new circleci task to run the new task templates.

**Metadata**

Should close this issue: https://github.com/ethereum-optimism/superchain-ops/issues/482