### PR TITLE
Use stdToml where possible, custom functions elsewhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ draft*signer*.json
 ready-*
 
 broadcast/*
+
+# ignore specstory files
+.specstory/

--- a/src/improvements/AddressRegistry.sol
+++ b/src/improvements/AddressRegistry.sol
@@ -5,6 +5,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 
 import {Vm} from "forge-std/Vm.sol";
 import {StdChains} from "forge-std/StdChains.sol";
+import {stdToml} from "forge-std/StdToml.sol";
 import {GameTypes, GameType} from "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 
 /// @notice Contains getters for arbitrary methods from all L1 contracts, including legacy getters
@@ -42,6 +43,7 @@ interface IFetcher {
 /// (EOAs) while ensuring correctness and uniqueness.
 contract AddressRegistry is StdChains {
     using EnumerableSet for EnumerableSet.UintSet;
+    using stdToml for string;
 
     address private constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
     Vm private constant vm = Vm(VM_ADDRESS);
@@ -287,6 +289,11 @@ contract AddressRegistry is StdChains {
     /// @return An array of ChainInfo structs representing the supported chains
     function getChains() public view returns (ChainInfo[] memory) {
         return chains;
+    }
+
+    /// @notice reads a ChainInfo array from a toml file
+    function readChainsFromToml(string memory toml, string memory key) public view returns (ChainInfo[] memory) {
+        return abi.decode(vm.parseToml(vm.readFile(toml), key), (ChainInfo[]));
     }
 
     /// @notice Verifies that the given L2 chain ID is supported

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -35,6 +35,7 @@ contract TransferOwnerTemplate is L2TaskBase {
     function _templateSetup(string memory taskConfigFilePath) internal override {
         string memory toml = vm.readFile(taskConfigFilePath);
         newOwner = toml.readAddress(".newOwner");
+        
         // only allow one chain to be modified at a time with this 
         AddressRegistry.ChainInfo[] memory _chains = addrRegistry.readChainsFromToml(taskConfigFilePath, ".l2chains");
         require(_chains.length == 1, "Must specify exactly one chain id to transfer ownership for");

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -35,8 +35,8 @@ contract TransferOwnerTemplate is L2TaskBase {
     function _templateSetup(string memory taskConfigFilePath) internal override {
         string memory toml = vm.readFile(taskConfigFilePath);
         newOwner = toml.readAddress(".newOwner");
-        
-        // only allow one chain to be modified at a time with this 
+
+        // only allow one chain to be modified at a time with this
         AddressRegistry.ChainInfo[] memory _chains = addrRegistry.readChainsFromToml(taskConfigFilePath, ".l2chains");
         require(_chains.length == 1, "Must specify exactly one chain id to transfer ownership for");
     }

--- a/src/improvements/template/TransferOwnerTemplate.sol
+++ b/src/improvements/template/TransferOwnerTemplate.sol
@@ -36,9 +36,7 @@ contract TransferOwnerTemplate is L2TaskBase {
         string memory toml = vm.readFile(taskConfigFilePath);
         newOwner = toml.readAddress(".newOwner");
         // only allow one chain to be modified at a time with this 
-        // we can't use stdToml here because it doesn't support decoding structs
-        AddressRegistry.ChainInfo[] memory _chains =
-            abi.decode(vm.parseToml(vm.readFile(taskConfigFilePath), ".l2chains"), (AddressRegistry.ChainInfo[]));
+        AddressRegistry.ChainInfo[] memory _chains = addrRegistry.readChainsFromToml(taskConfigFilePath, ".l2chains");
         require(_chains.length == 1, "Must specify exactly one chain id to transfer ownership for");
     }
 


### PR DESCRIPTION
**Description**

There is a [suggestion](https://github.com/ethereum-optimism/superchain-ops/pull/595#discussion_r1955401835) from @mds1 about using `stdToml` instead of the more raw `parseToml` commands.

I took a stab at it. In the current repo, we would use `stdToml` exactly twice, because most of the time we are parsing structs that `stdToml` can't manage.

We could extract the struct-reading abi.decode command into its own function. Some of them would be reusable such as `AddressesRegistry.readChainsFromToml` in this PR. Most of them would be template-specific.

@mds1, worth it to fix the other templates in the same way as `TransferOwnerTemplate` here, or should we let it be?
