### PR TITLE
Retrieve domain and message hashes from tenderly

### DIFF
--- a/src/improvements/script/get-tenderly-trace.sh
+++ b/src/improvements/script/get-tenderly-trace.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple script to get a Tenderly trace from a simulation payload
+# Usage: ./get-tenderly-trace.sh payload.json
+
+# Check if a payload file was provided
+if [ $# -lt 1 ]; then
+  echo "Error: Payload file is required"
+  echo "Usage: $0 <payload_file>"
+  exit 1
+fi
+
+PAYLOAD_FILE="$1"
+
+# Check if the payload file exists
+if [ ! -f "$PAYLOAD_FILE" ]; then
+  echo "Error: Payload file not found: $PAYLOAD_FILE"
+  exit 1
+fi
+
+# Check for required environment variables
+if [ -z "${TENDERLY_ACCESS_TOKEN:-}" ]; then
+  echo "Error: TENDERLY_ACCESS_TOKEN environment variable is required"
+  exit 1
+fi
+
+if [ -z "${TENDERLY_USER:-}" ]; then
+  echo "Error: TENDERLY_USER environment variable is required"
+  exit 1
+fi
+
+if [ -z "${TENDERLY_PROJECT_SLUG:-}" ]; then
+  echo "Error: TENDERLY_PROJECT_SLUG environment variable is required"
+  exit 1
+fi
+
+# Read the payload from file
+PAYLOAD=$(cat "$PAYLOAD_FILE")
+
+# Call Tenderly simulation API
+RESPONSE=$(curl -s -X POST \
+  -H "Content-Type: application/json" \
+  -H "X-Access-Key: $TENDERLY_ACCESS_TOKEN" \
+  -d "$PAYLOAD" \
+  "https://api.tenderly.co/api/v1/account/$TENDERLY_USER/project/$TENDERLY_PROJECT_SLUG/simulate")
+
+# Check if the response contains an error
+if echo "$RESPONSE" | jq -e '.error' >/dev/null 2>&1; then
+  echo "Error from Tenderly API: $(echo "$RESPONSE" | jq -r '.error')" >&2
+  exit 1
+fi
+
+# Extract and output the response
+echo "$RESPONSE" | jq -r '.simulation'
+
+# Extract the simulation ID from the response
+SIMULATION_ID=$(echo "$RESPONSE" | jq -r '.simulation.id')
+
+# Output the Tenderly dashboard URL
+echo "View the simulation in Tenderly dashboard:"
+echo "https://dashboard.tenderly.co/$TENDERLY_USER/$TENDERLY_PROJECT_SLUG/simulator/$SIMULATION_ID"
+echo ""
+
+# Retrieve the full simulation details
+echo "Retrieving full simulation details..."
+FULL_SIMULATION=$(curl -s -H "X-Access-Key: $TENDERLY_ACCESS_TOKEN" \
+  "https://api.tenderly.co/api/v1/account/$TENDERLY_USER/project/$TENDERLY_PROJECT_SLUG/simulations/$SIMULATION_ID")
+
+# Check if there was an error retrieving the simulation
+if echo "$FULL_SIMULATION" | jq -e '.error' >/dev/null 2>&1; then
+  echo "Error retrieving simulation details: $(echo "$FULL_SIMULATION" | jq -r '.error')" >&2
+  exit 1
+fi
+
+# Output the full simulation details
+echo "Full simulation details:"
+echo "$FULL_SIMULATION" | jq '.'
+echo ""

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -685,7 +685,7 @@ abstract contract MultisigTask is Test, Script {
         // Add each storage override
         for (uint j = 0; j < stateOverrides[0].overrides.length; j++) {
             string memory comma = j < stateOverrides[0].overrides.length - 1 ? "," : "";
-            console.log("\"0x%s\":\"0x%s\"%s",
+            console.log("\"%s\":\"%s\"%s",
                 vm.toString(bytes32(stateOverrides[0].overrides[j].key)),
                 vm.toString(stateOverrides[0].overrides[j].value),
                 comma

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -658,13 +658,43 @@ abstract contract MultisigTask is Test, Script {
 
     /// @notice print the tenderly simulation link with the state overrides
     function printTenderlySimulationLink(Action[] memory actions) internal view {
-        Simulation.StateOverride[] memory overrides = new Simulation.StateOverride[](1);
-        overrides[0] =
+        Simulation.StateOverride[] memory stateOverrides = new Simulation.StateOverride[](1);
+        stateOverrides[0] =
             Simulation.overrideSafeThresholdOwnerAndNonce(parentMultisig, msg.sender, _getNonce(parentMultisig));
         bytes memory txData = _execTransationCalldata(
             parentMultisig, getMulticall3Calldata(actions), Signatures.genPrevalidatedSignature(msg.sender)
         );
-        Simulation.logSimulationLink({_to: parentMultisig, _data: txData, _from: msg.sender, _overrides: overrides});
+        Simulation.logSimulationLink({_to: parentMultisig, _data: txData, _from: msg.sender, _overrides: stateOverrides});
+
+        // Log the simulation payload
+        console.log("\n\n------------------ Tenderly Simulation Payload ------------------");
+        
+        // Log the Tenderly JSON payload
+        string memory part1 = string.concat(
+            "{\"network_id\":\"", vm.toString(block.chainid),
+            "\",\"from\":\"", vm.toString(msg.sender),
+            "\",\"to\":\"", vm.toString(parentMultisig), "\""
+        );
+        string memory part2 = string.concat(
+            ",\"input\":\"", vm.toString(txData),
+            "\",\"value\":\"0x0\",\"state_objects\":{\"",
+            vm.toString(parentMultisig), "\":{\"storage\":{"
+        );
+        console.log("%s%s", part1, part2);
+        
+        // Add each storage override
+        for (uint j = 0; j < stateOverrides[0].overrides.length; j++) {
+            string memory comma = j < stateOverrides[0].overrides.length - 1 ? "," : "";
+            console.log("\"0x%s\":\"0x%s\"%s",
+                vm.toString(bytes32(stateOverrides[0].overrides[j].key)),
+                vm.toString(stateOverrides[0].overrides[j].value),
+                comma
+            );
+        }
+        
+        // Close the JSON structure
+        console.log("}}}}");
+        console.log("------------------ End of Payload ------------------");
     }
 
     /// @notice get the hash for this safe transaction


### PR DESCRIPTION
**Description**

#679 and #195 both depend on being able to retrieve the domain and message hash from a task execution simulated on tenderly.

This PR makes MultisigTask.sol output to console the json payload necessary to create a simulation on tenderly. We write the console output to a temporary file where it can be picked by a script that extracts the payload, creates the simulation, and extracts the domain and message hash.


