### PR TITLE
Scheduled workflow added for clarity.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,12 +352,16 @@ jobs:
             (cd src/improvements/script && shellcheck -x *)
 
 workflows:
-  main:
+  monorepo_integration_test_scheduled:
     when:
-      or:
         - equal: [build_four_hours, << pipeline.trigger_source >>]
-        - not:
-            equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+    jobs:
+      - print_versions
+      - monorepo_integration_test:
+          filters:
+            branches:
+              only: main
+  main:
     jobs:
       - print_versions
       # Forge checks.


### PR DESCRIPTION
With the current change, the workflow doesn't run as expected (see screenshot). This change creates a separate workflow that only gets run when the trigger source is the `build_four_hours`. This way it's easier to reason about the workflows in isolation. 

![CleanShot 2025-02-05 at 23 50 23@2x](https://github.com/user-attachments/assets/209c4b8e-a483-4715-a7be-dbdbf7237e50)
