### PR TITLE
refactor: execTransaction not using try/catch + allowing specific gas limits to be passed

### DIFF
--- a/src/improvements/nested.just
+++ b/src/improvements/nested.just
@@ -14,6 +14,7 @@ cmd := "yq '.templateName' " + TASK_PATH + "/config.toml"
 export SCRIPT_NAME := shell(cmd)
 export signatures := env_var_or_default('SIGNATURES', '')
 export randomPersonEoa := "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+export forkBlockNumber := env_var_or_default('FORK_BLOCK_NUMBER', '-1')
 
 simulate whichSafe hdPath='0':
   #!/usr/bin/env bash
@@ -21,6 +22,7 @@ simulate whichSafe hdPath='0':
   safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} ${SCRIPT_PATH} "{{whichSafe}}")
 
   echo "RPC URL: ${rpcUrl}"
+  echo ""
 
   config=${TASK_PATH}/config.toml
   script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
@@ -39,8 +41,18 @@ simulate whichSafe hdPath='0':
   fi
   echo ""
 
+  # Allow simulating from a specific block by setting FORK_BLOCK_NUMBER in the task's .env file.
+  # If not set (or set to -1), default to using the latest block.
+  if [ "${forkBlockNumber}" = "-1" ]; then
+    fork_block_arg=""
+  else
+    echo "Using fork block number from env: ${forkBlockNumber}"
+    fork_block_arg="--fork-block-number ${forkBlockNumber}"
+  fi
+
   forge build
   forge script ${script} \
+    ${fork_block_arg} \
     --rpc-url ${rpcUrl} \
     --sender ${signer} \
     --sig "signFromChildMultisig(string,address)" \

--- a/src/improvements/nested.just
+++ b/src/improvements/nested.just
@@ -22,7 +22,6 @@ simulate whichSafe hdPath='0':
   safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} ${SCRIPT_PATH} "{{whichSafe}}")
 
   echo "RPC URL: ${rpcUrl}"
-  echo ""
 
   config=${TASK_PATH}/config.toml
   script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol

--- a/src/improvements/single.just
+++ b/src/improvements/single.just
@@ -13,6 +13,7 @@ export rpcUrl := shell(rpc_cmd)
 cmd := "yq '.templateName' " + TASK_PATH + "/config.toml"
 export SCRIPT_NAME := shell(cmd)
 export signatures := env_var_or_default('SIGNATURES', '')
+export forkBlockNumber := env_var_or_default('FORK_BLOCK_NUMBER', '-1')
 
 simulate hdPath='0':
   #!/usr/bin/env bash
@@ -25,8 +26,18 @@ simulate hdPath='0':
   echo "Using script ${script}"
   echo ""
 
+  # Allow simulating from a specific block by setting FORK_BLOCK_NUMBER in the task's .env file.
+  # If not set (or set to -1), default to using the latest block.
+  if [ "${forkBlockNumber}" = "-1" ]; then
+    fork_block_arg=""
+  else
+    echo "Using fork block number from env: ${forkBlockNumber}"
+    fork_block_arg="--fork-block-number ${forkBlockNumber}"
+  fi
+
   forge build
   forge script ${script} \
+    ${fork_block_arg} \
     --rpc-url ${rpcUrl} \
     --sig "simulateRun(string)" ${config}
 

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -444,13 +444,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         return vm.isContext(VmSafe.ForgeContext.ScriptBroadcast) || vm.isContext(VmSafe.ForgeContext.ScriptResume);
     }
 
-    /// @notice executes a transaction to the target multisig
-    /// @param multisig to execute the transaction from
-    /// @param target to call when executing the transaction
-    /// @param value amount of value to send from the safe
-    /// @param data calldata to send from the safe
-    /// @param operationType type of operation to execute
-    /// @param signatures for the safe transaction
+    /// @notice Executes a transaction to the target multisig.
     function execTransaction(
         address multisig,
         address target,
@@ -481,6 +475,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         // Otherwise, default to the remaining gas. This helps surface out-of-gas errors earlier,
         // before they would show up in Tenderly's simulation results.
         uint256 gas = vm.envOr("TENDERLY_GAS", gasleft());
+        console.log("Passing %s gas to execTransaction (from env or gasleft)", gas);
         (bool success, bytes memory returnData) = multisig.call{gas: gas}(callData);
 
         if (!success) {

--- a/test/tasks/NestedMultisigTask.t.sol
+++ b/test/tasks/NestedMultisigTask.t.sol
@@ -263,7 +263,7 @@ contract NestedMultisigTaskTest is Test {
     /// is correct for OPCMBaseTask. This test uses the OPCMUpgradeV200 template as a way to test OPCMBaseTask.
     function testNestedExecuteWithSignaturesOPCM() public {
         address foundationChildMultisig = 0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B;
-        // In block 7972617, and upgrade occurred at: https://sepolia.etherscan.io/tx/0x12b76ef5c31145a3bf6bb71b9c3c7ddd3cd7f182011187353e3ceb1830891fb7
+        // In block 7972617, an upgrade occurred at: https://sepolia.etherscan.io/tx/0x12b76ef5c31145a3bf6bb71b9c3c7ddd3cd7f182011187353e3ceb1830891fb7
         // Which meant this test failed. We're forking at the block before to continue to test this.
         vm.createSelectFork("sepolia", 7972616);
         uint256 snapshotId = vm.snapshotState();

--- a/test/tasks/NestedMultisigTask.t.sol
+++ b/test/tasks/NestedMultisigTask.t.sol
@@ -259,11 +259,13 @@ contract NestedMultisigTaskTest is Test {
         );
     }
 
-    /// @notice Test that the data to sign generated in simulateRun for the child multisigs
+    /// @notice Test that the 'data to sign' generated in simulateRun for the child multisigs
     /// is correct for OPCMBaseTask. This test uses the OPCMUpgradeV200 template as a way to test OPCMBaseTask.
     function testNestedExecuteWithSignaturesOPCM() public {
-        address foundationChildMultisig = 0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B; // sepolia
-        vm.createSelectFork("sepolia");
+        address foundationChildMultisig = 0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B;
+        // In block 7972617, and upgrade occurred at: https://sepolia.etherscan.io/tx/0x12b76ef5c31145a3bf6bb71b9c3c7ddd3cd7f182011187353e3ceb1830891fb7
+        // Which meant this test failed. We're forking at the block before to continue to test this.
+        vm.createSelectFork("sepolia", 7972616);
         uint256 snapshotId = vm.snapshotState();
         multisigTask = new OPCMUpgradeV200();
         string memory opcmTaskConfigFilePath = "test/tasks/example/sep/002-opcm-upgrade-v200/config.toml";

--- a/test/tasks/example/sep/002-opcm-upgrade-v200/.env
+++ b/test/tasks/example/sep/002-opcm-upgrade-v200/.env
@@ -1,1 +1,4 @@
 TENDERLY_GAS=15000000
+# In block 7972617, an upgrade occurred at: https://sepolia.etherscan.io/tx/0x12b76ef5c31145a3bf6bb71b9c3c7ddd3cd7f182011187353e3ceb1830891fb7
+# Which meant this task failed. We're forking at the block before to continue to test this.
+FORK_BLOCK_NUMBER=7972616


### PR DESCRIPTION
Opting to not use a try catch block when invoking execTransaction on the safe. This means we can simplify the code and also pass through custom gas parameters. 

The new code allows Tenderly gas configuration to be passed through if it's given. 