### PR TITLE
Implement sortAccountAccesses function using LibSort

### DIFF
--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -200,6 +200,7 @@ library AccountAccessParser {
             }
         }
 
+        // Sort the account accesses and return the sorted array
         _accountAccesses = sortAccountAccesses(_accountAccesses);
     }
 
@@ -720,10 +721,10 @@ library AccountAccessParser {
         return (0, "");
     }
 
-    /// @notice Sorts an array of AccountAccess structs in place by account address.
+    /// @notice Sorts an array of AccountAccess structs by account address and returns a new sorted array.
     function sortAccountAccesses(VmSafe.AccountAccess[] memory _accountAccesses)
         internal
-        view
+        pure
         returns (VmSafe.AccountAccess[] memory sorted_)
     {
         // If array is empty or has only one element, it's already sorted
@@ -744,14 +745,12 @@ library AccountAccessParser {
         // Sort addresses and track index changes
         _sortWithIndices(addresses, indices);
 
-        // Create the sorted result array
+        // Create a new array for the sorted result
         sorted_ = new VmSafe.AccountAccess[](_accountAccesses.length);
 
-        // Reconstruct the sorted array using the sorted indices
+        // Fill the sorted array using the sorted indices
         for (uint256 i = 0; i < _accountAccesses.length; i++) {
             sorted_[i] = _accountAccesses[indices[i]];
-            console.log(sorted_[i].account);
-            console.log(indices[i]);
         }
     }
 

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -6,6 +6,7 @@ import {console} from "forge-std/console.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {LibString} from "@solady/utils/LibString.sol";
+import {LibSort} from "@solady/utils/LibSort.sol";
 
 /// @notice Parses account accesses into decoded transfers and state diffs.
 /// The core methods intended to be part of the public interface are `decodeAndPrint`, `decode`,
@@ -198,6 +199,8 @@ library AccountAccessParser {
                 index++;
             }
         }
+
+        _accountAccesses = sortAccountAccesses(_accountAccesses);
     }
 
     function getNewContracts(VmSafe.AccountAccess[] memory accesses)
@@ -715,6 +718,68 @@ library AccountAccessParser {
 
         console.log("\x1B[33m[WARN]\x1B[0m Target address not found: %s", vm.toString(target));
         return (0, "");
+    }
+
+    /// @notice Sorts an array of AccountAccess structs in place by account address.
+    function sortAccountAccesses(VmSafe.AccountAccess[] memory _accountAccesses)
+        internal
+        view
+        returns (VmSafe.AccountAccess[] memory sorted_)
+    {
+        // If array is empty or has only one element, it's already sorted
+        if (_accountAccesses.length <= 1) {
+            return _accountAccesses;
+        }
+
+        // Create a mapping structure to track original indices
+        address[] memory addresses = new address[](_accountAccesses.length);
+        uint256[] memory indices = new uint256[](_accountAccesses.length);
+
+        // Fill the arrays
+        for (uint256 i = 0; i < _accountAccesses.length; i++) {
+            addresses[i] = _accountAccesses[i].account;
+            indices[i] = i;
+        }
+
+        // Sort addresses and track index changes
+        _sortWithIndices(addresses, indices);
+
+        // Create the sorted result array
+        sorted_ = new VmSafe.AccountAccess[](_accountAccesses.length);
+
+        // Reconstruct the sorted array using the sorted indices
+        for (uint256 i = 0; i < _accountAccesses.length; i++) {
+            sorted_[i] = _accountAccesses[indices[i]];
+            console.log(sorted_[i].account);
+            console.log(indices[i]);
+        }
+    }
+
+    /// @dev Helper function to sort addresses while keeping track of their original indices
+    function _sortWithIndices(address[] memory addresses, uint256[] memory indices) internal pure {
+        uint256 n = addresses.length;
+
+        // Create a temporary array of structs to hold address and index pairs
+        uint256[] memory pairs = new uint256[](n);
+
+        // Pack each address (20 bytes) with its index (max 12 bytes) into a single uint256
+        // This allows us to sort a single array and keep track of the indices
+        for (uint256 i = 0; i < n; i++) {
+            // Pack address and index into a single uint256
+            // Address in the higher bits, index in the lower bits
+            pairs[i] = (uint256(uint160(addresses[i])) << 96) | indices[i];
+        }
+
+        // Sort the pairs using LibSort
+        LibSort.sort(pairs);
+
+        // Unpack the sorted pairs back into the separate arrays
+        for (uint256 i = 0; i < n; i++) {
+            // Extract address from higher bits
+            addresses[i] = address(uint160(pairs[i] >> 96));
+            // Extract index from lower bits (mask with 2^96 - 1 to get only the lower 96 bits)
+            indices[i] = pairs[i] & ((1 << 96) - 1);
+        }
     }
 
     /// @notice Probabilistically check if an address is a GnosisSafe.

--- a/test/libraries/AccountAccessParser.t.sol
+++ b/test/libraries/AccountAccessParser.t.sol
@@ -497,6 +497,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
 
             assertEq(transfers.length, 0, "10");
             assertEq(diffs.length, 0, "20");
+
+            _assertAscending(accesses);
         }
 
         // Test ETH transfer only
@@ -517,6 +519,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
             assertEq(transfers[0].value, 100, "60");
             assertEq(transfers[0].tokenAddress, AccountAccessParser.ETHER, "70");
             assertEq(diffs.length, 0, "80");
+
+            _assertAscending(accesses);
         }
 
         // Test reverted ETH transfer (should be excluded)
@@ -534,6 +538,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
 
             assertEq(transfers.length, 0, "90");
             assertEq(diffs.length, 0, "100");
+
+            _assertAscending(accesses);
         }
 
         // Test ERC20 transfer only
@@ -554,6 +560,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
             assertEq(transfers[0].value, 100, "140");
             assertEq(transfers[0].tokenAddress, addr1, "150");
             assertEq(diffs.length, 0, "160");
+
+            _assertAscending(accesses);
         }
 
         // Test reverted ERC20 transfer (should be excluded)
@@ -571,6 +579,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
 
             assertEq(transfers.length, 0, "170");
             assertEq(diffs.length, 0, "180");
+
+            _assertAscending(accesses);
         }
 
         // Test state diffs only
@@ -592,6 +602,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
             assertEq(diffs[0].raw.slot, AccountAccessParser.GUARDIAN_SLOT, "220");
             assertEq(diffs[0].raw.oldValue, val0, "230");
             assertEq(diffs[0].raw.newValue, val2, "240");
+
+            _assertAscending(accesses);
         }
 
         // Test reverted state diffs (should be excluded)
@@ -610,6 +622,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
 
             assertEq(transfers.length, 0, "250");
             assertEq(diffs.length, 0, "260");
+
+            _assertAscending(accesses);
         }
 
         // Test combination of transfers and state diffs
@@ -646,6 +660,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
             assertEq(diffs[0].raw.slot, AccountAccessParser.PAUSED_SLOT, "360");
             assertEq(diffs[0].raw.oldValue, val0, "370");
             assertEq(diffs[0].raw.newValue, val1, "380");
+
+            _assertAscending(accesses);
         }
 
         // Test combination of reverted and non-reverted operations
@@ -673,6 +689,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
             assertEq(diffs.length, 1, "420");
             assertEq(diffs[0].raw.oldValue, val0, "430");
             assertEq(diffs[0].raw.newValue, val1, "440");
+
+            _assertAscending(accesses);
         }
 
         // Test state changes that revert back to original (should not appear in diffs)
@@ -691,6 +709,8 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
 
             assertEq(transfers.length, 0, "450");
             assertEq(diffs.length, 0, "460");
+
+            _assertAscending(accesses);
         }
 
         // Test multiple accounts with state changes
@@ -720,6 +740,21 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
             assertEq(diffs[1].raw.slot, AccountAccessParser.GUARDIAN_SLOT, "540");
             assertEq(diffs[1].raw.oldValue, val0, "550");
             assertEq(diffs[1].raw.newValue, val3, "560");
+
+            _assertAscending(accesses);
+        }
+    }
+
+    function _assertAscending(VmSafe.AccountAccess[] memory _accesses) internal pure {
+        if (_accesses.length == 0) {
+            return;
+        }
+        for (uint256 i = 0; i < _accesses.length - 1; i++) {
+            assertLt(
+                uint256(uint160(_accesses[i].account)),
+                uint256(uint160(_accesses[i + 1].account)),
+                "Accesses are not in ascending order"
+            );
         }
     }
 


### PR DESCRIPTION
This PR implements the sortAccountAccesses function in the AccountAccessParser library using LibSort. The function sorts an array of AccountAccess structs by their account address and returns a new sorted array.