### PR TITLE
fix: using internal rpc urls for forge test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url
-        task: "<< parameters.task >>"
+      - set-simulation-eth-rpc-url:
+          task: "<< parameters.task >>"
       - run:
           name: "simulate << parameters.task >>"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ commands:
       - utils/checkout-with-mise
       - set-simulation-eth-rpc-url:
           task: "<< parameters.task >>"
+          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
+          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate << parameters.task >>"
           command: |
@@ -53,6 +55,8 @@ commands:
       - utils/checkout-with-mise
       - set-simulation-eth-rpc-url:
           task: "<< parameters.task >>"
+          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
+          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate nested << parameters.task >>"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
           name: forge test
           command: |
             forge --version
-            forge test -vvv
+            forge test --profile $FOUNDRY_PROFILE -vvv
   
   monorepo_integration_test:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,12 +303,12 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
           name: forge test
-          environment:
-            FOUNDRY_PROFILE: ci
           command: |
             forge --version
             forge test -vvv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,10 @@ commands:
     parameters:
       task:
         type: string
+      l1_mainnet_rpc_url:
+        type: string
+      l1_sepolia_rpc_url:
+        type: string
     steps:
       - run:
           name: "Set ETH_RPC_URL according to the task being simulated"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,6 +295,8 @@ jobs:
       - utils/checkout-with-mise
       - run:
           name: forge test
+          environment:
+            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
           command: |
             forge --version
             forge test -vvv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,6 @@ commands:
       - utils/checkout-with-mise
       - run:
           name: "simulate << parameters.task >>"
-          environment:
-            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
           command: |
             just install
             cd tasks/<< parameters.task >>
@@ -53,8 +51,6 @@ commands:
       - utils/checkout-with-mise
       - run:
           name: "simulate nested << parameters.task >>"
-          environment:
-            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
           command: |
             just install
             cd tasks/<< parameters.task >>
@@ -261,6 +257,8 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
     steps:
       - simulate:
           task: "/eth/ink-002-set-respected-game-type"
@@ -269,6 +267,8 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      ETH_RPC_URL: << pipeline.parameters.l1_sepolia_rpc_url >>
     steps:
       - simulate_nested:
           task: "/sep/zora-002-fp-upgrade"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
               # Use L1_RPC_URL and L2_RPC_URL here.
 
   just_simulate_sc_rehearsal_1:
+    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
@@ -220,6 +221,7 @@ jobs:
             just simulate # simulate again to make sure the json is still valid
 
   just_simulate_sc_rehearsal_2:
+    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
@@ -238,6 +240,7 @@ jobs:
             just simulate # simulate again to make sure the json is still valid
 
   just_simulate_sc_rehearsal_4:
+    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
@@ -255,6 +258,7 @@ jobs:
             just simulate-council # simulate again to make sure the json is still valid
 
   just_simulate_ink_respected_game_type:
+    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
@@ -262,6 +266,7 @@ jobs:
           task: "/eth/ink-002-set-respected-game-type"
 
   just_simulate_zora_002_fp_upgrade:
+    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
@@ -293,6 +298,7 @@ jobs:
             forge fmt --check
   
   forge_test:
+    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,12 +32,10 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url:
-          task: "<< parameters.task >>"
-          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
-          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate << parameters.task >>"
+          environment:
+            FOUNDRY_PROFILE: ci
           command: |
             just install
             cd tasks/<< parameters.task >>
@@ -53,12 +51,10 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url:
-          task: "<< parameters.task >>"
-          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
-          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate nested << parameters.task >>"
+          environment:
+            FOUNDRY_PROFILE: ci
           command: |
             just install
             cd tasks/<< parameters.task >>
@@ -70,27 +66,6 @@ commands:
               --dotenv-path $(pwd)/.env \
               --justfile ../../../nested.just \
               simulate council
-
-  set-simulation-eth-rpc-url:
-    description: "Sets ETH_RPC_URL according to the task being simulated"
-    parameters:
-      task:
-        type: string
-      l1_mainnet_rpc_url:
-        type: string
-      l1_sepolia_rpc_url:
-        type: string
-    steps:
-      - run:
-          name: "Set ETH_RPC_URL according to the task being simulated"
-          command: |
-            if echo "<< parameters.task >>" | grep -qiE "sep|sepolia"; then
-              echo "Setting ETH_RPC_URL to << parameters.l1_sepolia_rpc_url >>"
-              echo 'export ETH_RPC_URL="<< parameters.l1_sepolia_rpc_url >>"' >> $BASH_ENV
-            else
-              echo "Setting ETH_RPC_URL to << parameters.l1_mainnet_rpc_url >>"
-              echo 'export ETH_RPC_URL="<< parameters.l1_mainnet_rpc_url >>"' >> $BASH_ENV
-            fi
 
   notify-failures-on-develop:
     description: "Notify Slack"
@@ -342,20 +317,18 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
           name: monorepo integration tests
-          environment:
-            FOUNDRY_PROFILE: ci
           command: |
             (cd src/improvements && just monorepo-integration-test)
       - notify-failures-on-develop:
           mentions: "@security-team"
       - run:
           name: Print failed test traces
-          environment:
-            FOUNDRY_PROFILE: ci
           command: (cd src/improvements && just monorepo-integration-test rerun)
           when: on_fail
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
             FOUNDRY_PROFILE: ci
           command: |
             forge --version
-            forge test --profile $FOUNDRY_PROFILE -vvv
+            forge test -vvv
   
   monorepo_integration_test:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
+      - set-simulation-eth-rpc-url
+        task: "<< parameters.task >>"
       - run:
           name: "simulate << parameters.task >>"
           command: |
@@ -49,6 +51,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
+      - set-simulation-eth-rpc-url
+        task: "<< parameters.task >>"
       - run:
           name: "simulate nested << parameters.task >>"
           command: |
@@ -62,6 +66,23 @@ commands:
               --dotenv-path $(pwd)/.env \
               --justfile ../../../nested.just \
               simulate council
+
+  set-simulation-eth-rpc-url:
+    description: "Sets ETH_RPC_URL according to the task being simulated"
+    parameters:
+      task:
+        type: string
+    steps:
+      - run:
+          name: "Set ETH_RPC_URL according to the task being simulated"
+          command: |
+            if echo "<< parameters.task >>" | grep -qiE "sep|sepolia"; then
+              echo "Setting ETH_RPC_URL to << parameters.l1_sepolia_rpc_url >>"
+              echo 'export ETH_RPC_URL="<< parameters.l1_sepolia_rpc_url >>"' >> $BASH_ENV
+            else
+              echo "Setting ETH_RPC_URL to << parameters.l1_mainnet_rpc_url >>"
+              echo 'export ETH_RPC_URL="<< parameters.l1_mainnet_rpc_url >>"' >> $BASH_ENV
+            fi
 
   notify-failures-on-develop:
     description: "Notify Slack"
@@ -257,8 +278,6 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
     steps:
       - simulate:
           task: "/eth/ink-002-set-respected-game-type"
@@ -267,8 +286,6 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      ETH_RPC_URL: << pipeline.parameters.l1_sepolia_rpc_url >>
     steps:
       - simulate_nested:
           task: "/sep/zora-002-fp-upgrade"
@@ -306,7 +323,7 @@ jobs:
       - run:
           name: forge test
           environment:
-            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
+            FOUNDRY_PROFILE: ci
           command: |
             forge --version
             forge test -vvv
@@ -320,7 +337,7 @@ jobs:
       - run:
           name: monorepo integration tests
           environment:
-            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
+            FOUNDRY_PROFILE: ci
           command: |
             (cd src/improvements && just monorepo-integration-test)
       - notify-failures-on-develop:
@@ -328,7 +345,7 @@ jobs:
       - run:
           name: Print failed test traces
           environment:
-            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
+            FOUNDRY_PROFILE: ci
           command: (cd src/improvements && just monorepo-integration-test rerun)
           when: on_fail
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,6 +268,8 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url
-        task: "<< parameters.task >>"
+      - set-simulation-eth-rpc-url:
+          task: "<< parameters.task >>"
       - run:
           name: "simulate nested << parameters.task >>"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ commands:
       - utils/checkout-with-mise
       - run:
           name: "simulate << parameters.task >>"
+          environment:
+            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
           command: |
             just install
             cd tasks/<< parameters.task >>
@@ -51,6 +53,8 @@ commands:
       - utils/checkout-with-mise
       - run:
           name: "simulate nested << parameters.task >>"
+          environment:
+            ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
           command: |
             just install
             cd tasks/<< parameters.task >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,12 +243,12 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
           name: just simulate r4-jointly-upgrade
+          environment:
+            FOUNDRY_PROFILE: ci
           command: |
             just install
             cd security-council-rehearsals
@@ -303,12 +303,12 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
           name: forge test
+          environment:
+            FOUNDRY_PROFILE: ci
           command: |
             forge --version
             forge test --profile $FOUNDRY_PROFILE -vvv

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,6 +24,8 @@ remappings = [
 
 [profile.ci]
 deny_warnings = true
+mainnet = "https://ci-mainnet-l1-archive.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
+sepolia = "https://ci-sepolia-l1.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
 
 [rpc_endpoints]
 localhost = "http://127.0.0.1:8545"

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,6 +24,8 @@ remappings = [
 
 [profile.ci]
 deny_warnings = true
+
+[profile.ci.rpc_endpoints]
 mainnet = "https://ci-mainnet-l1-archive.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
 sepolia = "https://ci-sepolia-l1.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
 


### PR DESCRIPTION
We have failing CI pipelines in superchain-ops: https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops 

All pipelines that are failing fail at the `forge test`, `simulate` or `simulate-nested` step. 


I've moved the internal addresses to the `foundry.toml` file. The thought process here is that we can eventually remove references to them in the circleci yml file. In the meantime, we will rely on foundry profiles to make sure the correct rpc's are used. 