### PR TITLE
fix VALIDATION and config for 012-opcm-update-prestate-v300-uni.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,13 +505,6 @@ workflows:
       # We wll need to rewrite the rehearsals with the new superchain-ops structure anyway, so this is ok.
       # - just_simulate_sc_rehearsal_1
 
-      # U15 Sepolia Unichain
-      - just_simulate_single_improvements:
-          name: "simulate single sep/012-opcm-update-prestate-v300-uni"
-          task: "/sep/012-opcm-update-prestate-v300-uni"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-
       - just_simulate_nested:
           task: "/eth/zora-002-fp-upgrade"
           context:

--- a/src/improvements/tasks/sep/012-opcm-update-prestate-v300-uni/README.md
+++ b/src/improvements/tasks/sep/012-opcm-update-prestate-v300-uni/README.md
@@ -1,6 +1,6 @@
 # 012-opcm-update-prestate-v300-uni: Sepolia Update Prestate v3.0.0: Unichain Sepolia
 
-Status: [READY TO SIGN]()
+https://sepolia.etherscan.io/tx/0xa781f19379990806ca91690e1abce8ce065016b3676c7a6a542389054c44b4dc
 
 ## Objective
 

--- a/src/improvements/tasks/sep/012-opcm-update-prestate-v300-uni/VALIDATION.md
+++ b/src/improvements/tasks/sep/012-opcm-update-prestate-v300-uni/VALIDATION.md
@@ -19,7 +19,7 @@ the values printed to the terminal when you run the task.
 > Before signing, ensure the below hashes match what is on your ledger.
 >
 > - Domain Hash: `0x2fedecce87979400ff00d5cec4c77da942d43ab3b9db4a5ffc51bb2ef498f30b`
-> - Message Hash: `0x3f060669a35f5e427a46039a88858c7fba405c20241a856141512d15e1118537`
+> - Message Hash: `0xae2f771c19884236a99b653504109a869d048a9782ff69d28788ac73dae52a2f`
 
 ## Understanding Task Calldata
 
@@ -95,12 +95,12 @@ Note: The changes listed below do not include threshold, nonce and owner mapping
   
 - **Key:**          `0x0000000000000000000000000000000000000000000000000000000000000005`
   - **Decoded Kind:**      `uint256`
-  - **Before:** `30`
-  - **After:** `31`
+  - **Before:** `31`
+  - **After:** `32`
   - **Summary:** Nonce update
   - **Detail:** Nonce update for the parent multisig. You can verify manually with the following:
-    - Before: `cast --to-dec 0x1e` = 30
-    - After: `cast --to-dec 0x1f` = 31
+    - Before: `cast --to-dec 0x1f` = 31
+    - After: `cast --to-dec 0x20` = 32
 
   ---
   

--- a/src/improvements/tasks/sep/012-opcm-update-prestate-v300-uni/config.toml
+++ b/src/improvements/tasks/sep/012-opcm-update-prestate-v300-uni/config.toml
@@ -23,8 +23,3 @@ OPCM = "0xfbceed4de885645fbded164910e10f52febfab35" # Sepolia op-contracts/v3.0.
 StandardValidatorV300 = "0x2d56022cb84ce6b961c3b4288ca36386bcd9024c" # Sepolia https://github.com/ethereum-optimism/optimism/blob/f79ed8b9c9cbdbf8bb492074f3f98da7f072e21a/op-validator/pkg/validations/addresses.go#L30
 FoundationUpgradeSafe = "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B" # Owner on the proxy admin owner
 SecurityCouncil = "0xf64bc17485f0B4Ea5F06A96514182FC4cB561977" # Owner on the proxy admin owner
-
-[stateOverrides]
-0xd363339eE47775888Df411A163c586a8BdEA9dbf = [
-     {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = "0x000000000000000000000000000000000000000000000000000000000000001e"}
-]


### PR DESCRIPTION
The unichain devs had added an additional owner to the SAFE wallet, which changed the Message Hash and nonce used in the VALIDATION script

<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
