### PR TITLE
FIX: replace -j flag with --json in sep/fp-recovery/005/justfile

### DIFF
--- a/tasks/sep/fp-recovery/005-set-game-implementation/justfile
+++ b/tasks/sep/fp-recovery/005-set-game-implementation/justfile
@@ -113,7 +113,7 @@ copy-anchor-state fromGameType='' toGameTypes='':
   SUPERCHAIN_CONFIG=$(cast call "${REGISTRY_PROXY}" 'superchainConfig()(address)')
 
   # Load the current anchor state
-  ANCHOR_JSON=$(cast call -j "${REGISTRY_PROXY}" 'anchors(uint32)(bytes32,uint256)' '{{fromGameType}}')
+  ANCHOR_JSON=$(cast call --json "${REGISTRY_PROXY}" 'anchors(uint32)(bytes32,uint256)' '{{fromGameType}}')
   ANCHOR_ROOT=$(echo "${ANCHOR_JSON}" | jq -r '.[0]')
   ANCHOR_BLOCK=$(echo "${ANCHOR_JSON}" | jq -r '.[1]')
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

The -j flag in the sep/fp-recovery/005-set-game-implementation/justfile causes a parsing error (possibly deprecated, misinterpreted or conflicting with another flag). Changing it to --json resolves the issue and correctly retrieves the expected JSON output.

<img width="1247" alt="Screenshot 2025-02-09 at 16 56 13" src="https://github.com/user-attachments/assets/ec9777c8-3d28-4e9f-9184-5879243d4285" />
