### PR TITLE
Add simulate task for eth/029

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,6 +220,13 @@ jobs:
     steps:
       - simulate:
           task: "/eth/ink-002-set-respected-game-type"
+  
+  just_simulate_eth_028_holocene_system_config_upgrade_and_init_multichain:
+    docker:
+      - image: << pipeline.parameters.ci_builder_image >>
+    steps:
+      - simulate:
+          task: "/eth/028-holocene-system-config-upgrade-and-init-multichain"
 
   forge_build:
     docker:
@@ -295,4 +302,5 @@ workflows:
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
       - just_simulate_ink_respected_game_type
+      - just_simulate_eth_028_holocene_system_config_upgrade_and_init_multichain
       # sepolia

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
       - simulate:
           task: "/eth/ink-002-set-respected-game-type"
   
-  just_simulate_eth_028_holocene_system_config_upgrade_and_init_multichain:
+  just_simulate_eth_029_holocene_system_config_upgrade_and_init_base:
     docker:
       - image: << pipeline.parameters.ci_builder_image >>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
       - image: << pipeline.parameters.ci_builder_image >>
     steps:
       - simulate:
-          task: "/eth/028-holocene-system-config-upgrade-and-init-multichain"
+          task: "/eth/029-holocene-system-config-upgrade-and-init-base"
 
   forge_build:
     docker:
@@ -302,5 +302,5 @@ workflows:
       - just_simulate_sc_rehearsal_2
       - just_simulate_sc_rehearsal_4
       - just_simulate_ink_respected_game_type
-      - just_simulate_eth_028_holocene_system_config_upgrade_and_init_multichain
+      - just_simulate_eth_029_holocene_system_config_upgrade_and_init_base
       # sepolia


### PR DESCRIPTION
Simulat ci task added for: https://github.com/ethereum-optimism/superchain-ops/tree/main/tasks/eth/029-holocene-system-config-upgrade-and-init-base

This wasn't added in the original PR. 