### PR TITLE
fix: Fixing flaky security council ci tasks.

### DIFF
--- a/security-council-rehearsals/2024-01-22-r2-remove-signer-0122/justfile
+++ b/security-council-rehearsals/2024-01-22-r2-remove-signer-0122/justfile
@@ -23,11 +23,9 @@ simulate hdPath='0':
     export ETH_RPC_URL
   fi
 
-  echo "Simulating with: ${signer}"
-  echo ""
   forge build
   forge script SignFromJson \
-    --rpc-url ${rpcUrl} \
+    --rpc-url ${ETH_RPC_URL} \
     --sig "signJson(string)" \
     "${location}/${bundle}.json" \
     --sender ${signer}

--- a/security-council-rehearsals/templates/r2-remove-signer/justfile
+++ b/security-council-rehearsals/templates/r2-remove-signer/justfile
@@ -26,7 +26,7 @@ simulate hdPath='0':
 
   forge build
   forge script ./SignFromJson.s.sol:SignFromJson \
-    --rpc-url ${rpcUrl} \
+    --rpc-url ${ETH_RPC_URL} \
     --sig "signJson(string)" \
     "${location}/${bundle}.json" \
     --sender ${signer}

--- a/security-council-rehearsals/templates/r4-jointly-upgrade/justfile
+++ b/security-council-rehearsals/templates/r4-jointly-upgrade/justfile
@@ -19,6 +19,13 @@ simulate-council hdPath='0':
   fi
   echo "Simulating with: ${signer}"
   echo ""
+
+  root_dir=$(git rev-parse --show-toplevel)
+  if [ "${FOUNDRY_PROFILE}" == "ci" ]; then
+    ETH_RPC_URL=$(yq eval ".profile.ci.rpc_endpoints.mainnet" "${root_dir}/foundry.toml")
+    export ETH_RPC_URL
+  fi
+
   forge build
   forge script ./NestedSignFromJson.s.sol:NestedSignFromJson \
     --rpc-url ${ETH_RPC_URL} \

--- a/security-council-rehearsals/templates/r4-jointly-upgrade/justfile
+++ b/security-council-rehearsals/templates/r4-jointly-upgrade/justfile
@@ -21,7 +21,7 @@ simulate-council hdPath='0':
   echo ""
   forge build
   forge script ./NestedSignFromJson.s.sol:NestedSignFromJson \
-    --rpc-url ${rpcUrl} \
+    --rpc-url ${ETH_RPC_URL} \
     --sender ${signer} \
     --sig "signJson(string,address)" \
     "${location}/${bundle}.json" \


### PR DESCRIPTION
As per discussions in Discord, we're hitting some flaky security council CI tasks. https://discord.com/channels/1244729134312198194/1342572064175030293/1349368472676733050

This allows the tasks to use the foundry.toml rpc url defined for CI. 