### PR TITLE
fix: Fix broken monorepo integration tests.

### DIFF
--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -79,9 +79,12 @@ monorepo-integration-test COMMAND="":
     ETH_RPC_URL=$(yq eval ".profile.\"${FOUNDRY_PROFILE}\".rpc_endpoints.mainnet" "${root_dir}/foundry.toml")
     export ETH_RPC_URL
     echo "Using mainnet RPC: ${ETH_RPC_URL}"
+    
+    # For now, we are running monorepo integration tests for the example eth tasks only.
+    mainnet_network_task_dir="eth" 
 
     forge build
-    forge script ${root_dir}/src/improvements/tasks/TaskRunner.sol:TaskRunner --sig "run(string)" ${allocs_path} --ffi --rpc-url $ETH_RPC_URL
+    forge script ${root_dir}/src/improvements/tasks/TaskRunner.sol:TaskRunner --sig "run(string,string)" ${allocs_path} ${mainnet_network_task_dir} --ffi --rpc-url $ETH_RPC_URL
     export SUPERCHAIN_OPS_ALLOCS_PATH=./allocs.json
     cd ${root_dir}/lib/optimism/packages/contracts-bedrock/
     # shellcheck disable=SC2194

--- a/src/improvements/script/fetch-tasks.sh
+++ b/src/improvements/script/fetch-tasks.sh
@@ -24,8 +24,6 @@ check_status() {
 }
 
 # Find README.md files for all mainnet example tasks and process them. 
-# This script only returns mainnet tasks for now. Returning sepolia tasks too would require
-# a lot of additional logic in TaskRunner.sol to switch networks.
 root_dir=$(git rev-parse --show-toplevel)
 network=$1
 if [[ -z "$network" ]]; then

--- a/src/improvements/script/fetch-tasks.sh
+++ b/src/improvements/script/fetch-tasks.sh
@@ -23,7 +23,7 @@ check_status() {
   fi
 }
 
-# Find README.md files for all mainnet example tasks and process them. 
+# Find README.md files for all tasks and process them.
 root_dir=$(git rev-parse --show-toplevel)
 network=$1
 if [[ -z "$network" ]]; then

--- a/src/improvements/script/fetch-tasks.sh
+++ b/src/improvements/script/fetch-tasks.sh
@@ -28,6 +28,11 @@ check_status() {
 # a lot of additional logic in TaskRunner.sol to switch networks.
 root_dir=$(git rev-parse --show-toplevel)
 network=$1
+if [[ -z "$network" ]]; then
+  echo "Usage: $0 <network>"
+  echo "Network is required"
+  exit 1
+fi
 files=$(find "$root_dir/src/improvements/tasks/example/$network" -type f -name 'README.md')
 for file in $files; do
   check_status "$file"

--- a/src/improvements/script/fetch-tasks.sh
+++ b/src/improvements/script/fetch-tasks.sh
@@ -23,9 +23,12 @@ check_status() {
   fi
 }
 
-# Find README.md files for all tasks and process them
+# Find README.md files for all mainnet example tasks and process them. 
+# This script only returns mainnet tasks for now. Returning sepolia tasks too would require
+# a lot of additional logic in TaskRunner.sol to switch networks.
 root_dir=$(git rev-parse --show-toplevel)
-files=$(find "$root_dir/src/improvements/tasks/example" -type f -name 'README.md')
+network=$1
+files=$(find "$root_dir/src/improvements/tasks/example/$network" -type f -name 'README.md')
 for file in $files; do
   check_status "$file"
 done

--- a/src/improvements/tasks/TaskRunner.sol
+++ b/src/improvements/tasks/TaskRunner.sol
@@ -32,9 +32,10 @@ contract TaskRunner is Script {
         return TaskConfig({templateName: templateName, l2chains: l2chains, path: configPath});
     }
 
-    function run() public {
-        string[] memory commands = new string[](1);
+    function run(string memory network) public {
+        string[] memory commands = new string[](2);
         commands[0] = "./src/improvements/script/fetch-tasks.sh";
+        commands[1] = network;
 
         bytes memory result = vm.ffi(commands);
 
@@ -54,8 +55,8 @@ contract TaskRunner is Script {
         }
     }
 
-    function run(string memory dumpStatePath) public {
-        run();
+    function run(string memory dumpStatePath, string memory network) public {
+        run(network);
         vm.dumpState(dumpStatePath);
     }
 

--- a/src/improvements/tasks/TaskRunner.sol
+++ b/src/improvements/tasks/TaskRunner.sol
@@ -55,6 +55,9 @@ contract TaskRunner is Script {
         }
     }
 
+    /// @notice Runs the task and dumps the state to a file.
+    /// The network parameter must be equivalent to the shortname of the network.
+    /// e.g. For Ethereum Mainnet: https://github.com/ethereum-lists/chains/blob/53965b4def1d2983bef638279a66fc88e408ad7c/_data/chains/eip155-1.json#L33
     function run(string memory dumpStatePath, string memory network) public {
         run(network);
         vm.dumpState(dumpStatePath);


### PR DESCRIPTION
[PR](https://github.com/ethereum-optimism/superchain-ops/pull/634) introduced a `sep` directory under `src/improvements/tasks/example/`. This meant that `fetch-tasks.sh` was grabbing not only mainnet but also sepolia tasks to simulated. The forge script command was configured with an ETH_RPC_URL for mainnet. When it came time to simulate the sepolia task, the execution reverted. 
In this PR, I only simulate mainnet tasks. This is a temporary work around and I've made a tracking issue [here](https://github.com/ethereum-optimism/superchain-ops/issues/651) to come back to. We want to make sure the OPCM task that's currently in the `sep` directory gets added to the `eth` directory.