### PR TITLE
fix: tight variable packing for uint supported in account access parser

### DIFF
--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -571,8 +571,8 @@ library AccountAccessParser {
         if (_slot == START_BLOCK_SLOT) {
             return DecodedSlot({
                 kind: "uint256",
-                oldValue: toUint(_oldValue),
-                newValue: toUint(_newValue),
+                oldValue: toUint256(_oldValue),
+                newValue: toUint256(_newValue),
                 summary: "Start block",
                 detail: "Unstructured storage slot for the start block number."
             });
@@ -620,8 +620,8 @@ library AccountAccessParser {
         if (_slot == REQUIRED_SLOT) {
             return DecodedSlot({
                 kind: "uint256",
-                oldValue: toUint(_oldValue),
-                newValue: toUint(_newValue),
+                oldValue: toUint256(_oldValue),
+                newValue: toUint256(_newValue),
                 summary: "Required protocol version",
                 detail: "Unstructured storage slot for the required protocol version."
             });
@@ -629,8 +629,8 @@ library AccountAccessParser {
         if (_slot == RECOMMENDED_SLOT) {
             return DecodedSlot({
                 kind: "uint256",
-                oldValue: toUint(_oldValue),
-                newValue: toUint(_newValue),
+                oldValue: toUint256(_oldValue),
+                newValue: toUint256(_newValue),
                 summary: "Recommended protocol version",
                 detail: "Unstructured storage slot for the recommended protocol version."
             });
@@ -705,9 +705,17 @@ library AccountAccessParser {
                 } else if (kind.eq("address")) {
                     oldValue = toAddress(_oldValue, offset);
                     newValue = toAddress(_newValue, offset);
-                } else if (kind.contains("uint")) {
-                    oldValue = toUint(_oldValue, offset);
-                    newValue = toUint(_newValue, offset);
+                    // We're not exhaustively handling all uint types here.
+                    // We will add more as needed.
+                } else if (kind.contains("uint32")) {
+                    oldValue = toUint32(_oldValue, offset);
+                    newValue = toUint32(_newValue, offset);
+                } else if (kind.contains("uint64")) {
+                    oldValue = toUint64(_oldValue, offset);
+                    newValue = toUint64(_newValue, offset);
+                } else if (kind.contains("uint256")) {
+                    oldValue = toUint256(_oldValue, offset);
+                    newValue = toUint256(_newValue, offset);
                 }
 
                 string memory label = layout[i]._label;
@@ -813,11 +821,19 @@ library AccountAccessParser {
         return vm.toString(address(uint160(uint256(_value) >> (_offset * 8))));
     }
 
-    function toUint(bytes32 _value) internal pure returns (string memory) {
-        return toUint(_value, 0);
+    function toUint256(bytes32 _value) internal pure returns (string memory) {
+        return toUint256(_value, 0);
     }
 
-    function toUint(bytes32 _value, uint256 _offset) internal pure returns (string memory) {
+    function toUint256(bytes32 _value, uint256 _offset) internal pure returns (string memory) {
         return vm.toString(uint256(_value) >> (_offset * 8));
+    }
+
+    function toUint32(bytes32 _value, uint256 _offset) internal pure returns (string memory) {
+        return vm.toString(uint32(uint256(_value) >> (_offset * 8)));
+    }
+
+    function toUint64(bytes32 _value, uint256 _offset) internal pure returns (string memory) {
+        return vm.toString(uint64(uint256(_value) >> (_offset * 8)));
     }
 }

--- a/test/libraries/AccountAccessParser.t.sol
+++ b/test/libraries/AccountAccessParser.t.sol
@@ -903,6 +903,18 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
         assertTrue(sortedDiffs[0].raw.slot < sortedDiffs[1].raw.slot, "Slots should be sorted");
     }
 
+    function test_tight_variable_packing_extractions_uint() public pure {
+        // [offset: 12, bytes: 4, value: 0x000f79c5, name: blobbasefeeScalar][offset: 8, bytes: 4, value: 0x0000146b, name: basefeeScalar] [offset: 0, bytes: 8, value: 60_000_000, name: gasLimit]
+        // Example taken from: lib/optimism/packages/contracts-bedrock/snapshots/storageLayout/SystemConfig.json (slot: 104)
+        bytes32 slotValue = bytes32(uint256(0x00000000000000000000000000000000000f79c50000146b0000000003938700));
+        string memory gasLimit = AccountAccessParser.toUint64(slotValue, 0);
+        assertEq(gasLimit, "60000000", "Failed to extract uint64 from bytes32");
+        string memory basefeeScalar = AccountAccessParser.toUint32(slotValue, 8);
+        assertEq(basefeeScalar, "5227", "Failed to extract uint32 from bytes32");
+        string memory blobbasefeeScalar = AccountAccessParser.toUint32(slotValue, 12);
+        assertEq(blobbasefeeScalar, "1014213", "Failed to extract uint32 from bytes32");
+    }
+
     function accountAccess(address _account, VmSafe.StorageAccess[] memory _storageAccesses)
         internal
         pure


### PR DESCRIPTION
We were seeing incorrect data in the auto generated state diffs when trying to decode slots that are packed. 