### PR TITLE
Fix Sepolia 001-opcm-upgrade-v200

### DIFF
--- a/src/improvements/nested.just
+++ b/src/improvements/nested.just
@@ -61,7 +61,8 @@ simulate whichSafe hdPath='0':
 sign whichSafe hdPath='0':
   #!/usr/bin/env bash
   # Get the appropriate safe address based on whichSafe
-  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} ${SCRIPT_PATH} "{{whichSafe}}")
+  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} "{{whichSafe}}")
+
 
   config=${TASK_PATH}/config.toml
   script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
@@ -82,7 +83,7 @@ sign whichSafe hdPath='0':
 approve whichSafe hdPath='0':
   #!/usr/bin/env bash
   # Get the appropriate safe address based on whichSafe
-  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} ${SCRIPT_PATH} "{{whichSafe}}")
+  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} "{{whichSafe}}")
 
   config=${TASK_PATH}/config.toml
   script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
@@ -102,7 +103,7 @@ approve whichSafe hdPath='0':
 simulate-approve whichSafe hdPath='0':
   #!/usr/bin/env bash
   # Get the appropriate safe address based on whichSafe
-  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} ${SCRIPT_PATH} "{{whichSafe}}")
+  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} "{{whichSafe}}")
 
   config=${TASK_PATH}/config.toml
   script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol

--- a/src/improvements/tasks/sep/001-opcm-upgrade-v200/VALIDATION.md
+++ b/src/improvements/tasks/sep/001-opcm-upgrade-v200/VALIDATION.md
@@ -21,12 +21,12 @@ the values printed to the terminal when you run the task.
 > ### Child Safe 1: `0x6AF0674791925f767060Dd52f7fB20984E8639d8`
 >
 > - Domain Hash: `0x6f25427e79742a1eb82c103e2bf43c85fc59509274ec258ad6ed841c4a0048aa`
-> - Message Hash: `0x6e4bcbb8105ec2efa8a58c66289071ddb349610f32570b7f72fb047f577c4f82`
+> - Message Hash: `0xbdd593a729dadfa12c86ebac23914145d1ae0418ef1909ffecf78882d6720212`
 >
 > ### Child Safe 2: `0x646132A1667ca7aD00d36616AFBA1A28116C770A`
 >
 > - Domain Hash: `0x1d3f2566fd7b1bf017258b03d4d4d435d326d9cb051d5b7993d7c65e7ec78d0e`
-> - Message Hash: `0x6e4bcbb8105ec2efa8a58c66289071ddb349610f32570b7f72fb047f577c4f82`
+> - Message Hash: `0xbdd593a729dadfa12c86ebac23914145d1ae0418ef1909ffecf78882d6720212`
 
 
 ## Understanding Task Calldata


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

This PR fixes 2 things related to the Base Sepolia 001-opcm-upgrade-v200 task:
1. The `nested.just` file was calling the `get-safe.sh` bash script with the incorrect number of parameters.
2. The expected message hash in the `VALIDATION.md` was not correct and has been replaced with `0xbdd593a729dadfa12c86ebac23914145d1ae0418ef1909ffecf78882d6720212`