### PR TITLE
Move foundry version from stable to v1.0.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,9 +10,9 @@ yq = "4.44.5"
 # Foundry is a special case because it supplies multiple binaries at the same
 # GitHub release, so we need to use the aliasing trick to get mise to not error
 # The git ref here should be on the `stable` branch.
-forge = "stable"
-cast = "stable"
-anvil = "stable"
+forge = "v1.0.0"
+cast = "v1.0.0"
+anvil = "v1.0.0"
 
 [alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"


### PR DESCRIPTION
We want to pin our release to foundry v1.0.0, the stable tag will change on the future once they release new versions.

The tag exists here: https://github.com/foundry-rs/foundry/releases/tag/v1.0.0