### PR TITLE
refactor: start decoupling MultisigTask and AddressRegistry

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -521,21 +521,17 @@ abstract contract MultisigTask is Test, Script {
         _buildStarted = 1;
 
         _startBuild();
-
-        _buildSingle();
-
-        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
-
-        for (uint256 i = 0; i < chains.length; i++) {
-            _buildPerChain(chains[i].chainId);
-        }
-
+        _build();
         actions = _endBuild();
 
         _buildStarted = 0;
 
         return actions;
     }
+
+    /// @notice This is essentially a solidity script of the calls you want to make, and its
+    /// contents are extracted into calldata for the task.
+    function _build() internal virtual;
 
     /// @notice print task description, actions, transfers, state changes and EOAs datas to sign
     function print(
@@ -707,20 +703,6 @@ abstract contract MultisigTask is Test, Script {
     /// 1. template setup is the common entrypoint to the MultisigTask regardless of which function is run
     /// @notice abstract function to be implemented by the inheriting contract to setup the template
     function _templateSetup(string memory taskConfigFilePath) internal virtual;
-
-    /// 2. _buildSingle function is the main function for crafting calldata for templates that have calls to be
-    /// made outside of the for loop that iterates over the chains in the task. This function can be used for
-    /// calls to contracts that may or may not be chain specific.
-    /// Does not have to be overridden in inheriting contracts.
-    function _buildSingle() internal virtual {}
-
-    /// 3. _buildPerChain function is the main function for crafting calldata for templates that can be used across
-    /// multiple chains, it is called in a for loop, which iterates over the chains in the task. The _buildPerChain
-    /// function is called with the chainId as an argument the buildModifier captures all of the actions taken in
-    /// this function.
-    /// @notice build the task actions for a given l2chain
-    /// @dev override to add additional task specific build logic
-    function _buildPerChain(uint256 chainId) internal virtual;
 
     /// 4. _validate function is called after the build function has been run for all chains and the results
     /// of this tasks state transitions have been applied. This checks that the state transitions are valid

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -222,10 +222,14 @@ abstract contract MultisigTask is Test, Script {
         simulateRun(taskConfigFilePath, "", _childMultisig);
     }
 
+    /// @notice Deploys the address registry, which as a key-value lookup so addresses can be
+    /// retrieved by name.
+    function _deployAddressRegistry(string memory configPath) internal virtual returns (AddressRegistry);
+
     /// @notice Sets the address registry, initializes the task.
     /// @param taskConfigFilePath The path to the task configuration file.
     function _taskSetup(string memory taskConfigFilePath) internal {
-        AddressRegistry _addrRegistry = new AddressRegistry(taskConfigFilePath);
+        AddressRegistry _addrRegistry = _deployAddressRegistry(taskConfigFilePath);
 
         _templateSetup(taskConfigFilePath);
 
@@ -1166,5 +1170,11 @@ abstract contract MultisigTask is Test, Script {
         }
         // Otherwise, this value looks like an address that we'd expect to have code.
         return true;
+    }
+}
+
+abstract contract L2TaskBase is MultisigTask {
+    function _deployAddressRegistry(string memory taskConfigFilePath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(taskConfigFilePath);
     }
 }

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -433,7 +433,7 @@ abstract contract MultisigTask is Test, Script {
     ///          e.g. read state variables of the deployed contracts to make
     ///          sure they are deployed and initialized correctly, or read
     ///          states that are expected to have changed during the simulate step.
-    function validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory) public virtual {
+    function validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) public virtual {
         // write all state changes to storage
         _processStateDiffChanges(accountAccesses);
 
@@ -465,11 +465,7 @@ abstract contract MultisigTask is Test, Script {
 
         require(IGnosisSafe(parentMultisig).nonce() == nonce + 1, "MultisigTask: nonce not incremented");
 
-        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
-
-        for (uint256 i = 0; i < chains.length; i++) {
-            _validate(chains[i].chainId, accountAccesses);
-        }
+        _validate(accountAccesses, actions);
 
         // check that state diff is as expected
         checkStateDiff(accountAccesses);
@@ -704,14 +700,9 @@ abstract contract MultisigTask is Test, Script {
     /// @notice abstract function to be implemented by the inheriting contract to setup the template
     function _templateSetup(string memory taskConfigFilePath) internal virtual;
 
-    /// 4. _validate function is called after the build function has been run for all chains and the results
-    /// of this tasks state transitions have been applied. This checks that the state transitions are valid
-    /// and applied correctly.
-    /// @notice task specific validations
-    /// @dev override to add additional task specific validations
-    /// @param chainId The l2chainId
-    /// @param accountAccesses returned from the simulate or execute run function
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory accountAccesses) internal view virtual;
+    /// @notice Called after the build function has been run, to execute assertions on the calls and
+    /// state diffs.
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal view virtual;
 
     /// @notice validate actions inclusion
     /// default implementation check for duplicate actions

--- a/src/improvements/tasks/OPCMBaseTask.sol
+++ b/src/improvements/tasks/OPCMBaseTask.sol
@@ -114,11 +114,4 @@ abstract contract OPCMBaseTask is L2TaskBase {
     function _validate(uint256, VmSafe.AccountAccess[] memory) internal view virtual override {
         require(false, "You must implement the _validate function");
     }
-
-    /// @notice overrides to do nothing per chain
-    /// all the chains are handled in a single call to OPCM contract
-    function _buildPerChain(uint256) internal pure override {
-        // We must override this function but OPCM template do not support per chain builds.
-        // We cannot revert here because this build function is called by the parent MultisigTask.
-    }
 }

--- a/src/improvements/tasks/OPCMBaseTask.sol
+++ b/src/improvements/tasks/OPCMBaseTask.sol
@@ -110,8 +110,15 @@ abstract contract OPCMBaseTask is L2TaskBase {
         multicallTarget_ = MULTICALL3_DELEGATECALL_ADDRESS;
     }
 
-    // @notice this function must be overridden in the inheriting contract
-    function _validate(uint256, VmSafe.AccountAccess[] memory) internal view virtual override {
+    /// @notice this function must be overridden in the inheriting contract to run assertions on the state changes.
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions)
+        internal
+        view
+        virtual
+        override
+    {
+        accountAccesses; // No-ops to silence unused variable compiler warnings.
+        actions;
         require(false, "You must implement the _validate function");
     }
 }

--- a/src/improvements/tasks/OPCMBaseTask.sol
+++ b/src/improvements/tasks/OPCMBaseTask.sol
@@ -3,10 +3,10 @@ pragma solidity 0.8.15;
 
 import {VmSafe} from "forge-std/Vm.sol";
 
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {L2TaskBase, MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
 
 /// @notice base task for making calls to the Optimism Contracts Manager
-abstract contract OPCMBaseTask is MultisigTask {
+abstract contract OPCMBaseTask is L2TaskBase {
     /// @notice Optimism Contracts Manager Multicall3DelegateCall contract reference
     address public constant MULTICALL3_DELEGATECALL_ADDRESS = 0x93dc480940585D9961bfcEab58124fFD3d60f76a;
 

--- a/src/improvements/tasks/OPCMBaseTask.sol
+++ b/src/improvements/tasks/OPCMBaseTask.sol
@@ -2,7 +2,9 @@
 pragma solidity 0.8.15;
 
 import {VmSafe} from "forge-std/Vm.sol";
+import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 import {L2TaskBase, MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
 
 /// @notice base task for making calls to the Optimism Contracts Manager
@@ -98,10 +100,14 @@ abstract contract OPCMBaseTask is L2TaskBase {
         vm.startPrank(parentMultisig, true);
     }
 
-    /// @notice set the multicall address
-    /// overrides MultisigTask to set the multicall address to the delegatecall multicall address
-    function _setMulticallAddress() internal override {
-        multicallTarget = MULTICALL3_DELEGATECALL_ADDRESS;
+    function _configureTask(string memory taskConfigFilePath)
+        internal
+        override
+        returns (AddressRegistry addrRegistry_, IGnosisSafe parentMultisig_, address multicallTarget_)
+    {
+        // The only thing we change is overriding the multicall target.
+        (addrRegistry_, parentMultisig_, multicallTarget_) = super._configureTask(taskConfigFilePath);
+        multicallTarget_ = MULTICALL3_DELEGATECALL_ADDRESS;
     }
 
     // @notice this function must be overridden in the inheriting contract

--- a/src/improvements/tasks/TaskRunner.sol
+++ b/src/improvements/tasks/TaskRunner.sol
@@ -79,7 +79,6 @@ contract TaskRunner is Script {
 
         AddressRegistry _addrRegistry = new AddressRegistry(taskConfigFilePath);
         AddressRegistry.ChainInfo[] memory chains = _addrRegistry.getChains();
-        require(chains.length > 0, "MultisigTask: no chains found");
         address parentMultisig = _addrRegistry.getAddress(safeAddressString, chains[0].chainId);
         return task.isNestedSafe(parentMultisig);
     }

--- a/src/improvements/template/DisputeGameUpgradeTemplate.sol
+++ b/src/improvements/template/DisputeGameUpgradeTemplate.sol
@@ -68,18 +68,21 @@ contract DisputeGameUpgradeTemplate is L2TaskBase {
         }
     }
 
-    /// @notice Validates that implementations were set correctly for the specified chain ID
-    /// @param chainId The ID of the L2 chain to validate
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal view override {
-        IDisputeGameFactory disputeGameFactory =
-            IDisputeGameFactory(addrRegistry.getAddress("DisputeGameFactoryProxy", chainId));
+    /// @notice Validates that implementations were set correctly.
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory) internal view override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        if (setImplementations[chainId].l2ChainId != 0) {
-            assertEq(
-                address(disputeGameFactory.gameImpls(setImplementations[chainId].gameType)),
-                setImplementations[chainId].implementation,
-                "implementation not set"
-            );
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            IDisputeGameFactory dgf = IDisputeGameFactory(addrRegistry.getAddress("DisputeGameFactoryProxy", chainId));
+
+            if (setImplementations[chainId].l2ChainId != 0) {
+                assertEq(
+                    address(dgf.gameImpls(setImplementations[chainId].gameType)),
+                    setImplementations[chainId].implementation,
+                    "implementation not set"
+                );
+            }
         }
     }
 

--- a/src/improvements/template/DisputeGameUpgradeTemplate.sol
+++ b/src/improvements/template/DisputeGameUpgradeTemplate.sol
@@ -7,6 +7,7 @@ import {VmSafe} from "forge-std/Vm.sol";
 import "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title DisputeGameUpgradeTemplate
 /// @notice Template contract for upgrading dispute game implementations
@@ -37,6 +38,10 @@ contract DisputeGameUpgradeTemplate is MultisigTask {
         string[] memory storageWrites = new string[](1);
         storageWrites[0] = "DisputeGameFactoryProxy";
         return storageWrites;
+    }
+
+    function _deployAddressRegistry(string memory configPath) internal virtual override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
     }
 
     /// @notice Sets up the template with implementation configurations from a TOML file

--- a/src/improvements/template/DisputeGameUpgradeTemplate.sol
+++ b/src/improvements/template/DisputeGameUpgradeTemplate.sol
@@ -6,12 +6,12 @@ import {VmSafe} from "forge-std/Vm.sol";
 
 import "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {L2TaskBase} from "src/improvements/tasks/MultisigTask.sol";
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title DisputeGameUpgradeTemplate
 /// @notice Template contract for upgrading dispute game implementations
-contract DisputeGameUpgradeTemplate is MultisigTask {
+contract DisputeGameUpgradeTemplate is L2TaskBase {
     /// @notice Struct containing configuration for setting a dispute game implementation
     /// @param gameType The type of game to set the implementation for
     /// @param implementation The address of the new implementation
@@ -38,10 +38,6 @@ contract DisputeGameUpgradeTemplate is MultisigTask {
         string[] memory storageWrites = new string[](1);
         storageWrites[0] = "DisputeGameFactoryProxy";
         return storageWrites;
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal virtual override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 
     /// @notice Sets up the template with implementation configurations from a TOML file

--- a/src/improvements/template/DisputeGameUpgradeTemplate.sol
+++ b/src/improvements/template/DisputeGameUpgradeTemplate.sol
@@ -52,15 +52,19 @@ contract DisputeGameUpgradeTemplate is L2TaskBase {
     }
 
     /// @notice Builds the actions for setting dispute game implementations for a specific L2 chain ID
-    /// @param chainId The ID of the L2 chain to configure
-    function _buildPerChain(uint256 chainId) internal override {
-        IDisputeGameFactory disputeGameFactory =
-            IDisputeGameFactory(addrRegistry.getAddress("DisputeGameFactoryProxy", chainId));
+    function _build() internal override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        if (setImplementations[chainId].l2ChainId != 0) {
-            disputeGameFactory.setImplementation(
-                setImplementations[chainId].gameType, IDisputeGame(setImplementations[chainId].implementation)
-            );
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            IDisputeGameFactory disputeGameFactory =
+                IDisputeGameFactory(addrRegistry.getAddress("DisputeGameFactoryProxy", chainId));
+
+            if (setImplementations[chainId].l2ChainId != 0) {
+                disputeGameFactory.setImplementation(
+                    setImplementations[chainId].gameType, IDisputeGame(setImplementations[chainId].implementation)
+                );
+            }
         }
     }
 

--- a/src/improvements/template/EmptyTemplate.template.sol
+++ b/src/improvements/template/EmptyTemplate.template.sol
@@ -61,9 +61,10 @@ contract EmptyTemplate is MultisigTask {
     }
 
     /// @notice This method performs all validations and assertions that verify the calls executed as expected.
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal pure override {
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal pure override {
+        accountAccesses; // No-ops to silence unused variable compiler warnings.
+        actions;
         require(false, "TODO: Implement the logic to validate that the configuration was set as expected.");
-        chainId;
     }
 
     /// @notice Override to return a list of addresses that should not be checked for code length.

--- a/src/improvements/template/EmptyTemplate.template.sol
+++ b/src/improvements/template/EmptyTemplate.template.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.15;
 import {VmSafe} from "forge-std/Vm.sol";
 
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @notice A template contract for configuring protocol parameters.
 ///         This file is intentionally stripped down; please add your logic where indicated.
@@ -34,6 +35,10 @@ contract EmptyTemplate is MultisigTask {
         string[] memory storageWrites = new string[](1);
         storageWrites[0] = "SystemConfigProxy"; // TODO: This is an example. Change according to your task.
         return storageWrites;
+    }
+
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
     }
 
     /// @notice Sets up the template with implementation configurations from a TOML file.

--- a/src/improvements/template/EmptyTemplate.template.sol
+++ b/src/improvements/template/EmptyTemplate.template.sol
@@ -55,19 +55,9 @@ contract EmptyTemplate is MultisigTask {
         taskConfigFilePath;
     }
 
-    /// @notice Write the calls that you want to execute for each l2chain in the task.
-    /// These can be written as standard Solidity calls and then get parsed as calldata.
-    function _buildPerChain(uint256 chainId) internal pure override {
-        // Delete this function if _buildSingle() is implemented.
-        require(false, "TODO: Implement logic that executes per chain.");
-        chainId;
-    }
-    /// @notice Write the calls that you want to execute one time.
-    /// These can be written as standard Solidity calls and then get parsed as calldata.
-
-    function _buildSingle() internal pure override {
-        // Delete this function if _buildPerChain() is implemented.
-        require(false, "TODO: Normally implemented as part of OPCM templates. Executes logic for all chains.");
+    /// @notice Write the calls that you want to execute for the task.
+    function _build() internal pure override {
+        require(false, "TODO: Implement the logic to execute the task -- you can remove the pure modifier");
     }
 
     /// @notice This method performs all validations and assertions that verify the calls executed as expected.

--- a/src/improvements/template/EmptyTemplate.template.sol
+++ b/src/improvements/template/EmptyTemplate.template.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.15;
 
 import {VmSafe} from "forge-std/Vm.sol";
+import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
@@ -37,8 +38,12 @@ contract EmptyTemplate is MultisigTask {
         return storageWrites;
     }
 
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
+    function _configureTask(string memory configPath)
+        internal
+        override
+        returns (AddressRegistry addrRegistry_, IGnosisSafe parentMultisig_, address multicallTarget_)
+    {
+        return (new AddressRegistry(configPath), IGnosisSafe(address(0)), address(0));
     }
 
     /// @notice Sets up the template with implementation configurations from a TOML file.

--- a/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
+++ b/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
@@ -7,14 +7,14 @@ import {VmSafe} from "forge-std/Vm.sol";
 
 import "forge-std/Test.sol";
 
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {L2TaskBase} from "src/improvements/tasks/MultisigTask.sol";
 import {ModuleManager} from "lib/safe-contracts/contracts/base/ModuleManager.sol";
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 import {AccountAccessParser} from "src/libraries/AccountAccessParser.sol";
 
 /// @title EnableDeputyPauseModuleTemplate
 /// @notice Template contract for enabling a module in a Gnosis Safe
-contract EnableDeputyPauseModuleTemplate is MultisigTask {
+contract EnableDeputyPauseModuleTemplate is L2TaskBase {
     using AccountAccessParser for *;
     using stdStorage for StdStorage;
 
@@ -48,10 +48,6 @@ contract EnableDeputyPauseModuleTemplate is MultisigTask {
         storageWrites[0] = _SAFE_ADDRESS;
 
         return storageWrites;
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 
     /// @notice Sets up the template with module configuration from a TOML file

--- a/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
+++ b/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
@@ -64,12 +64,8 @@ contract EnableDeputyPauseModuleTemplate is L2TaskBase {
         assertEq(_chains.length, 1, "Must specify exactly one chain id to enable deputy pause module for");
     }
 
-    /// @notice Empty implementation as specified
-    /// @param chainId The ID of the L2 chain
-    function _buildPerChain(uint256 chainId) internal override {}
-
     /// @notice Builds the action for enabling the module in the Safe
-    function _buildSingle() internal override {
+    function _build() internal override {
         ModuleManager(parentMultisig).enableModule(newModule);
     }
 

--- a/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
+++ b/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
@@ -12,8 +12,7 @@ import {ModuleManager} from "lib/safe-contracts/contracts/base/ModuleManager.sol
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 import {AccountAccessParser} from "src/libraries/AccountAccessParser.sol";
 
-/// @title EnableDeputyPauseModuleTemplate
-/// @notice Template contract for enabling a module in a Gnosis Safe
+/// @notice Template contract for enabling the DeputyPauseModule in a Gnosis Safe
 contract EnableDeputyPauseModuleTemplate is L2TaskBase {
     using AccountAccessParser for *;
     using stdStorage for StdStorage;
@@ -69,10 +68,20 @@ contract EnableDeputyPauseModuleTemplate is L2TaskBase {
         ModuleManager(parentMultisig).enableModule(newModule);
     }
 
-    /// @notice Validates that the module was enabled correctly
-    /// @param chainId The chain ID of the L2 chain to validate
+    /// @notice Validates that the module was enabled correctly.
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory) internal view override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
+
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            _validatePerChain(chainId, accountAccesses);
+        }
+    }
+
+    /// @notice Validates that the module was enabled correctly for a given chain.
+    /// @param chainId The chain ID of the chain to validate
     /// @param accountAccess the list of account accesses performed by this task
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory accountAccess) internal view override {
+    function _validatePerChain(uint256 chainId, VmSafe.AccountAccess[] memory accountAccess) internal view {
         (address[] memory modules, address nextModule) =
             ModuleManager(parentMultisig).getModulesPaginated(SENTINEL_MODULE, 100);
 

--- a/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
+++ b/src/improvements/template/EnableDeputyPauseModuleTemplate.sol
@@ -50,6 +50,10 @@ contract EnableDeputyPauseModuleTemplate is MultisigTask {
         return storageWrites;
     }
 
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
+    }
+
     /// @notice Sets up the template with module configuration from a TOML file
     /// @param taskConfigFilePath Path to the TOML configuration file
     function _templateSetup(string memory taskConfigFilePath) internal override {

--- a/src/improvements/template/GasConfigTemplate.sol
+++ b/src/improvements/template/GasConfigTemplate.sol
@@ -47,15 +47,17 @@ contract GasConfigTemplate is L2TaskBase {
         }
     }
 
-    /// @notice Builds the actions for setting gas limits for a specific L2 chain ID
-    /// @param chainId The ID of the L2 chain to configure
-    function _buildPerChain(uint256 chainId) internal override {
-        // View only, filtered out by MultisigTask.sol
-        SystemConfig systemConfig = SystemConfig(addrRegistry.getAddress("SystemConfigProxy", chainId));
+    /// @notice Builds the actions for setting gas limits.
+    function _build() internal override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        if (gasLimits[chainId] != 0) {
-            // Mutative call, recorded by MultisigTask.sol for generating multisig calldata
-            systemConfig.setGasLimit(gasLimits[chainId]);
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            SystemConfig systemConfig = SystemConfig(addrRegistry.getAddress("SystemConfigProxy", chainId));
+            if (gasLimits[chainId] != 0) {
+                // Mutative call, recorded by MultisigTask.sol for generating multisig calldata
+                systemConfig.setGasLimit(gasLimits[chainId]);
+            }
         }
     }
 

--- a/src/improvements/template/GasConfigTemplate.sol
+++ b/src/improvements/template/GasConfigTemplate.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.15;
 import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {L2TaskBase} from "src/improvements/tasks/MultisigTask.sol";
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title GasConfigTemplate
 /// @notice Template contract for configuring gas limits
-contract GasConfigTemplate is MultisigTask {
+contract GasConfigTemplate is L2TaskBase {
     /// @notice Struct to store gas limits to be set for a specific L2 chain ID
     /// @param chainId The ID of the L2 chain
     /// @param gasLimit The gas limit to be set for the chain
@@ -26,10 +26,6 @@ contract GasConfigTemplate is MultisigTask {
     /// @return The string "SystemConfigOwner"
     function safeAddressString() public pure override returns (string memory) {
         return "SystemConfigOwner";
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal virtual override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 
     /// @notice Returns the storage write permissions required for this task

--- a/src/improvements/template/GasConfigTemplate.sol
+++ b/src/improvements/template/GasConfigTemplate.sol
@@ -5,6 +5,7 @@ import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title GasConfigTemplate
 /// @notice Template contract for configuring gas limits
@@ -25,6 +26,10 @@ contract GasConfigTemplate is MultisigTask {
     /// @return The string "SystemConfigOwner"
     function safeAddressString() public pure override returns (string memory) {
         return "SystemConfigOwner";
+    }
+
+    function _deployAddressRegistry(string memory configPath) internal virtual override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
     }
 
     /// @notice Returns the storage write permissions required for this task

--- a/src/improvements/template/GasConfigTemplate.sol
+++ b/src/improvements/template/GasConfigTemplate.sol
@@ -62,12 +62,14 @@ contract GasConfigTemplate is L2TaskBase {
     }
 
     /// @notice Validates that gas limits were set correctly for the specified chain ID
-    /// @param chainId The ID of the L2 chain to validate
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal view override {
-        SystemConfig systemConfig = SystemConfig(addrRegistry.getAddress("SystemConfigProxy", chainId));
-
-        if (gasLimits[chainId] != 0) {
-            assertEq(systemConfig.gasLimit(), gasLimits[chainId], "l2 gas limit not set");
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory) internal view override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            SystemConfig systemConfig = SystemConfig(addrRegistry.getAddress("SystemConfigProxy", chainId));
+            if (gasLimits[chainId] != 0) {
+                assertEq(systemConfig.gasLimit(), gasLimits[chainId], "l2 gas limit not set");
+            }
         }
     }
 

--- a/src/improvements/template/SetGameTypeTemplate.sol
+++ b/src/improvements/template/SetGameTypeTemplate.sol
@@ -7,12 +7,11 @@ import {
 import {LibGameType} from "@eth-optimism-bedrock/src/dispute/lib/LibUDT.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
-import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
+import {L2TaskBase} from "src/improvements/tasks/MultisigTask.sol";
 
 /// @title SetGameTypeTemplate
 /// @notice Template contract for setting game types in the Optimism system
-contract SetGameTypeTemplate is MultisigTask {
+contract SetGameTypeTemplate is L2TaskBase {
     using LibGameType for GameType;
 
     /// @notice Struct containing configuration for setting a respected game type
@@ -35,10 +34,6 @@ contract SetGameTypeTemplate is MultisigTask {
     /// @return The string "Challenger"
     function safeAddressString() public pure override returns (string memory) {
         return "Challenger";
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 
     /// @notice Returns the storage write permissions required for this task

--- a/src/improvements/template/SetGameTypeTemplate.sol
+++ b/src/improvements/template/SetGameTypeTemplate.sol
@@ -8,6 +8,7 @@ import {LibGameType} from "@eth-optimism-bedrock/src/dispute/lib/LibUDT.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title SetGameTypeTemplate
 /// @notice Template contract for setting game types in the Optimism system
@@ -34,6 +35,10 @@ contract SetGameTypeTemplate is MultisigTask {
     /// @return The string "Challenger"
     function safeAddressString() public pure override returns (string memory) {
         return "Challenger";
+    }
+
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
     }
 
     /// @notice Returns the storage write permissions required for this task

--- a/src/improvements/template/SetGameTypeTemplate.sol
+++ b/src/improvements/template/SetGameTypeTemplate.sol
@@ -72,7 +72,7 @@ contract SetGameTypeTemplate is L2TaskBase {
     }
 
     /// @notice Validates that game types were set correctly.abi
-    function _validate(VmSafe.AccountAccess[] memory, Action[] memory actions) internal view override {
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory) internal view override {
         AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
         for (uint256 i = 0; i < chains.length; i++) {

--- a/src/improvements/template/SetGameTypeTemplate.sol
+++ b/src/improvements/template/SetGameTypeTemplate.sol
@@ -71,18 +71,17 @@ contract SetGameTypeTemplate is L2TaskBase {
         }
     }
 
-    /// @notice Validates that game types were set correctly for the specified chain ID
-    /// @param chainId The ID of the L2 chain to validate
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal view override {
-        IOptimismPortal2 optimismPortal =
-            IOptimismPortal2(payable(addrRegistry.getAddress("OptimismPortalProxy", chainId)));
+    /// @notice Validates that game types were set correctly.abi
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory actions) internal view override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        if (setRespectedGameTypes[chainId].l2ChainId != 0) {
-            assertEq(
-                optimismPortal.respectedGameType().raw(),
-                setRespectedGameTypes[chainId].gameType.raw(),
-                "gameType not set"
-            );
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            IOptimismPortal2 portal = IOptimismPortal2(payable(addrRegistry.getAddress("OptimismPortalProxy", chainId)));
+            if (setRespectedGameTypes[chainId].l2ChainId != 0) {
+                uint256 currentGameType = portal.respectedGameType().raw();
+                assertEq(currentGameType, setRespectedGameTypes[chainId].gameType.raw(), "gameType not set");
+            }
         }
     }
 

--- a/src/improvements/template/TestOPCMUpgradeVxyz.sol
+++ b/src/improvements/template/TestOPCMUpgradeVxyz.sol
@@ -53,9 +53,8 @@ contract TestOPCMUpgradeVxyz is OPCMBaseTask {
         }
     }
 
-    /// @notice build the task action for all l2chains in the task
-    /// in a single call to the OPCM.upgrade() function.
-    function _buildSingle() internal override {
+    /// @notice Build the task action for all l2chains in the task in a single call to the OPCM.upgrade() function.
+    function _build() internal override {
         AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
         OpChainConfig[] memory opcmConfigs = new OpChainConfig[](chains.length);
 
@@ -68,9 +67,9 @@ contract TestOPCMUpgradeVxyz is OPCMBaseTask {
         }
         vm.label(opcm(), "OPCM");
 
-        (bool success,) =
+        (bool success, bytes memory data) =
             opcm().delegatecall(abi.encodeWithSignature("upgrade((address,address,bytes32)[])", opcmConfigs));
-        require(success, "OPCMUpgrateTemplate: failed to upgrade OPCM");
+        require(success, string.concat("OPCMUpgrateTemplate: failed to upgrade OPCM", vm.toString(data)));
     }
 
     /// @notice validate the task for a given l2chain

--- a/src/improvements/template/TestOPCMUpgradeVxyz.sol
+++ b/src/improvements/template/TestOPCMUpgradeVxyz.sol
@@ -42,10 +42,6 @@ contract TestOPCMUpgradeVxyz is OPCMBaseTask {
         return storageWrites;
     }
 
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
-    }
-
     /// @notice Sets up the template with prestate inputs from a TOML file
     /// @param taskConfigFilePath Path to the TOML configuration file
     function _templateSetup(string memory taskConfigFilePath) internal override {

--- a/src/improvements/template/TestOPCMUpgradeVxyz.sol
+++ b/src/improvements/template/TestOPCMUpgradeVxyz.sol
@@ -72,10 +72,9 @@ contract TestOPCMUpgradeVxyz is OPCMBaseTask {
         require(success, string.concat("OPCMUpgrateTemplate: failed to upgrade OPCM", vm.toString(data)));
     }
 
-    /// @notice validate the task for a given l2chain
-    /// for this dummy opcm there are no validations per l2 chain
-    /// for a real OPCM instance, add the validations per l2chain
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal view override {}
+    /// @notice Validate the task.
+    /// For this dummy opcm there are no validations, but for a real OPCM instance, add the validations.
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal view override {}
 
     /// @notice no code exceptions for this template
     function getCodeExceptions() internal view virtual override returns (address[] memory) {}

--- a/src/improvements/template/TestOPCMUpgradeVxyz.sol
+++ b/src/improvements/template/TestOPCMUpgradeVxyz.sol
@@ -42,6 +42,10 @@ contract TestOPCMUpgradeVxyz is OPCMBaseTask {
         return storageWrites;
     }
 
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
+    }
+
     /// @notice Sets up the template with prestate inputs from a TOML file
     /// @param taskConfigFilePath Path to the TOML configuration file
     function _templateSetup(string memory taskConfigFilePath) internal override {

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -19,6 +19,10 @@ contract TransferOwnerTemplate is MultisigTask {
         return "ProxyAdminOwner";
     }
 
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
+    }
+
     /// @notice Returns the storage write permissions required for this task
     /// @return Array of storage write permissions, in this case, only the ProxyAdmin is returned
     function _taskStorageWrites() internal pure virtual override returns (string[] memory) {

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -53,7 +53,7 @@ contract TransferOwnerTemplate is L2TaskBase {
     }
 
     /// @notice Validates that the owner was transferred correctly.
-    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal view override {
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory) internal view override {
         AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
         for (uint256 i = 0; i < chains.length; i++) {

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -37,14 +37,19 @@ contract TransferOwnerTemplate is L2TaskBase {
         require(_chains.length == 1, "Must specify exactly one chain id to transfer ownership for");
     }
 
-    /// @notice Builds the actions for setting gas limits for a specific L2 chain ID
-    /// @param chainId The ID of the L2 chain to configure
-    function _buildPerChain(uint256 chainId) internal override {
-        // View only, filtered out by MultisigTask.sol
-        ProxyAdmin proxyAdmin = ProxyAdmin(addrRegistry.getAddress("ProxyAdmin", chainId));
+    /// @notice Builds the actions for transferring ownership of the proxy admin
+    function _build() internal override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        // Mutative call, recorded by MultisigTask.sol for generating multisig calldata
-        proxyAdmin.transferOwnership(newOwner);
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+
+            // View only, filtered out by MultisigTask.sol
+            ProxyAdmin proxyAdmin = ProxyAdmin(addrRegistry.getAddress("ProxyAdmin", chainId));
+
+            // Mutative call, recorded by MultisigTask.sol for generating multisig calldata
+            proxyAdmin.transferOwnership(newOwner);
+        }
     }
 
     /// @notice Validates that gas limits were set correctly for the specified chain ID

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -52,12 +52,14 @@ contract TransferOwnerTemplate is L2TaskBase {
         }
     }
 
-    /// @notice Validates that gas limits were set correctly for the specified chain ID
-    /// @param chainId The ID of the L2 chain to validate
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal view override {
-        ProxyAdmin proxyAdmin = ProxyAdmin(addrRegistry.getAddress("ProxyAdmin", chainId));
+    /// @notice Validates that the owner was transferred correctly.
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal view override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        assertEq(proxyAdmin.owner(), newOwner, "new owner not set correctly");
+        for (uint256 i = 0; i < chains.length; i++) {
+            ProxyAdmin proxyAdmin = ProxyAdmin(addrRegistry.getAddress("ProxyAdmin", chains[i].chainId));
+            assertEq(proxyAdmin.owner(), newOwner, "new owner not set correctly");
+        }
     }
 
     /// @notice no code exceptions for this template

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -4,12 +4,12 @@ pragma solidity 0.8.15;
 import {ProxyAdmin} from "@eth-optimism-bedrock/src/universal/ProxyAdmin.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {L2TaskBase} from "src/improvements/tasks/MultisigTask.sol";
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title TransferOwnerTemplate
 /// @notice Template contract for transferring ownership of the proxy admin
-contract TransferOwnerTemplate is MultisigTask {
+contract TransferOwnerTemplate is L2TaskBase {
     /// @notice new owner address
     address public newOwner;
 
@@ -17,10 +17,6 @@ contract TransferOwnerTemplate is MultisigTask {
     /// @return The string "ProxyAdminOwner"
     function safeAddressString() public pure override returns (string memory) {
         return "ProxyAdminOwner";
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 
     /// @notice Returns the storage write permissions required for this task

--- a/test/tasks/MultisigTask.t.sol
+++ b/test/tasks/MultisigTask.t.sol
@@ -55,7 +55,7 @@ contract MultisigTaskUnitTest is Test {
     }
 
     function testRunFailsNoNetworks() public {
-        vm.expectRevert("MultisigTask: no chains found");
+        vm.expectRevert("AddressRegistry: no chains found");
         task.simulateRun("./test/tasks/mock/configs/InvalidNetworkConfig.toml");
     }
 

--- a/test/tasks/SingleMultisigTask.t.sol
+++ b/test/tasks/SingleMultisigTask.t.sol
@@ -187,7 +187,7 @@ contract SingleMultisigTaskTest is Test {
     function testRevertIfUnsupportedChain() public {
         vm.chainId(10);
         MultisigTask localMultisigTask = new GasConfigTemplate();
-        vm.expectRevert("Unsupported network");
+        vm.expectRevert("AddressRegistry: Unsupported task chain ID 10");
         localMultisigTask.simulateRun(taskConfigFilePath);
     }
 

--- a/test/tasks/mock/MockDisputeGameTask.sol
+++ b/test/tasks/mock/MockDisputeGameTask.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.15;
 
-import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 import {DisputeGameUpgradeTemplate} from "src/improvements/template/DisputeGameUpgradeTemplate.sol";
 
 /// Mock task that upgrades the Dispute Game implementation
@@ -13,9 +12,5 @@ contract MockDisputeGameTask is DisputeGameUpgradeTemplate {
         addresses[0] = address(0x0000000FFfFFfffFffFfFffFFFfffffFffFFffFf);
 
         return addresses;
-    }
-
-    function _deployAddressRegistry(string memory taskConfigFilePath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(taskConfigFilePath);
     }
 }

--- a/test/tasks/mock/MockDisputeGameTask.sol
+++ b/test/tasks/mock/MockDisputeGameTask.sol
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.15;
 
-import {IProxyAdmin} from "@eth-optimism-bedrock/interfaces/universal/IProxyAdmin.sol";
-import {Constants} from "@eth-optimism-bedrock/src/libraries/Constants.sol";
-import {IProxy} from "@eth-optimism-bedrock/interfaces/universal/IProxy.sol";
-import {VmSafe} from "forge-std/Vm.sol";
-
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 import {DisputeGameUpgradeTemplate} from "src/improvements/template/DisputeGameUpgradeTemplate.sol";
 
 /// Mock task that upgrades the Dispute Game implementation
@@ -18,5 +13,9 @@ contract MockDisputeGameTask is DisputeGameUpgradeTemplate {
         addresses[0] = address(0x0000000FFfFFfffFffFfFffFFFfffffFffFFffFf);
 
         return addresses;
+    }
+
+    function _deployAddressRegistry(string memory taskConfigFilePath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(taskConfigFilePath);
     }
 }

--- a/test/tasks/mock/MockMultisigTask.sol
+++ b/test/tasks/mock/MockMultisigTask.sol
@@ -7,12 +7,11 @@ import {IProxy} from "@eth-optimism-bedrock/interfaces/universal/IProxy.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 
 import {MockTarget} from "test/tasks/mock/MockTarget.sol";
-import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
-import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
+import {L2TaskBase} from "src/improvements/tasks/MultisigTask.sol";
 
 /// Mock task that upgrades the L1ERC721BridgeProxy implementation
 /// to an example implementation address
-contract MockMultisigTask is MultisigTask {
+contract MockMultisigTask is L2TaskBase {
     address public constant newImplementation = address(1000);
 
     /// @notice reference to the mock target contract
@@ -58,8 +57,4 @@ contract MockMultisigTask is MultisigTask {
 
     /// @notice no code exceptions for this template
     function getCodeExceptions() internal view virtual override returns (address[] memory) {}
-
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
-    }
 }

--- a/test/tasks/mock/MockMultisigTask.sol
+++ b/test/tasks/mock/MockMultisigTask.sol
@@ -56,7 +56,7 @@ contract MockMultisigTask is L2TaskBase {
     }
 
     /// @notice Validates that the proxy implementation was set correctly.
-    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal view override {
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory) internal view override {
         AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
         for (uint256 i = 0; i < chains.length; i++) {

--- a/test/tasks/mock/MockMultisigTask.sol
+++ b/test/tasks/mock/MockMultisigTask.sol
@@ -8,7 +8,7 @@ import {VmSafe} from "forge-std/Vm.sol";
 
 import {MockTarget} from "test/tasks/mock/MockTarget.sol";
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";
-import {Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
+import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// Mock task that upgrades the L1ERC721BridgeProxy implementation
 /// to an example implementation address
@@ -58,4 +58,8 @@ contract MockMultisigTask is MultisigTask {
 
     /// @notice no code exceptions for this template
     function getCodeExceptions() internal view virtual override returns (address[] memory) {}
+
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
+    }
 }

--- a/test/tasks/mock/MockMultisigTask.sol
+++ b/test/tasks/mock/MockMultisigTask.sol
@@ -55,11 +55,16 @@ contract MockMultisigTask is L2TaskBase {
         }
     }
 
-    function _validate(uint256 chainId, VmSafe.AccountAccess[] memory) internal view override {
-        IProxy proxy = IProxy(payable(addrRegistry.getAddress("L1ERC721BridgeProxy", chainId)));
-        bytes32 data = vm.load(address(proxy), Constants.PROXY_IMPLEMENTATION_ADDRESS);
+    /// @notice Validates that the proxy implementation was set correctly.
+    function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) internal view override {
+        AddressRegistry.ChainInfo[] memory chains = addrRegistry.getChains();
 
-        assertEq(bytes32(uint256(uint160(newImplementation))), data, "Proxy implementation not set correctly");
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            IProxy proxy = IProxy(payable(addrRegistry.getAddress("L1ERC721BridgeProxy", chainId)));
+            bytes32 data = vm.load(address(proxy), Constants.PROXY_IMPLEMENTATION_ADDRESS);
+            assertEq(bytes32(uint256(uint160(newImplementation))), data, "Proxy implementation not set correctly");
+        }
     }
 
     /// @notice no code exceptions for this template

--- a/test/tasks/mock/template/IncorrectGasConfigTemplate1.sol
+++ b/test/tasks/mock/template/IncorrectGasConfigTemplate1.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.15;
 
-import {SystemConfig} from "@eth-optimism-bedrock/src/L1/SystemConfig.sol";
-
 import {GasConfigTemplate} from "src/improvements/template/GasConfigTemplate.sol";
 import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
@@ -14,5 +12,9 @@ contract IncorrectGasConfigTemplate1 is GasConfigTemplate {
         /// wrong address
         storageWrites[0] = "SystemConfigOwner";
         return storageWrites;
+    }
+
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
     }
 }

--- a/test/tasks/mock/template/IncorrectGasConfigTemplate1.sol
+++ b/test/tasks/mock/template/IncorrectGasConfigTemplate1.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 import {GasConfigTemplate} from "src/improvements/template/GasConfigTemplate.sol";
-import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title IncorrectGasConfigTemplate1
 /// @notice allowed storage write to incorrect address
@@ -12,9 +11,5 @@ contract IncorrectGasConfigTemplate1 is GasConfigTemplate {
         /// wrong address
         storageWrites[0] = "SystemConfigOwner";
         return storageWrites;
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 }

--- a/test/tasks/mock/template/IncorrectGasConfigTemplate2.sol
+++ b/test/tasks/mock/template/IncorrectGasConfigTemplate2.sol
@@ -13,4 +13,8 @@ contract IncorrectGasConfigTemplate2 is GasConfigTemplate {
         storageWrites[0] = "SystemConfigOwner";
         return storageWrites;
     }
+
+    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
+        return new AddressRegistry(configPath);
+    }
 }

--- a/test/tasks/mock/template/IncorrectGasConfigTemplate2.sol
+++ b/test/tasks/mock/template/IncorrectGasConfigTemplate2.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.15;
 
 import {GasConfigTemplate} from "src/improvements/template/GasConfigTemplate.sol";
-import {AddressRegistry} from "src/improvements/AddressRegistry.sol";
 
 /// @title IncorrectGasConfigTemplate2
 /// @notice not all allowed storages writes are written to
@@ -12,9 +11,5 @@ contract IncorrectGasConfigTemplate2 is GasConfigTemplate {
         /// expected to be written to
         storageWrites[0] = "SystemConfigOwner";
         return storageWrites;
-    }
-
-    function _deployAddressRegistry(string memory configPath) internal override returns (AddressRegistry) {
-        return new AddressRegistry(configPath);
     }
 }


### PR DESCRIPTION
Begins decoupling MultisigTask and AddressRegistry. Remaining step is moving `chains` specific things out of `_taskSetup` and into `L2TaskBase`, which will allow us to delete a lot of the duplicate `_deployAddressRegistry` code

cc @prat-gpt @ElliotFriedman 