### PR TITLE
feat: opcm v300 add errors as config

### DIFF
--- a/src/improvements/nested.just
+++ b/src/improvements/nested.just
@@ -49,6 +49,7 @@ simulate whichSafe hdPath='0':
     fork_block_arg="--fork-block-number ${forkBlockNumber}"
   fi
 
+  echo "⏳ Task simulation in progress. Some tasks take longer than others..."
   forge build
   forge script ${script} \
     ${fork_block_arg} \
@@ -71,6 +72,7 @@ sign whichSafe hdPath='0':
   echo "Signing with: ${signer}"
   echo ""
 
+  echo "⏳ Task signing in progress. Some tasks take longer than others..."
   forge build
   # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.
   $(git rev-parse --show-toplevel)/bin/eip712sign --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" -- \
@@ -131,27 +133,13 @@ execute hdPath='0':
   echo "Using script ${script}"
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
 
+  echo "⏳ Task execution in progress. Some tasks take longer than others..."
   forge build
   forge script ${script} \
     --fork-url ${rpcUrl} \
     --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
     --broadcast \
     --sender ${sender} \
-    --sig "executeRun(string,bytes)" \
-    ${config} \
-    "0x"
-
-simulated-run hdPath='0':
-  #!/usr/bin/env bash
-  config=${TASK_PATH}/config.toml
-  script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
-
-  echo "Using script ${script}"
-
-  forge build
-  forge script ${script} \
-    --fork-url ${rpcUrl} \
-    --sender ${randomPersonEoa} \
     --sig "executeRun(string,bytes)" \
     ${config} \
     "0x"

--- a/src/improvements/single.just
+++ b/src/improvements/single.just
@@ -45,6 +45,7 @@ simulate hdPath='0':
     fork_block_arg="--fork-block-number ${forkBlockNumber}"
   fi
 
+  echo "⏳ Task simulation in progress. Some tasks take longer than others..."
   forge build
   forge script ${script} \
     ${fork_block_arg} \
@@ -66,6 +67,7 @@ sign hdPath='0':
   echo "Signing with: ${signer}"
   echo ""
 
+  echo "⏳ Task signing in progress. Some tasks take longer than others..."
   forge build
   # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.
   $(git rev-parse --show-toplevel)/bin/eip712sign --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" -- \
@@ -81,6 +83,7 @@ execute hdPath='0':
   echo "Using script ${script}"
   sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
 
+  echo "⏳ Task execution in progress. Some tasks take longer than others..."
   forge build
   forge script --fork-url ${rpcUrl} ${script} \
     --sig "executeRun(string,bytes)" ${config} ${signatures} \

--- a/src/improvements/template/OPCMUpgradeV300.sol
+++ b/src/improvements/template/OPCMUpgradeV300.sol
@@ -26,10 +26,11 @@ contract OPCMUpgradeV300 is OPCMTaskBase {
     struct OPCMUpgrade {
         Claim absolutePrestate;
         uint256 chainId;
+        string expectedValidationErrors;
     }
 
-    /// @notice Mapping of L2 chain IDs to their respective prestates.
-    mapping(uint256 => Claim) public absolutePrestates;
+    /// @notice Mapping of L2 chain IDs to their respective OPCMUpgrade structs.
+    mapping(uint256 => OPCMUpgrade) public upgrades;
 
     /// @notice Returns the storage write permissions required for this task.
     function _taskStorageWrites() internal view virtual override returns (string[] memory) {
@@ -50,11 +51,10 @@ contract OPCMUpgradeV300 is OPCMTaskBase {
         super._templateSetup(taskConfigFilePath);
         string memory tomlContent = vm.readFile(taskConfigFilePath);
 
-        // For OPCMUpgradeV300, the OPCMUpgrade struct is used to store the absolutePrestate for each l2 chain.
-        OPCMUpgrade[] memory upgrades =
-            abi.decode(tomlContent.parseRaw(".opcmUpgrades.absolutePrestates"), (OPCMUpgrade[]));
-        for (uint256 i = 0; i < upgrades.length; i++) {
-            absolutePrestates[upgrades[i].chainId] = upgrades[i].absolutePrestate;
+        // For OPCMUpgradeV300, the OPCMUpgrade struct is used to store the absolutePrestate and expectedValidationErrors for each l2 chain.
+        OPCMUpgrade[] memory _upgrades = abi.decode(tomlContent.parseRaw(".opcmUpgrades"), (OPCMUpgrade[]));
+        for (uint256 i = 0; i < _upgrades.length; i++) {
+            upgrades[_upgrades[i].chainId] = _upgrades[i];
         }
 
         OPCM = tomlContent.readAddress(".addresses.OPCM");
@@ -85,10 +85,11 @@ contract OPCMUpgradeV300 is OPCMTaskBase {
             new IOPContractsManager.OpChainConfig[](chains.length);
 
         for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
             opChainConfigs[i] = IOPContractsManager.OpChainConfig({
-                systemConfigProxy: ISystemConfig(superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId)),
-                proxyAdmin: IProxyAdmin(superchainAddrRegistry.getAddress("ProxyAdmin", chains[i].chainId)),
-                absolutePrestate: absolutePrestates[chains[i].chainId]
+                systemConfigProxy: ISystemConfig(superchainAddrRegistry.getAddress("SystemConfigProxy", chainId)),
+                proxyAdmin: IProxyAdmin(superchainAddrRegistry.getAddress("ProxyAdmin", chainId)),
+                absolutePrestate: upgrades[chainId].absolutePrestate
             });
         }
 
@@ -103,53 +104,21 @@ contract OPCMUpgradeV300 is OPCMTaskBase {
 
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
-            bytes32 currentAbsolutePrestate = Claim.unwrap(absolutePrestates[chainId]);
+            bytes32 expAbsolutePrestate = Claim.unwrap(upgrades[chainId].absolutePrestate);
+            string memory expErrors = upgrades[chainId].expectedValidationErrors;
             address proxyAdmin = superchainAddrRegistry.getAddress("ProxyAdmin", chainId);
             address sysCfg = superchainAddrRegistry.getAddress("SystemConfigProxy", chainId);
 
             IStandardValidatorV300.InputV300 memory input = IStandardValidatorV300.InputV300({
                 proxyAdmin: proxyAdmin,
                 sysCfg: sysCfg,
-                absolutePrestate: currentAbsolutePrestate,
+                absolutePrestate: expAbsolutePrestate,
                 l2ChainID: chainId
             });
 
-            string memory reasons = STANDARD_VALIDATOR_V300.validate({_input: input, _allowFailure: true});
+            string memory errors = STANDARD_VALIDATOR_V300.validate({_input: input, _allowFailure: true});
 
-            // PDDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            // PLDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            string memory expectedErrors_11155420 = "PDDG-ANCHORP-40,PLDG-ANCHORP-40";
-
-            // PDDG-DWETH-30: Delayed WETH owner must be l1PAOMultisig (for permissioned dispute game) - It is checking for the OP Sepolia PAO
-            // PDDG-ANCHORP-40: The anchor state registry's permissioned root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            // PDDG-120: Non-standard testnet challenger - Sony runs their own for testnet
-            // PLDG-10: Still on Permissioned games, so Permissionless dispute games are not needed
-            string memory expectedErrors_1946 = "PDDG-DWETH-30,PDDG-ANCHORP-40,PDDG-120,PLDG-10";
-
-            // PDDG-DWETH-30: Delayed WETH owner must be l1PAOMultisig (for permissioned dispute game) - It is checking for the OP Sepolia PAO
-            // PDDG-ANCHORP-40: The anchor state registry's permissioned root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            // PLDG-DWETH-30: Delayed WETH owner must be l1PAOMultisig (for permissioned dispute game) - It is checking for the OP Sepolia PAO
-            // PLDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            string memory expectedErrors_763373 = "PDDG-DWETH-30,PDDG-ANCHORP-40,PLDG-DWETH-30,PLDG-ANCHORP-40";
-
-            // PROXYA-10: Proxy admin owner must be l1PAOMultisig - This is OK because it is checking for the OP Sepolia PAO.
-            // DF-30: Dispute factory owner must be l1PAOMultisig - It is checking for the OP Sepolia PAO.
-            // PDDG-DWETH-30: Delayed WETH owner must be l1PAOMultisig (for permissioned dispute game) - It is checking for the OP Sepolia PAO
-            // PDDG-ANCHORP-40: The anchor state registry's permissioned root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            // PDDG-120: Permissioned dispute game challenger must match challenger address - It is checking for the OP Sepolia Challenger
-            // PLDG-DWETH-30: Delayed WETH owner must be l1PAOMultisig (for permissioned dispute game) - It is checking for the OP Sepolia PAO
-            // PLDG-ANCHORP-40: The anchor state registry's permissioned root is not 0xdead000000000000000000000000000000000000000000000000000000000000
-            string memory expectedErrors_1301 =
-                "PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-ANCHORP-40,PDDG-120,PLDG-DWETH-30,PLDG-ANCHORP-40";
-
-            // Base Sepolia and Unichain Sepolia have the same expected errors.
-            string memory expectedErrors_Base_84532 = expectedErrors_1301;
-
-            require(
-                reasons.eq(expectedErrors_11155420) || reasons.eq(expectedErrors_Base_84532)
-                    || reasons.eq(expectedErrors_1946) || reasons.eq(expectedErrors_763373),
-                string.concat("Unexpected errors: ", reasons)
-            );
+            require(errors.eq(expErrors), string.concat("Unexpected errors: ", errors, "; expected: ", expErrors));
         }
     }
 

--- a/src/improvements/template/OPCMUpgradeV300.sol
+++ b/src/improvements/template/OPCMUpgradeV300.sol
@@ -22,7 +22,7 @@ contract OPCMUpgradeV300 is OPCMTaskBase {
     /// @notice The StandardValidatorV300 address
     IStandardValidatorV300 public STANDARD_VALIDATOR_V300;
 
-    /// @notice Struct to store inputs for OPCM.upgrade() function per L2 chain.
+    /// @notice Struct to store inputs data for each L2 chain.
     struct OPCMUpgrade {
         Claim absolutePrestate;
         uint256 chainId;

--- a/test/tasks/example/sep/006-opcm-upgrade-v300/config.toml
+++ b/test/tasks/example/sep/006-opcm-upgrade-v300/config.toml
@@ -6,7 +6,7 @@ name = "OP Sepolia Testnet"
 
 [[opcmUpgrades]]
 chainId = 11155420
-absolutePrestate = "0x03ee2917da962ec266b091f4b62121dc9682bb0db534633707325339f99ee405" # op-program/v1.6.0-rc.2-64 - https://www.notion.so/oplabs/Isthmus-Sepolia-Mainnet-1d2f153ee162800880abe1b47910c071
+absolutePrestate = "0x03ee2917da962ec266b091f4b62121dc9682bb0db534633707325339f99ee405"
 # PDDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
 # PLDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
 expectedValidationErrors = "PDDG-ANCHORP-40,PLDG-ANCHORP-40"

--- a/test/tasks/example/sep/006-opcm-upgrade-v300/config.toml
+++ b/test/tasks/example/sep/006-opcm-upgrade-v300/config.toml
@@ -1,9 +1,15 @@
-l2chains = [{name = "OP Sepolia Testnet", chainId = 11155420}]
-
 templateName = "OPCMUpgradeV300"
 
-[opcmUpgrades]
-absolutePrestates = [{absolutePrestate = "0x03ee2917da962ec266b091f4b62121dc9682bb0db534633707325339f99ee405", chainId = 11155420}]
+[[l2chains]]
+chainId = 11155420
+name = "OP Sepolia Testnet"
+
+[[opcmUpgrades]]
+chainId = 11155420
+absolutePrestate = "0x03ee2917da962ec266b091f4b62121dc9682bb0db534633707325339f99ee405" # op-program/v1.6.0-rc.2-64 - https://www.notion.so/oplabs/Isthmus-Sepolia-Mainnet-1d2f153ee162800880abe1b47910c071
+# PDDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
+# PLDG-ANCHORP-40: The anchor state registry's permissionless root is not 0xdead000000000000000000000000000000000000000000000000000000000000
+expectedValidationErrors = "PDDG-ANCHORP-40,PLDG-ANCHORP-40"
 
 [addresses]
 OPCM = "0xfbceed4de885645fbded164910e10f52febfab35" # Sepolia op-contracts/v3.0.0-rc.2 https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-versions-sepolia.toml#L22


### PR DESCRIPTION
Like OPCMUpdatePrestateV300 template, we're requiring that tasks pass their error strings through their config files.