### PR TITLE
fix: Update Foundry dependency to include fix from Foundry PR #10069

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,9 +11,9 @@ yq = "4.44.5"
 # GitHub release, so we need to use the aliasing trick to get mise to not error
 # The git ref here should be on the `stable` branch.
 # WARNING: DO NOT CHANGE FORGE/CAST/ANVIL VERSIONS UNLESS ABSOLUTELY NECESSARY!
-# https://github.com/foundry-rs/foundry/releases/tag/nightly-23191fbeccfcf901f7c28590cb962d9693373c21
-# fix(forge): stack pranks, restore pranks at earlier call depths.
-forge = "nightly-23191fbeccfcf901f7c28590cb962d9693373c21"
+# https://github.com/foundry-rs/foundry/releases/tag/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd
+# fix(forge): apply startPrank with delegate only for top calls
+forge = "nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd"
 cast = "v1.0.0"
 anvil = "v1.0.0"
 

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -871,6 +871,13 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     /// --------------------------------------------------------------------
     /// --------------------------------------------------------------------
 
+    /// @notice Prank as the multisig.
+    /// Override to prank with delegatecall flag set to true
+    /// in case of OPCM tasks.
+    function _prankMultisig() internal virtual {
+        vm.startPrank(parentMultisig);
+    }
+
     /// @notice Validate actions inclusion. Default implementation checks for duplicate actions.
     function validateAction(address target, uint256 value, bytes memory data, Action[] memory actions) public pure {
         uint256 actionsLength = actions.length;
@@ -993,7 +1000,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     ///  2). start prank as the multisig
     ///  3). start a recording of all calls created during the task
     function _startBuild() private {
-        vm.startPrank(parentMultisig);
+        _prankMultisig();
 
         _startSnapshot = vm.snapshotState();
 

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -1093,11 +1093,16 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     function _isValidAction(VmSafe.AccountAccess memory access, uint256 topLevelDepth) internal view returns (bool) {
         bool accountNotRegistryOrVm =
             (access.account != AddressRegistry.unwrap(addrRegistry) && access.account != address(vm));
+        console.log("accountNotRegistryOrVm", accountNotRegistryOrVm);
         bool accessorNotRegistry = access.accessor != AddressRegistry.unwrap(addrRegistry);
+        console.log("accessorNotRegistry", accessorNotRegistry);
         bool isCall = (access.kind == VmSafe.AccountAccessKind.Call && access.depth == topLevelDepth);
+        console.log("isCall", isCall);
         bool isTopLevelDelegateCall =
             (access.kind == VmSafe.AccountAccessKind.DelegateCall && access.depth == topLevelDepth);
+        console.log("isTopLevelDelegateCall", isTopLevelDelegateCall);
         bool accessorIsParent = (access.accessor == parentMultisig);
+        console.log("accessorIsParent", accessorIsParent);
         return accountNotRegistryOrVm && accessorNotRegistry && (isCall || isTopLevelDelegateCall) && accessorIsParent;
     }
 

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -1085,11 +1085,13 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         bool accountNotRegistryOrVm =
             (access.account != AddressRegistry.unwrap(addrRegistry) && access.account != address(vm));
         bool accessorNotRegistry = access.accessor != AddressRegistry.unwrap(addrRegistry);
-        bool isCall = access.kind == VmSafe.AccountAccessKind.Call;
+        bool isCall = (access.kind == VmSafe.AccountAccessKind.Call && access.depth == topLevelDepth);
         bool isTopLevelDelegateCall =
             (access.kind == VmSafe.AccountAccessKind.DelegateCall && access.depth == topLevelDepth);
         bool accessorIsParent = (access.accessor == parentMultisig);
-        return accountNotRegistryOrVm && accessorNotRegistry && (isCall || isTopLevelDelegateCall) && accessorIsParent;
+        bool isValid =
+            accountNotRegistryOrVm && accessorNotRegistry && (isCall || isTopLevelDelegateCall) && accessorIsParent;
+        return isValid;
     }
 
     /// @notice Composes a description string for the given access using the provided operation string.

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -1080,7 +1080,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         }
     }
 
-    /// @notice Returns true if the given account access should be recorded as an action.
+    /// @notice Returns true if the given account access should be recorded as an action. This function is used to filter out
+    /// actions that we defined in the _build function of our template. The actions selected by this function will get executed
+    /// by the relevant Multicall3 contract.
     function _isValidAction(VmSafe.AccountAccess memory access, uint256 topLevelDepth) internal view returns (bool) {
         bool accountNotRegistryOrVm =
             (access.account != AddressRegistry.unwrap(addrRegistry) && access.account != address(vm));
@@ -1089,9 +1091,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         bool isTopLevelDelegateCall =
             (access.kind == VmSafe.AccountAccessKind.DelegateCall && access.depth == topLevelDepth);
         bool accessorIsParent = (access.accessor == parentMultisig);
-        bool isValid =
-            accountNotRegistryOrVm && accessorNotRegistry && (isCall || isTopLevelDelegateCall) && accessorIsParent;
-        return isValid;
+        return accountNotRegistryOrVm && accessorNotRegistry && (isCall || isTopLevelDelegateCall) && accessorIsParent;
     }
 
     /// @notice Composes a description string for the given access using the provided operation string.

--- a/src/improvements/tasks/types/OPCMTaskBase.sol
+++ b/src/improvements/tasks/types/OPCMTaskBase.sol
@@ -109,6 +109,13 @@ abstract contract OPCMTaskBase is L2TaskBase {
         multicallTarget_ = MULTICALL3_DELEGATECALL_ADDRESS;
     }
 
+    /// @notice Prank as the multisig.
+    function _prankMultisig() internal override {
+        // If delegateCall value is true then sets msg.sender for all subsequent delegate calls.
+        // We want this functionality for OPCM tasks.
+        vm.startPrank(parentMultisig, true);
+    }
+
     /// @notice this function must be overridden in the inheriting contract to run assertions on the state changes.
     function _validate(VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions)
         internal

--- a/src/improvements/template/OPCMUpdatePrestateV300.sol
+++ b/src/improvements/template/OPCMUpdatePrestateV300.sol
@@ -84,14 +84,10 @@ contract OPCMUpdatePrestateV300 is OPCMTaskBase {
             });
         }
 
-        // We expect this call to revert when invoked from the _build() function.
-        // The _build function's job is to record the high-level calls that will later be executed by the L1 Proxy Admin Owner safe.
-        // It is not responsible for ensuring correct execution — that responsibility lies with the 'execTransaction' function in MultisigTask.sol.
-        (bool success,) = OPCM.call(abi.encodeWithSelector(IOPCMPrestateUpdate.updatePrestate.selector, opChainConfigs));
-        require(
-            !success,
-            "OPCMUpdatePrestateV300: Call unexpectedly succeeded; expected revert due to non-delegatecall in _build."
-        );
+        vm.startPrank(parentMultisig, true);
+        (bool success,) =
+            OPCM.delegatecall(abi.encodeWithSelector(IOPCMPrestateUpdate.updatePrestate.selector, opChainConfigs));
+        require(success, "OPCMUpdatePrestateV300: Delegatecall failed.");
     }
 
     /// @notice This method performs all validations and assertions that verify the calls executed as expected.

--- a/src/improvements/template/OPCMUpdatePrestateV300.sol
+++ b/src/improvements/template/OPCMUpdatePrestateV300.sol
@@ -69,7 +69,15 @@ contract OPCMUpdatePrestateV300 is OPCMTaskBase {
         vm.label(address(STANDARD_VALIDATOR_V300), "StandardValidatorV300");
     }
 
-    /// @notice A single call to OPCM.updatePrestate() is made for all l2 chains that are defined in a tasks config.toml.
+    /// @notice Before implementing the `_build` function, template developers must consider the following:
+    /// 1. Which Multicall contract does this template use — `Multicall3` or `Multicall3Delegatecall`?
+    /// 2. Based on the contract, should the target be called using `call` or `delegatecall`?
+    /// 3. Ensure that the call to the target uses the appropriate method (`call` or `delegatecall`) accordingly.
+    /// Guidelines:
+    /// - `Multicall3Delegatecall`:
+    ///   If the template inherits from `OPCMTaskBase`, it uses the `Multicall3Delegatecall` contract.
+    ///   In this case, calls to the target **must** use `delegatecall`, e.g.:
+    ///   `(bool success,) = OPCM.delegatecall(abi.encodeWithSelector(IOPCMPrestateUpdate.upgrade.selector, opChainConfigs));`
     function _build() internal override {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         IOPContractsManager.OpChainConfig[] memory opChainConfigs =
@@ -86,7 +94,7 @@ contract OPCMUpdatePrestateV300 is OPCMTaskBase {
 
         (bool success,) =
             OPCM.delegatecall(abi.encodeWithSelector(IOPCMPrestateUpdate.updatePrestate.selector, opChainConfigs));
-        require(success, "OPCMUpdatePrestateV300: Delegatecall failed.");
+        require(success, "OPCMUpdatePrestateV300: Delegatecall failed in _build.");
     }
 
     /// @notice This method performs all validations and assertions that verify the calls executed as expected.

--- a/src/improvements/template/OPCMUpdatePrestateV300.sol
+++ b/src/improvements/template/OPCMUpdatePrestateV300.sol
@@ -84,7 +84,6 @@ contract OPCMUpdatePrestateV300 is OPCMTaskBase {
             });
         }
 
-        vm.startPrank(parentMultisig, true);
         (bool success,) =
             OPCM.delegatecall(abi.encodeWithSelector(IOPCMPrestateUpdate.updatePrestate.selector, opChainConfigs));
         require(success, "OPCMUpdatePrestateV300: Delegatecall failed.");

--- a/src/improvements/template/boilerplate/L2TaskBase.template.sol
+++ b/src/improvements/template/boilerplate/L2TaskBase.template.sol
@@ -44,7 +44,15 @@ contract L2TaskBaseTemplate is L2TaskBase {
         require(false, "TODO: Implement with the correct template setup.");
     }
 
-    /// @notice Write the calls that you want to execute for the task.
+    /// @notice Before implementing the `_build` function, task developers must consider the following:
+    /// 1. Which Multicall contract does this template use — `Multicall3` or `Multicall3Delegatecall`?
+    /// 2. Based on the contract, should the target be called using `call` or `delegatecall`?
+    /// 3. Ensure that the call to the target uses the appropriate method (`call` or `delegatecall`) accordingly.
+    /// Guidelines:
+    /// - `Multicall3`:
+    ///  If the template directlyinherits from `L2TaskBase` or `SimpleTaskBase`, it uses the `Multicall3` contract.
+    ///  In this case, calls to the target **must** use `call`, e.g.:
+    ///  ` dgm.setRespectedGameType(IOptimismPortal2(payable(portalAddress)), cfg[chainId].gameType);`
     function _build() internal override {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {

--- a/src/improvements/template/boilerplate/SimpleTaskBase.template.sol
+++ b/src/improvements/template/boilerplate/SimpleTaskBase.template.sol
@@ -43,7 +43,15 @@ contract SimpleTaskBaseTemplate is SimpleTaskBase {
         require(false, "TODO: Implement with the correct template setup.");
     }
 
-    /// @notice Write the calls that you want to execute for the task.
+    /// @notice Before implementing the `_build` function, template developers must consider the following:
+    /// 1. Which Multicall contract does this template use — `Multicall3` or `Multicall3Delegatecall`?
+    /// 2. Based on the contract, should the target be called using `call` or `delegatecall`?
+    /// 3. Ensure that the call to the target uses the appropriate method (`call` or `delegatecall`) accordingly.
+    /// Guidelines:
+    /// - `Multicall3`:
+    ///  If the template directlyinherits from `L2TaskBase` or `SimpleTaskBase`, it uses the `Multicall3` contract.
+    ///  In this case, calls to the target **must** use `call`, e.g.:
+    ///  ` dgm.setRespectedGameType(IOptimismPortal2(payable(portalAddress)), cfg[chainId].gameType);`
     function _build() internal override {
         simpleAddrRegistry;
         exampleVariable = 1;

--- a/test/tasks/MultisigTask.t.sol
+++ b/test/tasks/MultisigTask.t.sol
@@ -7,7 +7,6 @@ import {Test} from "forge-std/Test.sol";
 import {stdStorage, StdStorage} from "forge-std/StdStorage.sol";
 import {IGnosisSafe, Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
 import {LibString} from "@solady/utils/LibString.sol";
-import {console} from "forge-std/console.sol";
 
 import {MockTarget} from "test/tasks/mock/MockTarget.sol";
 import {MultisigTask} from "src/improvements/tasks/MultisigTask.sol";

--- a/test/tasks/MultisigTask.t.sol
+++ b/test/tasks/MultisigTask.t.sol
@@ -252,6 +252,145 @@ contract MultisigTaskUnitTest is Test {
         assertEq(data, expectedData, "Wrong aggregate calldata");
     }
 
+    function test_validAction_validCall() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.Call,
+            address(0x5678), // Random account
+            parentMultisig, // Valid accessor
+            uint64(topLevelDepth)
+        );
+        assertTrue(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_validAction_validDelegateCall() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.DelegateCall,
+            address(0x5678), // Random account
+            parentMultisig, // Valid accessor
+            uint64(topLevelDepth)
+        );
+        assertTrue(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_invalidAction_accountIsRegistry() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        address registryAddr = address(0xcafe1234);
+        stdstore.target(address(harness)).sig("addrRegistry()").checked_write(address(registryAddr));
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.Call,
+            registryAddr, // Invalid account
+            parentMultisig,
+            uint64(topLevelDepth)
+        );
+        assertFalse(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_invalidAction_accountIsVm() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.Call,
+            VM_ADDRESS, // Invalid account
+            parentMultisig,
+            uint64(topLevelDepth)
+        );
+        assertFalse(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_invalidAction_accessorIsRegistry() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        address registryAddr = address(0xcafe1234);
+        stdstore.target(address(harness)).sig("addrRegistry()").checked_write(address(registryAddr));
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.Call,
+            address(0x5678),
+            registryAddr, // Invalid accessor
+            uint64(topLevelDepth)
+        );
+        assertFalse(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_invalidAction_wrongAccessor() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.Call,
+            address(0x5678),
+            address(0x9999), // Wrong accessor
+            uint64(topLevelDepth)
+        );
+        assertFalse(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_invalidAction_wrongDepth() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.Call,
+            address(0x5678),
+            parentMultisig,
+            uint64(topLevelDepth + 1) // Wrong depth
+        );
+        assertFalse(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    function test_invalidAction_wrongKind() public {
+        MockMultisigTask harness = new MockMultisigTask();
+        address parentMultisig = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
+        stdstore.target(address(harness)).sig("parentMultisig()").checked_write(parentMultisig);
+        uint256 topLevelDepth = 1;
+        VmSafe.AccountAccess memory access = createAccess(
+            VmSafe.AccountAccessKind.StaticCall, // Invalid kind
+            address(0x5678),
+            parentMultisig,
+            uint64(topLevelDepth)
+        );
+        assertFalse(harness.wrapperIsValidAction(access, topLevelDepth));
+    }
+
+    // Helper to create AccountAccess struct
+    function createAccess(VmSafe.AccountAccessKind kind, address account, address accessor, uint64 depth)
+        internal
+        pure
+        returns (VmSafe.AccountAccess memory)
+    {
+        return VmSafe.AccountAccess({
+            chainInfo: VmSafe.ChainInfo({forkId: 0, chainId: 1}),
+            kind: kind,
+            account: account,
+            accessor: accessor,
+            initialized: false,
+            oldBalance: 0,
+            newBalance: 0,
+            deployedCode: "",
+            value: 0,
+            data: "",
+            reverted: false,
+            storageAccesses: new VmSafe.StorageAccess[](0),
+            depth: depth
+        });
+    }
+
     function createActions(
         address target,
         bytes memory data,

--- a/test/tasks/mock/MockMultisigTask.sol
+++ b/test/tasks/mock/MockMultisigTask.sol
@@ -71,4 +71,13 @@ contract MockMultisigTask is L2TaskBase {
 
     /// @notice no code exceptions for this template
     function getCodeExceptions() internal view virtual override returns (address[] memory) {}
+
+    /// @notice Wrapper function to call the internal _isValidAction function. This is used to test the internal function.
+    function wrapperIsValidAction(VmSafe.AccountAccess memory access, uint256 topLevelDepth)
+        public
+        view
+        returns (bool isValid)
+    {
+        return super._isValidAction(access, topLevelDepth);
+    }
 }


### PR DESCRIPTION


1. Updated the foundry dependency to: [7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd](https://github.com/foundry-rs/foundry/releases/tag/nightly-7a7ad4ea7282c30477d7fc0f39bf631acde7e7bd). This is to include a fix we've been waiting for to make writing templates work with delegate calls. I opened [this issue](https://github.com/foundry-rs/foundry/issues/9990) on Foundry a number of weeks ago.
2. Included a related fix to the _isValidAction function: https://github.com/ethereum-optimism/superchain-ops/pull/701
3. Added tests to the `_isValidAction` function as they didn't exist before. 