### PR TITLE
Bm/ci fix monorepo int tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,7 +313,7 @@ jobs:
           name: forge test
           command: |
             forge --version
-            forge test -vvv
+            forge test --profile $FOUNDRY_PROFILE -vvv
   
   monorepo_integration_test:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,10 @@ commands:
     parameters:
       task:
         type: string
+      l1_mainnet_rpc_url:
+        type: string
+      l1_sepolia_rpc_url:
+        type: string
     steps:
       - run:
           name: "Set ETH_RPC_URL according to the task being simulated"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ commands:
       - utils/checkout-with-mise
       - set-simulation-eth-rpc-url:
           task: "<< parameters.task >>"
+          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
+          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate << parameters.task >>"
           environment:
@@ -55,6 +57,8 @@ commands:
       - utils/checkout-with-mise
       - set-simulation-eth-rpc-url:
           task: "<< parameters.task >>"
+          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
+          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate nested << parameters.task >>"
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,12 +305,12 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
           name: forge test
-          environment:
-            FOUNDRY_PROFILE: ci
           command: |
             forge --version
             forge test -vvv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,7 +311,7 @@ jobs:
             FOUNDRY_PROFILE: ci
           command: |
             forge --version
-            forge test --profile $FOUNDRY_PROFILE -vvv
+            forge test -vvv
   
   monorepo_integration_test:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url
-        task: "<< parameters.task >>"
+      - set-simulation-eth-rpc-url:
+          task: "<< parameters.task >>"
       - run:
           name: "simulate nested << parameters.task >>"
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,8 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,8 +243,6 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
@@ -305,12 +303,12 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:
           name: forge test
+          environment:
+            FOUNDRY_PROFILE: ci
           command: |
             forge --version
             forge test --profile $FOUNDRY_PROFILE -vvv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,10 +368,7 @@ workflows:
       - forge_fmt
       - forge_test
       # This is a long running job, so we only run it on the main branch.
-      - monorepo_integration_test:
-          filters:
-            branches:
-              only: main
+      - monorepo_integration_test
       - shellcheck
       # RPC endpoint checks.
       - check_sepolia_rpc_endpoints

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,6 +263,8 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
     steps:
       - simulate:
           task: "/eth/ink-002-set-respected-game-type"
@@ -271,6 +273,8 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      ETH_RPC_URL: << pipeline.parameters.l1_sepolia_rpc_url >>
     steps:
       - simulate_nested:
           task: "/sep/zora-002-fp-upgrade"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,6 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url:
-          task: "<< parameters.task >>"
-          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
-          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate << parameters.task >>"
           environment:
@@ -55,10 +51,6 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url:
-          task: "<< parameters.task >>"
-          l1_mainnet_rpc_url: "<< pipeline.parameters.l1_mainnet_rpc_url >>"
-          l1_sepolia_rpc_url: "<< pipeline.parameters.l1_sepolia_rpc_url >>"
       - run:
           name: "simulate nested << parameters.task >>"
           environment:
@@ -74,27 +66,6 @@ commands:
               --dotenv-path $(pwd)/.env \
               --justfile ../../../nested.just \
               simulate council
-
-  set-simulation-eth-rpc-url:
-    description: "Sets ETH_RPC_URL according to the task being simulated"
-    parameters:
-      task:
-        type: string
-      l1_mainnet_rpc_url:
-        type: string
-      l1_sepolia_rpc_url:
-        type: string
-    steps:
-      - run:
-          name: "Set ETH_RPC_URL according to the task being simulated"
-          command: |
-            if echo "<< parameters.task >>" | grep -qiE "sep|sepolia"; then
-              echo "Setting ETH_RPC_URL to << parameters.l1_sepolia_rpc_url >>"
-              echo 'export ETH_RPC_URL="<< parameters.l1_sepolia_rpc_url >>"' >> $BASH_ENV
-            else
-              echo "Setting ETH_RPC_URL to << parameters.l1_mainnet_rpc_url >>"
-              echo 'export ETH_RPC_URL="<< parameters.l1_mainnet_rpc_url >>"' >> $BASH_ENV
-            fi
 
   notify-failures-on-develop:
     description: "Notify Slack"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
-      - set-simulation-eth-rpc-url
-        task: "<< parameters.task >>"
+      - set-simulation-eth-rpc-url:
+          task: "<< parameters.task >>"
       - run:
           name: "simulate << parameters.task >>"
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
+      - set-simulation-eth-rpc-url
+        task: "<< parameters.task >>"
       - run:
           name: "simulate << parameters.task >>"
           environment:
@@ -51,6 +53,8 @@ commands:
         type: string
     steps:
       - utils/checkout-with-mise
+      - set-simulation-eth-rpc-url
+        task: "<< parameters.task >>"
       - run:
           name: "simulate nested << parameters.task >>"
           environment:
@@ -66,6 +70,23 @@ commands:
               --dotenv-path $(pwd)/.env \
               --justfile ../../../nested.just \
               simulate council
+
+  set-simulation-eth-rpc-url:
+    description: "Sets ETH_RPC_URL according to the task being simulated"
+    parameters:
+      task:
+        type: string
+    steps:
+      - run:
+          name: "Set ETH_RPC_URL according to the task being simulated"
+          command: |
+            if echo "<< parameters.task >>" | grep -qiE "sep|sepolia"; then
+              echo "Setting ETH_RPC_URL to << parameters.l1_sepolia_rpc_url >>"
+              echo 'export ETH_RPC_URL="<< parameters.l1_sepolia_rpc_url >>"' >> $BASH_ENV
+            else
+              echo "Setting ETH_RPC_URL to << parameters.l1_mainnet_rpc_url >>"
+              echo 'export ETH_RPC_URL="<< parameters.l1_mainnet_rpc_url >>"' >> $BASH_ENV
+            fi
 
   notify-failures-on-develop:
     description: "Notify Slack"
@@ -263,8 +284,6 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      ETH_RPC_URL: << pipeline.parameters.l1_mainnet_rpc_url >>
     steps:
       - simulate:
           task: "/eth/ink-002-set-respected-game-type"
@@ -273,8 +292,6 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    environment:
-      ETH_RPC_URL: << pipeline.parameters.l1_sepolia_rpc_url >>
     steps:
       - simulate_nested:
           task: "/sep/zora-002-fp-upgrade"

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,6 +24,8 @@ remappings = [
 
 [profile.ci]
 deny_warnings = true
+mainnet = "https://ci-mainnet-l1-archive.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
+sepolia = "https://ci-sepolia-l1.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
 
 [profile.ci.rpc_endpoints]
 mainnet = "https://ci-mainnet-l1-archive.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml

--- a/foundry.toml
+++ b/foundry.toml
@@ -24,6 +24,8 @@ remappings = [
 
 [profile.ci]
 deny_warnings = true
+
+[profile.ci.rpc_endpoints]
 mainnet = "https://ci-mainnet-l1-archive.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
 sepolia = "https://ci-sepolia-l1.optimism.io" # Must have 'circleci_ip_ranges = true' in .circleci/config.yml
 

--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -70,7 +70,7 @@ monorepo-integration-test COMMAND="":
     root_dir=$(git rev-parse --show-toplevel)
     allocs_path=${root_dir}/lib/optimism/packages/contracts-bedrock/allocs.json
     forge build
-    forge script ${root_dir}/src/improvements/tasks/Runner.sol:Runner --sig "run(string)" ${allocs_path} --rpc-url $ETH_RPC_URL --ffi
+    forge script ${root_dir}/src/improvements/tasks/Runner.sol:Runner --sig "run(string)" ${allocs_path} --ffi
     export SUPERCHAIN_OPS_ALLOCS_PATH=./allocs.json
     cd ${root_dir}/lib/optimism/packages/contracts-bedrock/
     # shellcheck disable=SC2194

--- a/src/improvements/tasks/Runner.sol
+++ b/src/improvements/tasks/Runner.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
 
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
 
@@ -33,24 +34,25 @@ contract Runner is Script {
 
     function run() public {
         string[] memory commands = new string[](1);
-        commands[0] = "./src/improvements/script/fetch-tasks.sh";
+        console.log("ETH_RPC_URL", vm.envString("ETH_RPC_URL"));
+        // commands[0] = "./src/improvements/script/fetch-tasks.sh";
 
-        bytes memory result = vm.ffi(commands);
+        // bytes memory result = vm.ffi(commands);
 
-        string[] memory taskPaths = vm.split(string(result), "\n");
+        // string[] memory taskPaths = vm.split(string(result), "\n");
 
-        // Process each task
-        for (uint256 i = 0; i < taskPaths.length; i++) {
-            // Parse config
-            TaskConfig memory config = _parseConfig(taskPaths[i]);
+        // // Process each task
+        // for (uint256 i = 0; i < taskPaths.length; i++) {
+        //     // Parse config
+        //     TaskConfig memory config = _parseConfig(taskPaths[i]);
 
-            // Deploy and run the template
-            string memory templatePath =
-                string.concat("out/", config.templateName, ".sol/", config.templateName, ".json");
+        //     // Deploy and run the template
+        //     string memory templatePath =
+        //         string.concat("out/", config.templateName, ".sol/", config.templateName, ".json");
 
-            MultisigTask task = MultisigTask(deployCode(templatePath));
-            task.simulateRun(config.path);
-        }
+        //     MultisigTask task = MultisigTask(deployCode(templatePath));
+        //     task.simulateRun(config.path);
+        // }
     }
 
     function run(string memory dumpStatePath) public {

--- a/src/improvements/tasks/Runner.sol
+++ b/src/improvements/tasks/Runner.sol
@@ -35,24 +35,24 @@ contract Runner is Script {
     function run() public {
         string[] memory commands = new string[](1);
         console.log("ETH_RPC_URL", vm.envString("ETH_RPC_URL"));
-        // commands[0] = "./src/improvements/script/fetch-tasks.sh";
+        commands[0] = "./src/improvements/script/fetch-tasks.sh";
 
-        // bytes memory result = vm.ffi(commands);
+        bytes memory result = vm.ffi(commands);
 
-        // string[] memory taskPaths = vm.split(string(result), "\n");
+        string[] memory taskPaths = vm.split(string(result), "\n");
 
-        // // Process each task
-        // for (uint256 i = 0; i < taskPaths.length; i++) {
-        //     // Parse config
-        //     TaskConfig memory config = _parseConfig(taskPaths[i]);
+        // Process each task
+        for (uint256 i = 0; i < taskPaths.length; i++) {
+            // Parse config
+            TaskConfig memory config = _parseConfig(taskPaths[i]);
 
-        //     // Deploy and run the template
-        //     string memory templatePath =
-        //         string.concat("out/", config.templateName, ".sol/", config.templateName, ".json");
+            // Deploy and run the template
+            string memory templatePath =
+                string.concat("out/", config.templateName, ".sol/", config.templateName, ".json");
 
-        //     MultisigTask task = MultisigTask(deployCode(templatePath));
-        //     task.simulateRun(config.path);
-        // }
+            MultisigTask task = MultisigTask(deployCode(templatePath));
+            task.simulateRun(config.path);
+        }
     }
 
     function run(string memory dumpStatePath) public {


### PR DESCRIPTION
Monorepo integration tests relied on ETH_RPC_URL. Removing this dependency and ensuring the task relies on ci foundry profile. 