### PR TITLE
refactor: v1 markdown printing for state diffs.

### DIFF
--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -375,9 +375,17 @@ library AccountAccessParser {
         console.log("\n----------------- Task State Changes -------------------");
         console.log("\n--- Attention: Copy content below this line into the VALIDATION.md file. ---");
         require(_stateDiffs.length > 0, "No state changes found, this is unexpected.");
+        printMarkdown(_stateDiffs);
+        console.log("\n\n --- Attention: Copy content above this line into the VALIDATION.md file. ---");
+    }
+
+    /// @notice Prints the decoded state diffs to the console in markdown format.
+    /// This markdown is intended to be copied into the VALIDATION.md file.
+    function printMarkdown(DecodedStateDiff[] memory _stateDiffs) internal view noGasMetering {
         address currentAddress = address(0xdead);
         for (uint256 i = 0; i < _stateDiffs.length; i++) {
             if (currentAddress != _stateDiffs[i].who) {
+                console.log("---"); // Add markdown horizontal rule.
                 string memory currentContractName = bytes(_stateDiffs[i].contractName).length > 0
                     ? string.concat(_stateDiffs[i].contractName)
                     : "TODO: enter contract name";
@@ -391,24 +399,25 @@ library AccountAccessParser {
             console.log("\n#### Decoded State Change: %s", i);
             console.log("- **Contract:**          `%s`", state.contractName);
             console.log("- **Chain ID:**          `%s`", state.l2ChainId == 0 ? "" : vm.toString(state.l2ChainId));
-            console.log("- **Raw Slot:**          `%s`", vm.toString(state.raw.slot));
-            console.log("- **Raw Old Value:**     `%s`", vm.toString(state.raw.oldValue));
-            console.log("- **Raw New Value:**     `%s`", vm.toString(state.raw.newValue));
 
+            console.log("\n- **Key:**          `%s`", vm.toString(state.raw.slot));
             if (bytes(state.decoded.kind).length == 0) {
+                console.log("- **Before:**     `%s`", vm.toString(state.raw.oldValue));
+                console.log("- **After:**     `%s`", vm.toString(state.raw.newValue));
+                console.log("\n- **Summary:**           %s", "");
+                console.log("- **Detail:**            %s", "");
                 console.log(
-                    "\x1B[33m[WARN]\x1B[0m Slot was not decoded. Please manually decode and provide a summary with the detail then remove this warning."
+                    "\n\x1B[33m[WARN]\x1B[0m Slot was not decoded. Please manually decode and provide a summary with the detail then remove this warning."
                 );
             } else {
                 console.log("- **Decoded Kind:**      `%s`", state.decoded.kind);
-                console.log("- **Decoded Old Value:** `%s`", state.decoded.oldValue);
-                console.log("- **Decoded New Value:** `%s`", state.decoded.newValue);
-                console.log("- **Summary:**           %s", state.decoded.summary);
+                console.log("- **Before:** `%s`", state.decoded.oldValue);
+                console.log("- **After:** `%s`", state.decoded.newValue);
+                console.log("\n- **Summary:**           %s", state.decoded.summary);
                 console.log("- **Detail:**            %s", state.decoded.detail);
             }
-            console.log("\n**TODO: Insert links for this state change.**");
+            console.log("\n**TODO: Insert links for this state change.**\n");
         }
-        console.log("\n\n --- Attention: Copy content above this line into the VALIDATION.md file. ---");
     }
 
     /// @notice Decodes an ETH transfer from an account access record, and returns an empty struct

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -364,36 +364,51 @@ library AccountAccessParser {
         } else {
             for (uint256 i = 0; i < _transfers.length; i++) {
                 DecodedTransfer memory transfer = _transfers[i];
-                console.log("\n----- DecodedTransfer[%s] -----", i);
-                console.log("From:              %s", transfer.from);
-                console.log("To:                %s", transfer.to);
-                console.log("Value:             %s", transfer.value);
-                console.log("Token Address:     %s", transfer.tokenAddress);
+                console.log("\n#### Decoded Transfer %s", i);
+                console.log("- **From:**              `%s`", transfer.from);
+                console.log("- **To:**                `%s`", transfer.to);
+                console.log("- **Value:**             `%s`", transfer.value);
+                console.log("- **Token Address:**     `%s`", transfer.tokenAddress);
             }
         }
 
         console.log("\n----------------- Task State Changes -------------------");
+        console.log("\n--- Attention: Copy content below this line into the VALIDATION.md file. ---");
         require(_stateDiffs.length > 0, "No state changes found, this is unexpected.");
+        address currentAddress = address(0xdead);
         for (uint256 i = 0; i < _stateDiffs.length; i++) {
+            if (currentAddress != _stateDiffs[i].who) {
+                string memory currentContractName = bytes(_stateDiffs[i].contractName).length > 0
+                    ? string.concat(_stateDiffs[i].contractName)
+                    : "TODO: enter contract name";
+                console.log(
+                    "\n### `%s`",
+                    string.concat(LibString.toHexString(_stateDiffs[i].who), " (", currentContractName, ")")
+                );
+                currentAddress = _stateDiffs[i].who;
+            }
             DecodedStateDiff memory state = _stateDiffs[i];
-            console.log("\n----- DecodedStateDiff[%s] -----", i);
-            console.log("Who:               %s", state.who);
-            console.log("Contract:          %s", state.contractName);
-            console.log("Chain ID:          %s", state.l2ChainId == 0 ? "" : vm.toString(state.l2ChainId));
-            console.log("Raw Slot:          %s", vm.toString(state.raw.slot));
-            console.log("Raw Old Value:     %s", vm.toString(state.raw.oldValue));
-            console.log("Raw New Value:     %s", vm.toString(state.raw.newValue));
+            console.log("\n#### Decoded State Change: %s", i);
+            console.log("- **Contract:**          `%s`", state.contractName);
+            console.log("- **Chain ID:**          `%s`", state.l2ChainId == 0 ? "" : vm.toString(state.l2ChainId));
+            console.log("- **Raw Slot:**          `%s`", vm.toString(state.raw.slot));
+            console.log("- **Raw Old Value:**     `%s`", vm.toString(state.raw.oldValue));
+            console.log("- **Raw New Value:**     `%s`", vm.toString(state.raw.newValue));
 
             if (bytes(state.decoded.kind).length == 0) {
-                console.log("\x1B[33m[WARN]\x1B[0m Slot was not decoded");
+                console.log(
+                    "\x1B[33m[WARN]\x1B[0m Slot was not decoded. Please manually decode and provide a summary with the detail then remove this warning."
+                );
             } else {
-                console.log("Decoded Kind:      %s", state.decoded.kind);
-                console.log("Decoded Old Value: %s", state.decoded.oldValue);
-                console.log("Decoded New Value: %s", state.decoded.newValue);
-                console.log("Summary:           %s", state.decoded.summary);
-                console.log("Detail:            %s", state.decoded.detail);
+                console.log("- **Decoded Kind:**      `%s`", state.decoded.kind);
+                console.log("- **Decoded Old Value:** `%s`", state.decoded.oldValue);
+                console.log("- **Decoded New Value:** `%s`", state.decoded.newValue);
+                console.log("- **Summary:**           %s", state.decoded.summary);
+                console.log("- **Detail:**            %s", state.decoded.detail);
             }
+            console.log("\n**TODO: Insert links for this state change.**");
         }
+        console.log("\n\n --- Attention: Copy content above this line into the VALIDATION.md file. ---");
     }
 
     /// @notice Decodes an ETH transfer from an account access record, and returns an empty struct


### PR DESCRIPTION
As per feedback from the first mainnet signing ceremony I've implemented grouping off state diffs by address and added markdown formatting to them. 

For an example of what this looks like checkout this gist: https://gist.github.com/blmalone/3b3d0b03fec70a07d20a64fb4024aaa2 

Example of what it looks like in the terminal:
![CleanShot 2025-04-04 at 11 41 11@2x](https://github.com/user-attachments/assets/b41cf9cf-3ddf-4df2-bd10-c8364c160791)




