### PR TITLE
docs: Tenderly bug - mention in NESTED.md

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -108,7 +108,7 @@ Now that we have verified the transaction performs the right
 operation, we need to extract the domain hash and the message hash to
 approve.
 
-Go back to the "Overview" tab, and find the
+Go back to the "Overview" tab, and find the **first**
 `GnosisSafe.checkSignatures` call. This call's `data` parameter
 contains both the domain hash and the message hash that will show up
 in your Ledger.
@@ -120,6 +120,10 @@ different:
 
 It will be a concatenation of `0x1901`, the domain hash, and the
 message hash: `0x1901[domain hash][message hash]`.
+
+Sometimes Tenderly can be buggy and may not show this function call in the simulator trace.
+If that happens, try refreshing the simulation link. If it still doesn’t show up, please contact the ceremony facilitator.
+Make sure not to confuse this function call with the second `GnosisSafe.checkSignatures` call.
 
 Note down this value. You will need to compare it with the ones
 displayed on the Ledger screen at signing.


### PR DESCRIPTION
As discussed [here](https://discord.com/channels/1244729134312198194/1331259603576557599/1355369378006437910). 

This one was a head-scratcher. Turns out Tenderly wasn't decoding the first multicall3 call properly, which led me down the garden path.

![CleanShot 2025-03-28 at 19 39 48@2x](https://github.com/user-attachments/assets/b9d3ed89-090a-4bfb-b82b-3c0a62c77572)
