### PR TITLE
fix: verbose logging on monorepo-integration-tests with rerun

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,6 +313,12 @@ jobs:
             (cd src/improvements && just monorepo-integration-test)
       - notify-failures-on-develop:
           mentions: "@security-team"
+      - run:
+          name: Print failed test traces
+          environment:
+            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
+          command: (cd src/improvements && just monorepo-integration-test rerun)
+          when: on_fail
 
   print_versions:
     docker:

--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -64,7 +64,7 @@ task COMMAND="" NETWORK="":
             ;;
     esac
     
-monorepo-integration-test:
+monorepo-integration-test COMMAND="":
     #!/usr/bin/env bash
     set -euo pipefail
     root_dir=$(git rev-parse --show-toplevel)
@@ -72,7 +72,16 @@ monorepo-integration-test:
     forge build
     forge script ${root_dir}/src/improvements/tasks/Runner.sol:Runner --sig "run(string)" ${allocs_path} --rpc-url $ETH_RPC_URL --ffi
     export SUPERCHAIN_OPS_ALLOCS_PATH=./allocs.json
-    cd ${root_dir}/lib/optimism/packages/contracts-bedrock/ && just test-upgrade-rerun
+    cd ${root_dir}/lib/optimism/packages/contracts-bedrock/
+    # shellcheck disable=SC2194
+    case "{{COMMAND}}" in
+        rerun)
+            just test-upgrade-rerun
+            ;;
+        *)
+            just test-upgrade
+            ;;
+    esac
     rm -f ${allocs_path} # clean up
 
 check-superchain-registry-latest:

--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -72,7 +72,7 @@ monorepo-integration-test:
     forge build
     forge script ${root_dir}/src/improvements/tasks/Runner.sol:Runner --sig "run(string)" ${allocs_path} --rpc-url $ETH_RPC_URL --ffi
     export SUPERCHAIN_OPS_ALLOCS_PATH=./allocs.json
-    cd ${root_dir}/lib/optimism/packages/contracts-bedrock/ && just test-upgrade
+    cd ${root_dir}/lib/optimism/packages/contracts-bedrock/ && just test-upgrade-rerun
     rm -f ${allocs_path} # clean up
 
 check-superchain-registry-latest:


### PR DESCRIPTION
Recent CI failure has shown our error logging isn't enough: https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops/3479/workflows/7e3d0fc2-2f83-4fac-a68e-0b61cd8a7afe/jobs/38952 