### PR TITLE
Bump to eip712sign v0.0.11

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ install-eip712sign:
   PATH="$REPO_ROOT/bin:$PATH"
   cd $REPO_ROOT
   mkdir -p bin || true
-  GOBIN="$REPO_ROOT/bin" go install github.com/base-org/eip712sign@v0.0.10
+  GOBIN="$REPO_ROOT/bin" go install github.com/base/eip712sign@v0.0.11
 
 # Bundle path should be provided including the .json file extension.
 add-transaction bundlePath to sig *params:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Bumps the eip712sign version to the latest version (`v0.0.11`), which upgrades the go-ethereum version to `v1.15.6`.

**Tests**

No tests added, just a dep bump.

**Additional context**

An attempt to solve for #375.