### PR TITLE
executed ink sep move to permissionless

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -512,7 +512,7 @@ workflows:
       - simulate_sequence:
           name: simulate_sequence_sep
           network: "sep"
-          tasks: "ink-003 ink-004"
+          tasks: ""
           block_number: "" # If not specified, the latest block number is used.
           context:
             - circleci-repo-readonly-authenticated-github-token

--- a/tasks/sep/ink-003-set-init-bond/README.md
+++ b/tasks/sep/ink-003-set-init-bond/README.md
@@ -1,6 +1,6 @@
 # ProxyAdminOwner - Set Dispute Game Implementation
 
-Status: READY TO SIGN
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x2da222585b59cdb3fa10d031c6198be120dcfb23291155d354a43527ff508adc)
 
 ## Objective
 

--- a/tasks/sep/ink-004-enable-permissionless-game/README.md
+++ b/tasks/sep/ink-004-enable-permissionless-game/README.md
@@ -1,6 +1,6 @@
 # Deputy Guardian - Enable Permissioness Dispute Game
 
-Status: READY TO SIGN
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0xe5b2f3851d02e90a1ed9f6730c71d80a072ed5a340229ce39558eb5febf21f2a)
 
 ## Objective
 


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Ink Sepolia upgraded to use permissionless fault proofs
