### PR TITLE
fix: Silence test failures until we have a long term fix.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,8 +351,8 @@ jobs:
           name: monorepo integration tests
           command: |
             (cd src/improvements && just monorepo-integration-test)
-      - notify-failures-on-develop:
-          mentions: "@security-team"
+      # - notify-failures-on-develop:
+      #     mentions: "@security-team"
       - run:
           name: Print failed test traces
           command: (cd src/improvements && just monorepo-integration-test rerun)


### PR DESCRIPTION
Our CI has been failing over the last couple of days. This PR silences the alerts we've been receiving until we get a long term fix implemented. We need to have an OPCM task that perfoms an upgrade. 