### PR TITLE
refactor: single simulation should give the option to change the from…

### DIFF
--- a/src/improvements/single.just
+++ b/src/improvements/single.just
@@ -15,16 +15,33 @@ export SCRIPT_NAME := shell(cmd)
 export signatures := env_var_or_default('SIGNATURES', '')
 export forkBlockNumber := env_var_or_default('FORK_BLOCK_NUMBER', '-1')
 
-simulate hdPath='0':
+# 'senderAddress' is the address you want to run this simulation as.
+# The 'senderAddress' will be the 'from' field in the Tenderly simulation. 
+simulate senderAddress="" hdPath='0':
   #!/usr/bin/env bash
 
   config=${TASK_PATH}/config.toml
   script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
 
   echo "RPC URL: ${rpcUrl}"
-
   echo "Using script ${script}"
-  echo ""
+
+  echo "Setting sender address..."
+  # Default fallback sender: address(uint160(uint256(keccak256("foundry default caller"))))
+  default_sender=0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38
+
+  if [ -z "$SIMULATE_WITHOUT_LEDGER" ]; then
+    sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Simulating with ledger account: ${sender}"
+  else 
+    if [ -n "{{senderAddress}}" ]; then
+      sender="{{senderAddress}}"
+      echo "Using 'senderAddress' as sender: ${sender}"
+    else
+      sender=$default_sender
+      echo "Using default sender: ${sender}"
+    fi
+  fi
 
   # Allow simulating from a specific block by setting FORK_BLOCK_NUMBER in the task's .env file.
   # If not set (or set to -1), default to using the latest block.
@@ -39,6 +56,7 @@ simulate hdPath='0':
   forge script ${script} \
     ${fork_block_arg} \
     --rpc-url ${rpcUrl} \
+    --sender ${sender} \
     --sig "simulateRun(string)" ${config}
 
 sign hdPath='0':


### PR DESCRIPTION
Alternative to this [PR](https://github.com/ethereum-optimism/superchain-ops/pull/799/files). We should allow users the ability to change the from address in the Tenderly simulation link. 