### PR TITLE
feat: activate op-txverify (only merge after all U13 tasks are executed)

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -333,10 +333,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         console.log("Domain Hash:    ", vm.toString(domainSeparator));
         console.log("Message Hash:   ", vm.toString(messageHash));
 
-        // TODO: Remove this feature flag after all U13 tasks are executed.
-        if (false) {
-            printOPTxVerifyLink(parentMultisig, callData, hex"");
-        }
+        printOPTxVerifyLink(parentMultisig, callData, hex"");
     }
 
     /// @notice This function prints a op-txverify link which can be used for verifying the authenticity of the domain and message hashes
@@ -691,10 +688,8 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         printEncodedTransactionData(dataToSign);
         console.log("\n\n------------------ Nested Multisig EOAs Hash to Approve ------------------");
         printChildHash(childMultisig, domainSeparator, messageHash);
-        // TODO: Remove this feature flag after all U13 tasks are executed.
-        if (false) {
-            printOPTxVerifyLink(childMultisig, parentCalldata, generateApproveMulticallData(actions));
-        }
+
+        printOPTxVerifyLink(childMultisig, parentCalldata, generateApproveMulticallData(actions));
     }
 
     /// @notice Helper function to print non-nested safe calldata.


### PR DESCRIPTION
We are going to roll out the op-txverify feature for U14. We should only merge this PR once all the U13 tasks have been executed. 