### PR TITLE
fix: Fetch latest storage layout from remote superchain-registry.

### DIFF
--- a/src/improvements/script/fetch-latest-storage-layout.sh
+++ b/src/improvements/script/fetch-latest-storage-layout.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# -----------------------------------------------------------
+# Script to fetch the latest storage layout for a given contract.
+#
+# This script:
+# 1. Reads the latest release tag from the main branch of the
+#    `superchain-registry` repository.
+# 2. Uses that tag to download the corresponding storage layout
+#    JSON file from the `optimism` monorepo.
+#
+# Usage:
+#   ./fetch-latest-storage-layout.sh <contract-name>
+#
+# Example:
+#   ./fetch-latest-storage-layout.sh L2StandardBridge
+#
+# Requirements:
+# - `curl` for HTTP requests
+# - `yq` for parsing the TOML standard-versions file
+#
+# Exits with an error if the contract name is missing or empty.
+# -----------------------------------------------------------
+
+contract_name_arg="${1:-}"
+
+# Check if contract name is unset or only whitespace
+if [[ -z "${contract_name_arg// }" ]]; then
+  echo "Usage: $0 <contract-name>"
+  echo "Error: Contract name is required and cannot be empty"
+  exit 1
+fi
+
+fetch_latest_storage_layout() {
+    local contract_name=$1
+    # Read from main branch of superchain-registry to ensure we're always using the latest release tag.
+    remote_url_standard_versions="https://raw.githubusercontent.com/ethereum-optimism/superchain-registry/refs/heads/main/validation/standard/standard-versions-mainnet.toml"
+    remote_toml_standard_versions=$(curl -sL "$remote_url_standard_versions")
+
+    latest_release_tag=$(echo "$remote_toml_standard_versions" | yq -p=toml 'keys | .[0]')
+
+    remote_url_storage_layout="https://raw.githubusercontent.com/ethereum-optimism/optimism/refs/tags/${latest_release_tag}/packages/contracts-bedrock/snapshots/storageLayout/${contract_name}.json"
+    remote_storage_layout=$(curl -sL "$remote_url_storage_layout")
+
+    echo "$remote_storage_layout"
+}
+
+fetch_latest_storage_layout "$contract_name_arg"

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -666,7 +666,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         VmSafe.AccountAccess[] memory accountAccesses,
         bool isSimulate,
         bytes32 txHash
-    ) public view {
+    ) public {
         if (!Utils.isFeatureEnabled("SIGNING_MODE_IN_PROGRESS")) {
             console.log("----------------- ATTENTION TASK DEVELOPERS -------------------");
             console.log("To properly document the task state changes, please follow these steps:");

--- a/test/libraries/AccountAccessParser.t.sol
+++ b/test/libraries/AccountAccessParser.t.sol
@@ -514,7 +514,7 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
         }
     }
 
-    function test_decode_succeeds() public view {
+    function test_decode_succeeds() public {
         // Test empty array
         {
             VmSafe.AccountAccess[] memory accesses = new VmSafe.AccountAccess[](0);
@@ -832,7 +832,7 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
         }
     }
 
-    function test_decode_sorts_decoded_state_diffs() public view {
+    function test_decode_sorts_decoded_state_diffs() public {
         // Create 5 test accounts with clear numerical values
         address account1 = address(0x1111111111111111111111111111111111111111);
         address account2 = address(0x2222222222222222222222222222222222222222);
@@ -873,7 +873,7 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
         assertEq(diffs[3].who, account4, "Fourth should be account4 (0x4444...)");
     }
 
-    function test_decode_reverts_if_state_diffs_not_sorted() public view {
+    function test_decode_reverts_if_state_diffs_not_sorted() public {
         address account1 = address(0x1);
         address account2 = address(0x2);
 


### PR DESCRIPTION
This is PR acts as a stepping stone to implement this issue: https://github.com/ethereum-optimism/superchain-ops/issues/339 

We are using the latest storage layout for a given contract to attempt decoding against. 