### PR TITLE
feat: minimal changes for foundry 1.0.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,9 +10,9 @@ yq = "4.44.5"
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
 # The git ref here should be on the `stable` branch.
-forge = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
-cast = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
-anvil = "nightly-5d16800a64e5357fbb2493e4cae061756d145981"
+forge = "stable"
+cast = "stable"
+anvil = "stable"
 
 [alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"

--- a/test/libraries/BytecodeComparison.t.sol
+++ b/test/libraries/BytecodeComparison.t.sol
@@ -18,16 +18,17 @@ contract MockContract {
 /// @notice Library to expose the internal functions, to avoid tests stopping after hitting an expected revert.
 /// https://book.getfoundry.sh/cheatcodes/expect-revert
 library BytecodeComparisonHarness {
-
     function compare(address _contractA, address _contractB, BytecodeComparison.Diff[] memory _allowed)
-        external view
+        external
+        view
         returns (bool)
     {
         return BytecodeComparison.compare(_contractA, _contractB, _allowed);
     }
 
     function compare(bytes memory _bytecodeA, bytes memory _bytecodeB, BytecodeComparison.Diff[] memory _allowed)
-        external pure
+        external
+        pure
         returns (bool)
     {
         return BytecodeComparison.compare(_bytecodeA, _bytecodeB, _allowed);

--- a/test/libraries/BytecodeComparison.t.sol
+++ b/test/libraries/BytecodeComparison.t.sol
@@ -32,6 +32,7 @@ contract BytecodeComparison_compare_Test is Test {
     }
 
     /// @notice Test that different contracts with different bytecode lengths revert.
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_differentBytecode_reverts() public {
         MockContract contractA = new MockContract(100);
         VeryDifferentContract contractB = new VeryDifferentContract();
@@ -55,6 +56,7 @@ contract BytecodeComparison_compare_Test is Test {
     }
 
     /// @notice Test that an unallowed diff reverts.
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_unallowedDiff_reverts() public {
         bytes memory bytecodeA = hex"0011223344556677";
         bytes memory bytecodeB = hex"0011FF3344556677";
@@ -91,6 +93,7 @@ contract BytecodeComparison_compare_Test is Test {
     }
 
     /// @notice Test that a wrong diff position reverts.
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_wrongDiffPosition_reverts() public {
         bytes memory bytecodeA = hex"0011223344556677";
         bytes memory bytecodeB = hex"0011FF3344556677";
@@ -106,6 +109,7 @@ contract BytecodeComparison_compare_Test is Test {
     }
 
     /// @notice Test that a wrong diff content reverts.
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_wrongDiffContent_reverts() public {
         bytes memory bytecodeA = hex"0011223344556677";
         bytes memory bytecodeB = hex"0011FF3344556677";


### PR DESCRIPTION
**Description**

Foundry 1.0.0 is out, and this repo is an easier place to test the upgrade than the monorepo.

To allow the existing tests to pass, it was chosen to allow `expectRevert` to catch reverts from internal functions, instead of the more convoluted route of creating a helper contract. From [here](https://book.getfoundry.sh/guides/v1.0-migration#expect-revert-cheatcode-disabled-on-internal-calls-by-default).

**Tests**

Compared to `nightly-5d16800a64e5357fbb2493e4cae061756d145981` there are no significant improvements on build (3.92s for 1.0.0 vs 3.88s for 0.3.1) or test time (21.35s vs 21.59s).
