### PR TITLE
add getter for address info

### DIFF
--- a/src/improvements/IAddressRegistry.sol
+++ b/src/improvements/IAddressRegistry.sol
@@ -4,11 +4,36 @@ pragma solidity 0.8.15;
 /// @title Network Address Registry Interface
 /// @notice Interface for managing and retrieving addresses across different networks.
 interface IAddressRegistry {
+    /// @dev Structure for storing address details in the contract.
+    struct RegistryEntry {
+        address addr;
+        /// Address (contract or EOA)
+        /// Indicates if the address is a contract
+        bool isContract;
+    }
+
+    /// @dev Structure for reading chain list details from toml file
+    struct ChainInfo {
+        uint256 chainId;
+        string name;
+    }
+
+    /// @dev Structure for storing address info for a given address.
+    struct AddressInfo {
+        string identifier;
+        ChainInfo chainInfo;
+    }
+
     /// @notice Retrieves an address by its identifier for a specified L2 chain
     /// @param identifier The unique identifier associated with the address
     /// @param l2ChainId The chain ID of the L2 network
     /// @return The address associated with the given identifier on the specified chain
     function getAddress(string memory identifier, uint256 l2ChainId) external view returns (address);
+
+    /// @notice Retrieves the identifier and chain info for a given address.
+    /// @param addr The address to retrieve info for.
+    /// @return The identifier and chain info for the given address.
+    function getAddressInfo(address addr) external view returns (AddressInfo memory);
 
     /// @notice Checks if an address is a contract for a given identifier and L2 chain
     /// @param identifier The unique identifier associated with the address

--- a/test/registry/AddressRegistry.t.sol
+++ b/test/registry/AddressRegistry.t.sol
@@ -37,6 +37,7 @@ contract MainnetAddressRegistryTest is Test {
         AddressRegistry.ChainInfo[] memory chains = addresses.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
+            string memory chainName = chains[i].name;
             assertNotEq(
                 addresses.getAddress("L1StandardBridgeProxy", chainId), address(0), "L1StandardBridgeProxy not loaded"
             );
@@ -48,6 +49,70 @@ contract MainnetAddressRegistryTest is Test {
             assertNotEq(addresses.getAddress("AddressManager", chainId), address(0), "AddressManager not loaded");
             assertNotEq(
                 addresses.getAddress("OptimismPortalProxy", chainId), address(0), "OptimismPortalProxy not loaded"
+            );
+
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("L1StandardBridgeProxy", chainId)).identifier,
+                "L1StandardBridgeProxy",
+                "L1StandardBridgeProxy identifier not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("L1StandardBridgeProxy", chainId)).chainInfo.chainId,
+                chainId,
+                "L1StandardBridgeProxy chain id not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("L1StandardBridgeProxy", chainId)).chainInfo.name,
+                chainName,
+                "L1StandardBridgeProxy chain name not loaded"
+            );
+
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("L1CrossDomainMessengerProxy", chainId)).identifier,
+                "L1CrossDomainMessengerProxy",
+                "L1CrossDomainMessengerProxy identifier not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("L1CrossDomainMessengerProxy", chainId)).chainInfo.chainId,
+                chainId,
+                "L1CrossDomainMessengerProxy chain id not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("L1CrossDomainMessengerProxy", chainId)).chainInfo.name,
+                chainName,
+                "L1CrossDomainMessengerProxy chain name not loaded"
+            );
+
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("AddressManager", chainId)).identifier,
+                "AddressManager",
+                "AddressManager identifier not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("AddressManager", chainId)).chainInfo.chainId,
+                chainId,
+                "AddressManager chain id not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("AddressManager", chainId)).chainInfo.name,
+                chainName,
+                "AddressManager chain name not loaded"
+            );
+
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("OptimismPortalProxy", chainId)).identifier,
+                "OptimismPortalProxy",
+                "OptimismPortalProxy identifier not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("OptimismPortalProxy", chainId)).chainInfo.chainId,
+                chainId,
+                "OptimismPortalProxy chain id not loaded"
+            );
+            assertEq(
+                addresses.getAddressInfo(addresses.getAddress("OptimismPortalProxy", chainId)).chainInfo.name,
+                chainName,
+                "OptimismPortalProxy chain name not loaded"
             );
 
             // Note: Some older chains (pre-MCP-L1) do not have a SuperchainConfig.
@@ -114,6 +179,11 @@ contract MainnetAddressRegistryTest is Test {
     function testGetNonExistentAddressFails() public {
         vm.expectRevert("Address not found");
         addresses.getAddress("NON_EXISTENT_ADDRESS", opMainnetChainId);
+    }
+
+    function testGetNonExistentAddressInfoFails() public {
+        vm.expectRevert("Address Info not found");
+        addresses.getAddressInfo(address(0x1234567890123456789012345678901234567890));
     }
 
     function testInvalidL2ChainIdIsAddressContractFails() public {


### PR DESCRIPTION
**Description**
Add a getter function in address registry that returns info corresponding to an address. It return the address identifier and a chain info struct which contains l2chain name and l2chain id.
<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**
Updated tests for the happy path and for the revert path.

**Metadata**
[reference](https://discord.com/channels/1244729134312198194/1327372079380824267/1339085947169411204)
