### PR TITLE
replace deprecated forge vm cheatcodes revertTo and snapshot

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -867,7 +867,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     function _startBuild() private {
         vm.startPrank(parentMultisig);
 
-        _startSnapshot = vm.snapshot();
+        _startSnapshot = vm.snapshotState();
 
         vm.startStateDiffRecording();
     }
@@ -882,7 +882,8 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
 
         // Roll back state changes.
         require(
-            vm.revertTo(_startSnapshot), "MultisigTask: failed to revert back to snapshot, unsafe state to run task"
+            vm.revertToState(_startSnapshot),
+            "MultisigTask: failed to revert back to snapshot, unsafe state to run task"
         );
         require(accesses.length > 0, "MultisigTask: no account accesses found");
 

--- a/test/tasks/NestedMultisigTask.t.sol
+++ b/test/tasks/NestedMultisigTask.t.sol
@@ -134,7 +134,7 @@ contract NestedMultisigTaskTest is Test {
     /// is correct for MultisigTask
     function testNestedExecuteWithSignatures() public {
         vm.createSelectFork("mainnet");
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
         (VmSafe.AccountAccess[] memory accountAccesses, MultisigTask.Action[] memory actions) = runTask();
         address parentMultisig = multisigTask.parentMultisig();
         address[] memory parentMultisigOwners = IGnosisSafe(parentMultisig).getOwners();
@@ -148,7 +148,7 @@ contract NestedMultisigTaskTest is Test {
             IDisputeGameFactory(superchainAddrRegistry.getAddress("DisputeGameFactoryProxy", 10));
 
         // revert to snapshot so that the safe is in the same state as before the task was run
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         MultiSigOwner[] memory newOwners = new MultiSigOwner[](9);
         (newOwners[0].walletAddress, newOwners[0].privateKey) = makeAddrAndKey("Owner0");
@@ -217,7 +217,7 @@ contract NestedMultisigTaskTest is Test {
         multisigTask = new DisputeGameUpgradeTemplate();
 
         /// snapshot before running the task so we can roll back to this pre-state
-        uint256 newSnapshot = vm.snapshot();
+        uint256 newSnapshot = vm.snapshotState();
 
         (accountAccesses, actions) = multisigTask.simulateRun(taskConfigFilePath);
 
@@ -232,7 +232,7 @@ contract NestedMultisigTaskTest is Test {
         bytes32 taskHash = multisigTask.getHash(callData, parentMultisig);
 
         /// now run the executeRun flow
-        vm.revertTo(newSnapshot);
+        vm.revertToState(newSnapshot);
         multisigTask.executeRun(taskConfigFilePath, prepareSignatures(parentMultisig, taskHash));
         addrRegistry = multisigTask.addrRegistry();
 
@@ -248,7 +248,7 @@ contract NestedMultisigTaskTest is Test {
     /// is correct for OPCMBaseTask. This test uses the OPCMUpgradeV200 template as a way to test OPCMBaseTask.
     function testNestedExecuteWithSignaturesOPCM() public {
         vm.createSelectFork("sepolia");
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
         multisigTask = new OPCMUpgradeV200();
         string memory opcmTaskConfigFilePath = "test/tasks/example/sep/002-opcm-upgrade-v200/config.toml";
         (VmSafe.AccountAccess[] memory accountAccesses, MultisigTask.Action[] memory actions) =
@@ -262,7 +262,7 @@ contract NestedMultisigTaskTest is Test {
             childMultisigDatasToSign[i] = getNestedDataToSign(parentMultisigOwners[i], actions);
         }
         // Revert to snapshot so that the safe is in the same state as before the task was run
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         MultiSigOwner[] memory newOwners = new MultiSigOwner[](9);
         (newOwners[0].walletAddress, newOwners[0].privateKey) = makeAddrAndKey("Owner0");
@@ -330,13 +330,13 @@ contract NestedMultisigTaskTest is Test {
         multisigTask = new OPCMUpgradeV200();
 
         // Snapshot before running the task so we can roll back to this pre-state
-        uint256 newSnapshot = vm.snapshot();
+        uint256 newSnapshot = vm.snapshotState();
 
         (accountAccesses, actions) = multisigTask.simulateRun(opcmTaskConfigFilePath);
         bytes32 taskHash =
             multisigTask.getHash(multisigTask.getMulticall3Calldata(actions), multisigTask.parentMultisig());
 
-        vm.revertTo(newSnapshot);
+        vm.revertToState(newSnapshot);
         multisigTask.executeRun(opcmTaskConfigFilePath, prepareSignatures(parentMultisig, taskHash));
     }
 

--- a/test/tasks/SingleMultisigTask.t.sol
+++ b/test/tasks/SingleMultisigTask.t.sol
@@ -264,14 +264,14 @@ contract SingleMultisigTaskTest is Test {
         string memory opcmTaskConfigFilePath = "test/tasks/mock/configs/MockDisputeGameUpgradesToEOA.toml";
         multisigTask = new DisputeGameUpgradeTemplate();
 
-        uint256 start = vm.snapshot();
+        uint256 start = vm.snapshotState();
 
         multisigTask.simulateRun("test/tasks/mock/configs/DisputeGameUpgradeCodeException.toml");
         addrRegistry = multisigTask.addrRegistry();
         address account =
             toSuperchainAddrRegistry(addrRegistry).getAddress("DisputeGameFactoryProxy", getChain("optimism").chainId);
 
-        vm.revertTo(start);
+        vm.revertToState(start);
 
         string memory err = string.concat(
             "Likely address in storage has no code\n",
@@ -287,7 +287,7 @@ contract SingleMultisigTaskTest is Test {
     }
 
     function testExecuteWithSignatures() public {
-        uint256 snapshotId = vm.snapshot();
+        uint256 snapshotId = vm.snapshotState();
         (, MultisigTask.Action[] memory actions) = runTask();
         addrRegistry = multisigTask.addrRegistry();
         multisigTask.processTaskActions(actions);
@@ -297,7 +297,7 @@ contract SingleMultisigTaskTest is Test {
         address systemConfigMode = toSuperchainAddrRegistry(addrRegistry).getAddress("SystemConfigProxy", 34443);
         address systemConfigMetal = toSuperchainAddrRegistry(addrRegistry).getAddress("SystemConfigProxy", 1750);
         // revert to snapshot so that the safe is in the same state as before the task was run
-        vm.revertTo(snapshotId);
+        vm.revertToState(snapshotId);
 
         MultiSigOwner[] memory newOwners = new MultiSigOwner[](9);
         (newOwners[0].walletAddress, newOwners[0].privateKey) = makeAddrAndKey("Owner0");


### PR DESCRIPTION
When we run `forge test` foundry prints a warning stating 

```
Warning: the following cheatcode(s) are deprecated and will be removed in future versions:
  revertTo(uint256): replaced by `revertToState`
  snapshot(): replaced by `snapshotState`
```

This pr replaces the occurrences of the deprecated cheatcodes with the recommended ones.