### PR TITLE
fix: enable DelayedWeth owner verification in SignFromJson.s.sol

### DIFF
--- a/tasks/sep-dev-0/007-mt-cannon/SignFromJson.s.sol
+++ b/tasks/sep-dev-0/007-mt-cannon/SignFromJson.s.sol
@@ -153,8 +153,7 @@ contract NestedSignFromJson is OriginalSignFromJson {
         string memory errPrefix = string.concat("weth", gameStr, "-");
 
         console.log(string.concat("check IDelayedWETH implementation for GameType ", gameStr));
-        // TODO: Fix DelayedWeth owners which are currently misconfigured
-        // require(weth.owner() == proxyAdminOwnerSafe, string.concat(errPrefix, "100"));
+        require(weth.owner() == proxyAdminOwnerSafe, string.concat(errPrefix, "100"));
         require(weth.delay() == wethDelay, string.concat(errPrefix, "200"));
     }
     


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR fixes the DelayedWeth owner verification in the SignFromJson.s.sol file for the MT Cannon task. The verification was previously disabled with a TODO comment indicating that the DelayedWeth owners were misconfigured.

The change enables proper validation that the owner of DelayedWeth instances matches the expected proxyAdminOwnerSafe address during verification.

**Tests**

The change is in a validation script that runs assertions during deployment. The fix enables a previously disabled check, ensuring that the DelayedWeth contracts have the correct owner configuration.

No additional tests were added as the validation itself serves as a test during the deployment process.

**Additional context**

This addresses a TODO comment in the code that was explicitly marking the DelayedWeth owner verification as disabled due to misconfiguration. The fix assumes that the owners are now correctly configured and enables the verification check.

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->