### PR TITLE
fix: Clean up monorepo justfile command

### DIFF
--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -67,8 +67,10 @@ task COMMAND="" NETWORK="":
 monorepo-integration-test:
     #!/usr/bin/env bash
     set -euo pipefail
-    export root_dir=$(git rev-parse --show-toplevel)
+    root_dir=$(git rev-parse --show-toplevel)
+    allocs_path=${root_dir}/lib/optimism/packages/contracts-bedrock/allocs.json
     forge build
-    forge script ${root_dir}/test/Runner.sol:Runner --sig "run(string)" ${root_dir}/lib/optimism/packages/contracts-bedrock/allocs.json --rpc-url $ETH_RPC_URL --ffi
+    forge script ${root_dir}/test/Runner.sol:Runner --sig "run(string)" ${allocs_path} --rpc-url $ETH_RPC_URL --ffi
     export SUPERCHAIN_OPS_ALLOCS_PATH=./allocs.json
     cd ${root_dir}/lib/optimism/packages/contracts-bedrock/ && just test-upgrade
+    rm -f ${allocs_path} # clean up


### PR DESCRIPTION
Before, this command would leave allocs.json lying around in `lib/optimism/packages/contracts-bedrock/allocs.json`. This PR cleans it up after use. 