### PR TITLE
fix: reduce forge test flakiness from vm.removeFile.

### DIFF
--- a/test/tasks/MultisigTask.t.sol
+++ b/test/tasks/MultisigTask.t.sol
@@ -56,7 +56,7 @@ contract MultisigTaskUnitTest is Test {
         string memory fileName = createTempTomlFile(commonToml);
         // Instantiate the SuperchainAddressRegistry contract
         addrRegistry = new SuperchainAddressRegistry(fileName);
-        vm.removeFile(fileName);
+        removeFile(fileName);
 
         // Instantiate the Mock MultisigTask contract
         task = MultisigTask(new MockMultisigTask());
@@ -218,7 +218,7 @@ contract MultisigTaskUnitTest is Test {
         string memory fileName = createTempTomlFile(commonToml);
         (VmSafe.AccountAccess[] memory accountAccesses, MultisigTask.Action[] memory actions) =
             runTestSimulation(fileName, securityCouncilChildMultisig);
-        vm.removeFile(fileName);
+        removeFile(fileName);
 
         vm.expectRevert("MultisigTask: execute failed");
         task.simulate("", actions);
@@ -230,7 +230,7 @@ contract MultisigTaskUnitTest is Test {
     function testGetCalldata() public {
         string memory fileName = createTempTomlFile(commonToml);
         (, MultisigTask.Action[] memory actions) = runTestSimulation(fileName, securityCouncilChildMultisig);
-        vm.removeFile(fileName);
+        removeFile(fileName);
 
         (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) = task.processTaskActions(actions);
 
@@ -275,5 +275,11 @@ contract MultisigTaskUnitTest is Test {
         string memory fileName = string.concat(randomBytes, ".toml");
         vm.writeFile(fileName, tomlContent);
         return fileName;
+    }
+
+    /// @notice This function is used to remove a file. The reason we use a try catch
+    /// is because sometimes the file may not exist and this leads to flaky tests.
+    function removeFile(string memory fileName) internal {
+        try vm.removeFile(fileName) {} catch {}
     }
 }

--- a/test/tasks/NestedMultisigTask.t.sol
+++ b/test/tasks/NestedMultisigTask.t.sol
@@ -48,7 +48,7 @@ contract NestedMultisigTaskTest is Test {
         multisigTask = new DisputeGameUpgradeTemplate();
         string memory configFilePath = createTempTomlFile(taskConfigToml);
         (accountAccesses, actions) = multisigTask.signFromChildMultisig(configFilePath, childMultisig);
-        vm.removeFile(configFilePath);
+        removeFile(configFilePath);
         addrRegistry = multisigTask.addrRegistry();
         superchainAddrRegistry = SuperchainAddressRegistry(AddressRegistry.unwrap(addrRegistry));
     }
@@ -221,7 +221,7 @@ contract NestedMultisigTaskTest is Test {
             multisigTask = new DisputeGameUpgradeTemplate();
             string memory configFilePath = createTempTomlFile(taskConfigToml);
             multisigTask.approveFromChildMultisig(configFilePath, childMultisig, packedSignaturesChild);
-            vm.removeFile(configFilePath);
+            removeFile(configFilePath);
         }
 
         // execute the task
@@ -232,7 +232,7 @@ contract NestedMultisigTaskTest is Test {
 
         string memory config = createTempTomlFile(taskConfigToml);
         (accountAccesses, actions) = multisigTask.signFromChildMultisig(config, SECURITY_COUNCIL_CHILD_MULTISIG);
-        vm.removeFile(config);
+        removeFile(config);
 
         // Check that the implementation is upgraded correctly
         assertEq(
@@ -248,7 +248,7 @@ contract NestedMultisigTaskTest is Test {
         vm.revertToState(newSnapshot);
         string memory taskConfigFilePath = createTempTomlFile(taskConfigToml);
         multisigTask.executeRun(taskConfigFilePath, prepareSignatures(parentMultisig, taskHash));
-        vm.removeFile(taskConfigFilePath);
+        removeFile(taskConfigFilePath);
         addrRegistry = multisigTask.addrRegistry();
 
         // Check that the implementation is upgraded correctly for a second time
@@ -416,5 +416,11 @@ contract NestedMultisigTaskTest is Test {
         string memory fileName = string.concat(randomBytes, ".toml");
         vm.writeFile(fileName, tomlContent);
         return fileName;
+    }
+
+    /// @notice This function is used to remove a file. The reason we use a try catch
+    /// is because sometimes the file may not exist and this leads to flaky tests.
+    function removeFile(string memory fileName) internal {
+        try vm.removeFile(fileName) {} catch {}
     }
 }

--- a/test/tasks/StateOverrideManager.t.sol
+++ b/test/tasks/StateOverrideManager.t.sol
@@ -44,7 +44,7 @@ contract StateOverrideManagerUnitTest is Test {
         assertEq(IGnosisSafe(task.parentMultisig()).getThreshold(), 2, "Threshold must be 2");
         uint256 threshold = uint256(vm.load(address(task.parentMultisig()), bytes32(uint256(0x4))));
         assertEq(threshold, 2, "Threshold must be 2 using vm.load");
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testNonceStateOverrideApplied() public {
@@ -60,7 +60,7 @@ contract StateOverrideManagerUnitTest is Test {
         string memory fileName = createTempTomlFile(toml);
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertNonceIncremented(2730, task);
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testInvalidAddressInStateOverrideFails() public {
@@ -76,7 +76,7 @@ contract StateOverrideManagerUnitTest is Test {
         MultisigTask task = new MockMultisigTask();
         vm.expectRevert();
         task.simulateRun(fileName);
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testDecimalKeyInConfigForStateOverridePasses() public {
@@ -91,7 +91,7 @@ contract StateOverrideManagerUnitTest is Test {
         string memory fileName = createTempTomlFile(toml);
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertNonceIncremented(1, task);
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testAddressValueInConfigForStateOverridePasses() public {
@@ -116,7 +116,7 @@ contract StateOverrideManagerUnitTest is Test {
             )
         );
         assertEq(actualImplAddr, expectedImplAddr, "Implementation address is not correct");
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testDecimalValuesInConfigForStateOverridePasses() public {
@@ -131,7 +131,7 @@ contract StateOverrideManagerUnitTest is Test {
         string memory fileName = createTempTomlFile(toml);
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertNonceIncremented(101, task);
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testOnlyDefaultTenderlyStateOverridesApplied() public {
@@ -140,7 +140,7 @@ contract StateOverrideManagerUnitTest is Test {
 
         uint256 expectedNonce = task.nonce();
         assertDefaultStateOverrides(expectedNonce, 2, task, SECURITY_COUNCIL_CHILD_MULTISIG, 0);
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testUserTenderlyStateOverridesTakePrecedence() public {
@@ -164,7 +164,7 @@ contract StateOverrideManagerUnitTest is Test {
             bytes32(uint256(expectedNonce)),
             "User defined override must be applied last"
         );
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testAdditionalUserStateOverridesApplied() public {
@@ -189,7 +189,7 @@ contract StateOverrideManagerUnitTest is Test {
         );
         assertEq(allOverrides[2].overrides[0].key, overrideKey, "User override key must match expected value");
         assertEq(allOverrides[2].overrides[0].value, bytes32(uint256(9999)), "User override must be applied last");
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function testMultipleAddressStateOverridesApplied() public {
@@ -233,7 +233,7 @@ contract StateOverrideManagerUnitTest is Test {
         assertEq(
             allOverrides[3].overrides[0].value, bytes32(uint256(8888)), "Second address user override must be applied"
         );
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     /// @notice This test uses the 'Base Sepolia Testnet' at a block where the ProxyAdminOwner is known to be a single safe.
@@ -251,7 +251,7 @@ contract StateOverrideManagerUnitTest is Test {
         Simulation.StateOverride[] memory allOverrides =
             assertDefaultStateOverrides(expectedNonce, 1, dgt, address(0), 0);
         assertEq(allOverrides.length, 1, "Only parent overrides should be applied");
-        vm.removeFile(fileName);
+        removeFile(fileName);
     }
 
     function createAndRunTask(string memory fileName, address childMultisig) internal returns (MultisigTask) {
@@ -434,5 +434,11 @@ contract StateOverrideManagerUnitTest is Test {
             bytes32(uint256(0x1)),
             "Owner Override: Must contain second owner mapping override value"
         );
+    }
+
+    /// @notice This function is used to remove a file. The reason we use a try catch
+    /// is because sometimes the file may not exist and this leads to flaky tests.
+    function removeFile(string memory fileName) internal {
+        try vm.removeFile(fileName) {} catch {}
     }
 }


### PR DESCRIPTION
Sometimes we can see flakes like this one: https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops/5523/workflows/936c7d63-14f2-4e7a-a515-899f31e9ce7b/jobs/73695 - If a file doesn't exist to delete then that is okay and we shouldn't revert. 

This PR is super simple:
 - It wraps all vm.removeFile calls in a try catch.