### PR TITLE
refactor simulate-nested command into a just-simulate-nested job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,12 +450,6 @@ workflows:
           context:
             - circleci-repo-readonly-authenticated-github-token
 
-      # sepolia
-      - just_simulate_nested:
-          task: "/sep/ink-002-holocene-system-config-upgrade"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-
       # Simulation sequence for Superchain Version Sync (at the 27th of February 2025). The next task would be 31 but we need to wait until the task is 31 is merged.
       # tasks: "030 031"
       - simulate_sequence:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,13 +263,6 @@ jobs:
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
 
-  just_simulate_030_sony_holocene_system_config_upgrade:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    steps:
-      - simulate_nested:
-          task: "/eth/030-soneium-holocene-system-config-upgrade"
-
   simulate_sequence:
     description: "Runs a sequence of simulations"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,29 +44,6 @@ commands:
               --justfile ../../../single.just \
               simulate
 
-  simulate_nested:
-    description: "Runs simulations of a nested task"
-    parameters:
-      task:
-        type: string
-    steps:
-      - utils/checkout-with-mise
-      - run:
-          name: "simulate nested << parameters.task >>"
-          environment:
-            FOUNDRY_PROFILE: ci
-          command: |
-            just install
-            cd tasks/<< parameters.task >>
-            SIMULATE_WITHOUT_LEDGER=true just \
-              --dotenv-path $(pwd)/.env \
-              --justfile ../../../nested.just \
-              simulate foundation
-            SIMULATE_WITHOUT_LEDGER=true just \
-              --dotenv-path $(pwd)/.env \
-              --justfile ../../../nested.just \
-              simulate council
-
   notify-failures-on-develop:
     description: "Notify Slack"
     parameters:
@@ -263,6 +240,31 @@ jobs:
             just prepare-json
             just simulate-council # simulate again to make sure the json is still valid
 
+  just_simulate_nested:
+    description: "Runs simulations of a nested task"
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    parameters:
+      task:
+        type: string
+    steps:
+      - utils/checkout-with-mise
+      - run:
+          name: "simulate nested << parameters.task >>"
+          environment:
+            FOUNDRY_PROFILE: ci
+          command: |
+            just install
+            cd tasks/<< parameters.task >>
+            SIMULATE_WITHOUT_LEDGER=true just \
+              --dotenv-path $(pwd)/.env \
+              --justfile ../../../nested.just \
+              simulate foundation
+            SIMULATE_WITHOUT_LEDGER=true just \
+              --dotenv-path $(pwd)/.env \
+              --justfile ../../../nested.just \
+              simulate council
+
   simulate_sequence:
     description: "Runs a sequence of simulations"
     parameters:
@@ -447,9 +449,15 @@ workflows:
       - just_simulate_sc_rehearsal_4:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      # sepolia
 
-      # Simulation sequence for Superchain Version Sync (at the 27th of February 2025). The next task would be 31 but we need to wait until it is merged.
+      # sepolia
+      - just_simulate_nested:
+          task: "/sep/ink-002-holocene-system-config-upgrade"
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+
+      # Simulation sequence for Superchain Version Sync (at the 27th of February 2025). The next task would be 31 but we need to wait until the task is 31 is merged.
+      # tasks: "030 031"
       - simulate_sequence:
           network: "eth"
           tasks: "030"


### PR DESCRIPTION
I think that the way we setup task specific jobs is unnecessary, and we can instead just convert simulate-nested into a reusable job.

This should make task PRs a bit less noisy and reduce churn in this repo.

