### PR TITLE
fix: _isValidAction bug - only record top level call access kind

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -876,7 +876,7 @@ abstract contract MultisigTask is Test, Script {
     function _isValidAction(VmSafe.AccountAccess memory access, uint256 topLevelDepth) internal view returns (bool) {
         bool accountNotRegistryOrVm = (access.account != address(addrRegistry) && access.account != address(vm));
         bool accessorNotRegistry = access.accessor != address(addrRegistry);
-        bool isCall = access.kind == VmSafe.AccountAccessKind.Call;
+        bool isCall = (access.kind == VmSafe.AccountAccessKind.Call && access.depth == topLevelDepth);
         bool isTopLevelDelegateCall =
             (access.kind == VmSafe.AccountAccessKind.DelegateCall && access.depth == topLevelDepth);
         bool accessorIsParent = (access.accessor == parentMultisig);


### PR DESCRIPTION
I encountered this issue when I was trying to make a delegatecall from within a `_build()` function in a template. If the delegatecall contains _calls_ inside the top level delegate call, then they incorrectly get added as a valid action. I do not believe this is intended behavior. 

Would be good to get @prat-gpt to review as I know you wrote this logic originally. 

I was wondering "why don't non-top level calls get included in valid actions right now?". I believe the reason they don't is because of the line `bool accessorIsParent = (access.accessor == parentMultisig);` in `_isValidAction`. 