### PR TITLE
Fix: Sepolia Support for `Sim-Sequence`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,5 +473,5 @@ workflows:
 
       - simulate_sequence:
           network: "sep"
-          tasks: ""
+          tasks: "032"
           block_number: "" # If not specified, the latest block number is used.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,11 +467,17 @@ workflows:
       # Simulation sequence for Superchain Version Sync (at the 27th of February 2025). The next task would be 31 but we need to wait until the task is 31 is merged.
       # tasks: "030 031"
       - simulate_sequence:
+          name: simulate_sequence_eth
           network: "eth"
           tasks: "030"
           block_number: "21938584" # If not specified, the latest block number is used.
+          context:
+            - circleci-repo-readonly-authenticated-github-token
 
       - simulate_sequence:
+          name: simulate_sequence_sep
           network: "sep"
           tasks: "032"
           block_number: "" # If not specified, the latest block number is used.
+          context:
+            - circleci-repo-readonly-authenticated-github-token


### PR DESCRIPTION
In this PR,
- Fix Sim-sequence to make better support for sepolia tasks
- Added the task 032 again in the CI, since it worked locally.
- Renaming of the `sim-sequence-1 `->  `sim-sequence-eth`  and same for `sim-sequence-2` -> `sim-sequence-sep` to improve clarity.






