### PR TITLE
fix: Fix bash script output in verify-geth-endpoint.sh

### DIFF
--- a/ops/verify-geth-endpoint.sh
+++ b/ops/verify-geth-endpoint.sh
@@ -11,7 +11,7 @@ get_current_block() {
     echo "response: $response"
     hex=$(echo "$response" | jq -r '.result')
     trimmed_hex=${hex#0x}
-    echo $((16#$trimmed_hex))
+    echo "$((16#$trimmed_hex))"
 }
 
 # Check that the node is synced


### PR DESCRIPTION
## Description
This pull request fixes a potential issue in the verify-geth-endpoint.sh script by adding double quotes around the arithmetic expansion when outputting the block number. This change follows bash scripting best practices and prevents potential issues when handling special characters or spaces in variable values.
The specific change is in the get_current_block() function, where:
echo $((16#$trimmed_hex))
was changed to:
echo "$((16#$trimmed_hex))"
## Tests
The script functionality remains unchanged, but is now more robust. The script was manually tested to ensure it continues to work as expected with the added quotes.
## Additional context
This is a minor fix that follows shell scripting best practices. While the specific issue might not manifest in this particular case (as arithmetic expansions typically don't contain spaces), it's good practice to quote variable expansions in bash to prevent word splitting and globbing.
## Metadata
Fixes #N/A (No specific issue was referenced for this change)