### PR TITLE
Add readonly public repo token context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,29 +366,53 @@ workflows:
         - equal: [webhook, << pipeline.trigger_source >>]
         - equal: ["build_four_hours", <<pipeline.schedule.name>>]
     jobs:
-      - print_versions
+      - print_versions:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # Forge checks.
-      - forge_build
-      - forge_fmt
-      - forge_test
+      - forge_build:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - forge_fmt:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - forge_test:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # This is a long running job, so we only run it on the main branch.
       - monorepo_integration_test:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
           filters:
             branches:
               only: main
-      - shellcheck
+      - shellcheck:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # RPC endpoint checks.
-      - check_sepolia_rpc_endpoints
-      - check_mainnet_rpc_endpoints
+      - check_sepolia_rpc_endpoints:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - check_mainnet_rpc_endpoints:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       - example_mainnet_job:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
           requires:
             - check_mainnet_rpc_endpoints
       # Verify that all tasks have a valid status in their README.
-      - check_task_statuses
+      - check_task_statuses:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # Verify that all tasks have correctly uppercased nonce overrides.
-      - check_nonce_overrides
+      - check_nonce_overrides:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # check that superchain-registry is up to date
-      - check_superchain_registry
+      - check_superchain_registry:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # Task simulations.
       # Please add an invocation to `just simulate` if a ceremony is
       # active (e.g. it is the next ceremony to perform or you
@@ -400,9 +424,17 @@ workflows:
       # and now it fails with stack too deep after https://github.com/ethereum-optimism/superchain-ops/pull/528.
       # We wll need to rewrite the rehearsals with the new superchain-ops structure anyway, so this is ok.
       # - just_simulate_sc_rehearsal_1
-      - just_simulate_sc_rehearsal_2
-      - just_simulate_sc_rehearsal_4
-      - just_simulate_ink_respected_game_type
+      - just_simulate_sc_rehearsal_2:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - just_simulate_sc_rehearsal_4:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+      - just_simulate_ink_respected_game_type:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
       # sepolia
-      - just_simulate_zora_002_fp_upgrade
-
+      - just_simulate_zora_002_fp_upgrade:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+       


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->
When using mise in the repo it reach unauthenticated requests to GitHub rate limit. To overcome the issue we added a readonly GITHUB_TOKEN that will be used for the requests. 
```
WARN  GitHub rate limit exceeded. Resets at 2025-02-20 04:52:17
WARN  GitHub API returned a 403 Forbidden error. This likely means you have exceeded the rate limit.
WARN  GITHUB_TOKEN is not set. This means mise is making unauthenticated requests to GitHub which have a lower rate limit.
To increase the rate limit, set the GITHUB_TOKEN environment variable to a GitHub personal access token.
Create a token at https://github.com/settings/tokens and set it as GITHUB_TOKEN in your environment.
You do not need to give this token any scopes.
```

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
