### PR TITLE
fix: fixed bug in simulation of tasks.

### DIFF
--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -110,31 +110,16 @@ simulate-all-templates:
     #!/usr/bin/env bash
     set -euo pipefail
     root_dir=$(git rev-parse --show-toplevel)
-    nested_just_file="${root_dir}/src/improvements/nested.just"
-    single_just_file="${root_dir}/src/improvements/single.just"
     forge build
 
     simulation_count=0
-    
     for task in ${root_dir}/src/improvements/tasks/example/*/*; do
-        echo ""
         if [ -d "$task" ]; then
-            rpcUrl=$(${root_dir}/src/improvements/script/get-rpc-url.sh $task)
-            echo "Task: $task"
-            is_nested=$(forge script ${root_dir}/src/improvements/tasks/TaskRunner.sol --sig "isNestedTask(string)" "$task/config.toml" --rpc-url $rpcUrl -vvvv)
-            if [ "$is_nested" = "true" ]; then
-                (cd $task && SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile $nested_just_file simulate foundation)
-                echo "Task $task is nested"
-            else
-                (cd $task && SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile $single_just_file simulate)
-                echo "Task $task is not nested"
-            fi
+            ${root_dir}/src/improvements/script/simulate-task.sh $task
             simulation_count=$((simulation_count + 1))
         fi
     done
-
-    echo "\n$simulation_count simulations run."
-
+    echo "$simulation_count simulations run."
     template_count=$(find "${root_dir}/src/improvements/template" -type f ! -name "*.template.sol" | wc -l)
 
     if [ "$simulation_count" -ne "$template_count" ]; then

--- a/src/improvements/script/simulate-task.sh
+++ b/src/improvements/script/simulate-task.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Simulates a task given a path to the task directory. This function will determine if the task is nested or not then
+# simulate it with the appropriate justfile.
+simulate_task() {
+    task=$1
+    root_dir=$(git rev-parse --show-toplevel)
+    nested_just_file="${root_dir}/src/improvements/nested.just"
+    single_just_file="${root_dir}/src/improvements/single.just"
+
+    rpcUrl=$("$root_dir"/src/improvements/script/get-rpc-url.sh "$task")
+    echo "Task: $task"
+    is_nested=$(forge script "$root_dir"/src/improvements/tasks/TaskRunner.sol --sig "isNestedTask(string)" "$task/config.toml" --rpc-url "$rpcUrl" --json | jq -r '.returns["0"].value')
+    echo "Is nested: $is_nested"
+    pushd "$task" > /dev/null
+    if [ "$is_nested" = "true" ]; then
+        echo "Simulating nested task: $task"
+        SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path "$(pwd)"/.env --justfile "$nested_just_file" simulate foundation
+    else
+        echo "Simulating single task: $task"
+        SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path "$(pwd)"/.env --justfile "$single_just_file" simulate
+    fi
+    echo "Done simulating task: $task"
+    popd > /dev/null
+}
+
+simulate_task "$1"

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -143,6 +143,10 @@ abstract contract MultisigTask is Test, Script {
         validate(accountAccesses, actions);
         print(actions, accountAccesses, optionalChildMultisig, true);
 
+        if (optionalChildMultisig != address(0)) {
+            require(isNestedSafe(parentMultisig), "MultisigTask: multisig must be nested");
+        }
+
         return (accountAccesses, actions);
     }
 
@@ -216,7 +220,6 @@ abstract contract MultisigTask is Test, Script {
     /// @param _childMultisig The address of the child multisig.
     function signFromChildMultisig(string memory taskConfigFilePath, address _childMultisig) public {
         simulateRun(taskConfigFilePath, "", _childMultisig);
-        require(isNestedSafe(parentMultisig), "MultisigTask: multisig must be nested");
     }
 
     /// @notice Sets the address registry, initializes the task.

--- a/src/improvements/tasks/example/README.md
+++ b/src/improvements/tasks/example/README.md
@@ -1,0 +1,1 @@
+This `example` directory contains example tasks that are used to make sure templates can always be simulated. When adding a new template, you should add a new task in this directory and make sure that it is simulated via the `template_regression_tests` job in the `circleci/config.yml` file.


### PR DESCRIPTION
I noticed the isNestedSafe forge script wasn't parsing the return value correctly. It's now working as expected. I also clarified the purpose of the `example` directory with a simple readme. Moved a check into root simulateRun function for full coverage.