### PR TITLE
Fix: Block number Returned is Not Integer. 

### DIFF
--- a/ops/verify-geth-endpoint.sh
+++ b/ops/verify-geth-endpoint.sh
@@ -8,7 +8,8 @@ get_current_block() {
     data='{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
     # shellcheck disable=SC2086
     response=$(curl -s -X POST -H "Content-Type: application/json" --data "$data" $URL)
-    echo "response: $response"
+    echo "response: $response" >&2 # Display the response in the logs
+
     hex=$(echo "$response" | jq -r '.result')
     trimmed_hex=${hex#0x}
     echo $((16#$trimmed_hex))


### PR DESCRIPTION
This PR fix an minor issue that has been introduced two year ago that making the node always returning healthy even if it's not healthy. 

Now instead of returning the full JSON we only return the _block number_. 

![6fbe3625847f7028025010c5c8e9342ff9b75f6dc64fcf178dfe7b525d5b30df](https://github.com/user-attachments/assets/ea3ce82b-80bc-463a-a7bd-476d5f30a3df)


**tests** 
I tested this inside `anvil` to make sure this is expected. 
```bash
$ ./ops/verify-geth-endpoint.sh http://localhost:8545
response: {"jsonrpc":"2.0","id":1,"result":false}
Replica is not syncing.
response: {"jsonrpc":"2.0","id":1,"result":"0x0"}
block: 0
Block height is 0.
```
