### PR TITLE
feat: mvp of normalized state diff

### DIFF
--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -78,6 +78,7 @@ library AccountAccessParser {
     }
 
     // Temporary struct used during deduplication.
+    // TODO Rename this, as it's also now used in `normalizedStateDiffHash`.
     struct TempStateChange {
         address who;
         bytes32 slot;
@@ -342,6 +343,10 @@ library AccountAccessParser {
         // which is a characteristic of an approve hash operation. We assume that if such a storage
         // change is seen in a very large slot, it is an approve hash operation. Setting modules
         // and guards in storage would not result in the slot having a value of 1.
+        // TODO Consider making this more robust to compute slots, if it adds value. In the safe
+        // storage layout, the only other mapping that sets slots to 1 is the `signedMessages`
+        // mapping but we don't use that. (The owners linked list can also have a value of 1 for the
+        // sentinel owner but that is only written when the safe is originally setup)
         return _diff.oldValue == bytes32(0) && _diff.newValue == bytes32(uint256(1))
             && _diff.slot > bytes32(uint256(0x1000000000));
     }

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -119,6 +119,8 @@ library AccountAccessParser {
     bytes32 internal constant GAS_PAYING_TOKEN_SLOT = bytes32(uint256(keccak256("opstack.gaspayingtoken")) - 1);
     bytes32 internal constant GAS_PAYING_TOKEN_NAME_SLOT = bytes32(uint256(keccak256("opstack.gaspayingtokenname")) - 1);
     bytes32 internal constant GAS_PAYING_TOKEN_SYMBOL_SLOT = bytes32(uint256(keccak256("opstack.gaspayingtokensymbol")) - 1);
+
+    bytes32 internal constant GNOSIS_SAFE_NONCE_SLOT = bytes32(uint256(5));
     // forgefmt: disable-end
 
     modifier noGasMetering() {
@@ -237,6 +239,127 @@ library AccountAccessParser {
         for (uint256 i = 0; i < count; i++) {
             newContracts[i] = temp[i];
         }
+    }
+
+    /// @notice Computes a hash of the normalized state diff from account accesses. The spec for
+    /// method is:
+    ///   1. The input is an array of `VmSafe.AccountAccess[]` containing all storage writes.
+    ///   2. It calls `AccountAccessParser.getUniqueWrites` to filter down all storage writes to a state diff
+    ///   3. With that state diff, we normalize it by removing data from the state diff array that
+    ///      may change between initial simulation and execution. Removal is done by simply removing
+    ///      the entry from the `AccountAccess[]` array. The set of state changes to remove is:
+    ///       1. If the state change is an EOA nonce increment, remove it.
+    ///       2. Remove the following state changes from Gnosis Safes:
+    ///           1. Nonce increments.
+    ///           2. Setting an approve hash in storage (the hash is dependent on the nonce, which may change)
+    ///       3. If the storage slot contains a timestamp, normalize that timestamp to be all zeroes.
+    ///           1. This will have to be informed by knowing the storage layouts, which is ok
+    ///           2. We should only normalize the specific section of the slot corresponding to the
+    ///              timestamp, since some timestamps are packed into slots with other data.
+    ///   4. The hash to return is computed as `keccak256(abi.encode(normalizedArray))`.
+    /// @return bytes32 hash of the normalized state diff
+    function normalizedStateDiffHash(VmSafe.AccountAccess[] memory _accountAccesses) internal view returns (bytes32) {
+        // Get all storage writes as a state diff.
+        address[] memory uniqueAddresses = getUniqueWrites({accesses: _accountAccesses, _sort: false});
+
+        // Create a temporary array to store normalized state changes.
+        // We set the size to 1000 because we will likely never have more than 1000 state changes.
+        uint256 maxStateChanges = 1000;
+        TempStateChange[] memory normalizedChanges = new TempStateChange[](maxStateChanges);
+        uint256 normalizedCount = 0;
+
+        // Process each account with storage writes.
+        for (uint256 i = 0; i < uniqueAddresses.length; i++) {
+            address account = uniqueAddresses[i];
+            StateDiff[] memory diffs = getStateDiffFor({accesses: _accountAccesses, who: account, _sort: false});
+
+            // Process each diff and apply normalization logic.
+            for (uint256 j = 0; j < diffs.length; j++) {
+                StateDiff memory diff = diffs[j];
+                bool shouldInclude = true;
+
+                // 1. If the state change is an EOA nonce increment, remove it.
+                if (isEOANonceIncrement(account, diff)) {
+                    shouldInclude = false;
+                }
+                // 2. Remove Gnosis Safe nonce increment and approve hash changes.
+                else if (isGnosisSafe(account)) {
+                    // 2.1 Nonce increment.
+                    if (isGnosisSafeNonceIncrement(diff)) {
+                        shouldInclude = false;
+                    }
+                    // 2.2 Setting an approve hash in storage.
+                    else if (isGnosisSafeApproveHash(diff)) {
+                        shouldInclude = false;
+                    }
+                }
+                // 3. If the slot contains a timestamp, normalize it to zeroes.
+                else if (slotContainsTimestamp(account, diff)) {
+                    diff = normalizeTimestamp(diff);
+                }
+
+                // Include the diff in our normalized array if it should be included.
+                if (shouldInclude) {
+                    normalizedChanges[normalizedCount] = TempStateChange({
+                        who: account,
+                        slot: diff.slot,
+                        firstOld: diff.oldValue,
+                        lastNew: diff.newValue
+                    });
+                    normalizedCount++;
+                    require(normalizedCount < maxStateChanges, "AccountAccessParser: Max state changes reached");
+                }
+            }
+        }
+
+        // Create the final array with the correct size.
+        TempStateChange[] memory finalArray = new TempStateChange[](normalizedCount);
+        for (uint256 i = 0; i < normalizedCount; i++) {
+            finalArray[i] = normalizedChanges[i];
+        }
+
+        // Return keccak256 hash of the abi-encoded normalized array.
+        return keccak256(abi.encode(finalArray));
+    }
+
+    /// @notice Checks if the state diff represents an EOA nonce increment
+    function isEOANonceIncrement(address _account, StateDiff memory _diff) internal view returns (bool) {
+        uint256 codeSize = _account.code.length;
+        return codeSize == 0 && _diff.slot == bytes32(0) && uint256(_diff.newValue) == uint256(_diff.oldValue) + 1;
+    }
+
+    /// @notice Checks if the state diff represents a Gnosis Safe nonce increment
+    function isGnosisSafeNonceIncrement(StateDiff memory _diff) internal pure returns (bool) {
+        // In Gnosis Safe, the nonce is stored at slot 5. See `GnosisSafeStorage.sol` to verify.
+        return _diff.slot == GNOSIS_SAFE_NONCE_SLOT && uint256(_diff.newValue) == uint256(_diff.oldValue) + 1;
+    }
+
+    /// @notice Checks if the state diff represents setting an approve hash in a Gnosis Safe
+    function isGnosisSafeApproveHash(StateDiff memory _diff) internal pure returns (bool) {
+        // In Gnosis Safe, approvedHashes is a mapping at slot 8
+        // The slot for a specific hash approval is calculated with the keccak256 hash of the address
+        // and slot. We can't know the specific slot value here, but we can detect a change from 0 to 1
+        // which is a characteristic of an approve hash operation. We assume that if such a storage
+        // change is seen in a very large slot, it is an approve hash operation. Setting modules
+        // and guards in storage would not result in the slot having a value of 1.
+        return _diff.oldValue == bytes32(0) && _diff.newValue == bytes32(uint256(1))
+            && _diff.slot > bytes32(uint256(0x1000000000));
+    }
+
+    /// @notice Checks if the storage slot contains a timestamp that should be normalized
+    function slotContainsTimestamp(address _account, StateDiff memory _diff) internal pure returns (bool) {
+        // TODO Check out the storage layout snapshots and hardcode the slots that contain timestamps.
+        // We will have to call getter methods on _account to infer what protocol contract it is.
+        _account;
+        _diff;
+        return false;
+    }
+
+    /// @notice Normalizes a timestamp in a storage slot by zeroing out only the timestamp portion
+    function normalizeTimestamp(StateDiff memory _diff) internal pure returns (StateDiff memory) {
+        // This is a placeholder that should be implemented based on specific contract knowledge
+        // For now, just return the original diff unchanged
+        return _diff;
     }
 
     /// @notice Extracts all unique storage writes (i.e. writes where the value has actually changed)

--- a/test/libraries/AccountAccessParser.t.sol
+++ b/test/libraries/AccountAccessParser.t.sol
@@ -1024,3 +1024,209 @@ contract AccountAccessParser_decodeAndPrint_Test is Test {
         }
     }
 }
+
+// TODO Add integration tests in a follow up PR that actually send transactions and use the recorded state diff.
+contract AccountAccessParser_normalizedStateDiffHash_Test is Test {
+    using AccountAccessParser for VmSafe.AccountAccess[];
+
+    bytes32 internal constant GNOSIS_SAFE_NONCE_SLOT = bytes32(uint256(5));
+
+    bool constant isWrite = true;
+    bool constant reverted = true;
+
+    bytes32 constant slot0 = bytes32(uint256(0));
+    bytes32 constant slot1 = bytes32(uint256(1));
+    bytes32 constant slot2 = bytes32(uint256(2));
+
+    bytes32 constant val0 = bytes32(uint256(0));
+    bytes32 constant val1 = bytes32(uint256(1));
+    bytes32 constant val2 = bytes32(uint256(2));
+
+    address constant EOA_ADDR = address(0x1111);
+    address constant SAFE_ADDR = address(0x2222);
+    address constant RANDOM_CONTRACT_ADDR = address(0x3333);
+
+    function setupTests() public {
+        bytes memory safeCode = hex"01";
+        vm.etch(SAFE_ADDR, safeCode);
+        vm.mockCall(SAFE_ADDR, abi.encodeWithSignature("getThreshold()"), abi.encode(uint256(1)));
+
+        assertTrue(AccountAccessParser.isGnosisSafe(SAFE_ADDR), "SAFE_ADDR should be detected as a Gnosis Safe");
+        assertEq(EOA_ADDR.code.length, 0, "EOA_ADDR should have no code");
+    }
+
+    function test_normalizedStateDiffHash_EOANonceIncrement() public {
+        setupTests();
+
+        // Create a state diff for an EOA nonce increment (should be removed)
+        VmSafe.StorageAccess[] memory storageAccesses = new VmSafe.StorageAccess[](1);
+        storageAccesses[0] = storageAccess(EOA_ADDR, slot0, isWrite, val0, val1); // nonce 0 -> 1
+
+        VmSafe.AccountAccess[] memory accesses = new VmSafe.AccountAccess[](1);
+        accesses[0] = accountAccess(EOA_ADDR, storageAccesses);
+
+        // Get the normalized hash
+        bytes32 hash = accesses.normalizedStateDiffHash();
+
+        // Since this is just an EOA nonce increment, the normalized array should be empty
+        // and the hash should match an empty array
+        AccountAccessParser.TempStateChange[] memory emptyArray = new AccountAccessParser.TempStateChange[](0);
+        bytes32 expectedHash = keccak256(abi.encode(emptyArray));
+
+        assertEq(hash, expectedHash, "EOA nonce increment should be removed");
+    }
+
+    function test_normalizedStateDiffHash_GnosisSafeNonceIncrement() public {
+        setupTests();
+
+        // Create a state diff for a Gnosis Safe nonce increment (should be removed)
+        VmSafe.StorageAccess[] memory storageAccesses = new VmSafe.StorageAccess[](1);
+        storageAccesses[0] = storageAccess(SAFE_ADDR, GNOSIS_SAFE_NONCE_SLOT, isWrite, val0, val1); // nonce 0 -> 1
+
+        VmSafe.AccountAccess[] memory accesses = new VmSafe.AccountAccess[](1);
+        accesses[0] = accountAccess(SAFE_ADDR, storageAccesses);
+
+        // Get the normalized hash
+        bytes32 hash = accesses.normalizedStateDiffHash();
+
+        // Since this is just a Safe nonce increment, the normalized array should be empty
+        // and the hash should match an empty array
+        AccountAccessParser.TempStateChange[] memory emptyArray = new AccountAccessParser.TempStateChange[](0);
+        bytes32 expectedHash = keccak256(abi.encode(emptyArray));
+
+        assertEq(hash, expectedHash, "Gnosis Safe nonce increment should be removed");
+    }
+
+    function test_normalizedStateDiffHash_GnosisSafeApproveHash() public {
+        setupTests();
+
+        // Create a fake approved hash slot, this is a simplification since actual slot number doesn't matter
+        bytes32 approveHashSlot = keccak256(abi.encode(0xaaaa));
+
+        // Create a state diff for a Gnosis Safe approve hash (should be removed)
+        VmSafe.StorageAccess[] memory storageAccesses = new VmSafe.StorageAccess[](1);
+        storageAccesses[0] = storageAccess(SAFE_ADDR, approveHashSlot, isWrite, val0, val1); // approve hash
+
+        VmSafe.AccountAccess[] memory accesses = new VmSafe.AccountAccess[](1);
+        accesses[0] = accountAccess(SAFE_ADDR, storageAccesses);
+
+        // Get the normalized hash
+        bytes32 hash = accesses.normalizedStateDiffHash();
+
+        // Since this is just a Safe approve hash, the normalized array should be empty
+        // and the hash should match an empty array
+        AccountAccessParser.TempStateChange[] memory emptyArray = new AccountAccessParser.TempStateChange[](0);
+        bytes32 expectedHash = keccak256(abi.encode(emptyArray));
+
+        assertEq(hash, expectedHash, "Gnosis Safe approve hash should be removed");
+    }
+
+    function test_normalizedStateDiffHash_OtherChanges() public {
+        setupTests();
+
+        // Create a state diff for a regular contract (should be included)
+        VmSafe.StorageAccess[] memory storageAccesses = new VmSafe.StorageAccess[](1);
+        storageAccesses[0] = storageAccess(RANDOM_CONTRACT_ADDR, slot1, isWrite, val0, val2); // some random change
+
+        VmSafe.AccountAccess[] memory accesses = new VmSafe.AccountAccess[](1);
+        accesses[0] = accountAccess(RANDOM_CONTRACT_ADDR, storageAccesses);
+
+        // Get the normalized hash
+        bytes32 hash = accesses.normalizedStateDiffHash();
+
+        // This should be included in the normalized array
+        AccountAccessParser.TempStateChange[] memory emptyArray = new AccountAccessParser.TempStateChange[](0);
+        assertNotEq(hash, keccak256(abi.encode(emptyArray)), "Regular state change should be included");
+
+        // Create the expected TempStateChange array
+        AccountAccessParser.TempStateChange[] memory expectedArray = new AccountAccessParser.TempStateChange[](1);
+        expectedArray[0] =
+            AccountAccessParser.TempStateChange({who: RANDOM_CONTRACT_ADDR, slot: slot1, firstOld: val0, lastNew: val2});
+
+        bytes32 expectedHash = keccak256(abi.encode(expectedArray));
+        assertEq(hash, expectedHash, "Hash should match the expected TempStateChange");
+    }
+
+    function test_normalizedStateDiffHash_MixedChanges() public {
+        setupTests();
+
+        // Create a fake approved hash slot for the Safe
+        bytes32 approveHashSlot = keccak256(abi.encode(0xbbbb));
+
+        // Create the combined account accesses array with all our test cases
+        VmSafe.AccountAccess[] memory allAccesses = new VmSafe.AccountAccess[](3);
+
+        // 1. EOA nonce increment (should be filtered out)
+        VmSafe.StorageAccess[] memory eoaStorageAccesses = new VmSafe.StorageAccess[](1);
+        eoaStorageAccesses[0] = storageAccess(EOA_ADDR, slot0, isWrite, val0, val1);
+        allAccesses[0] = accountAccess(EOA_ADDR, eoaStorageAccesses);
+
+        // 2. Gnosis Safe changes (should be filtered out)
+        VmSafe.StorageAccess[] memory safeStorageAccesses = new VmSafe.StorageAccess[](2);
+        safeStorageAccesses[0] = storageAccess(SAFE_ADDR, GNOSIS_SAFE_NONCE_SLOT, isWrite, val0, val1); // nonce increment
+        safeStorageAccesses[1] = storageAccess(SAFE_ADDR, approveHashSlot, isWrite, val0, val1); // approve hash
+        allAccesses[1] = accountAccess(SAFE_ADDR, safeStorageAccesses);
+
+        // 3. Regular contract change (should be kept)
+        VmSafe.StorageAccess[] memory regularStorageAccesses = new VmSafe.StorageAccess[](1);
+        regularStorageAccesses[0] = storageAccess(RANDOM_CONTRACT_ADDR, slot1, isWrite, val0, val2);
+        allAccesses[2] = accountAccess(RANDOM_CONTRACT_ADDR, regularStorageAccesses);
+
+        // Get the normalized hash
+        bytes32 hash = allAccesses.normalizedStateDiffHash();
+
+        // Manually construct what we expect the normalized state to be using TempStateChange
+        AccountAccessParser.TempStateChange[] memory expectedArray = new AccountAccessParser.TempStateChange[](1);
+        expectedArray[0] =
+            AccountAccessParser.TempStateChange({who: RANDOM_CONTRACT_ADDR, slot: slot1, firstOld: val0, lastNew: val2});
+
+        bytes32 expectedHash = keccak256(abi.encode(expectedArray));
+
+        // Now let's check that the regular contract write is included and other writes are excluded
+        AccountAccessParser.TempStateChange[] memory emptyArray = new AccountAccessParser.TempStateChange[](0);
+        assertTrue(
+            hash != keccak256(abi.encode(emptyArray)),
+            "Hash should not be of an empty array (regular writes should be included)"
+        );
+
+        assertEq(hash, expectedHash, "Normalized hash should match expected state with only regular contract changes");
+    }
+
+    // Helper functions similar to those in AccountAccessParser.t.sol
+    function accountAccess(address _account, VmSafe.StorageAccess[] memory _storageAccesses)
+        internal
+        pure
+        returns (VmSafe.AccountAccess memory)
+    {
+        return VmSafe.AccountAccess({
+            chainInfo: VmSafe.ChainInfo({chainId: 1, forkId: 1}),
+            kind: VmSafe.AccountAccessKind.Call,
+            account: _account,
+            accessor: address(0),
+            initialized: true,
+            oldBalance: 0,
+            newBalance: 0,
+            deployedCode: new bytes(0),
+            value: 0,
+            data: new bytes(0),
+            reverted: false,
+            storageAccesses: _storageAccesses,
+            depth: 0
+        });
+    }
+
+    function storageAccess(address _account, bytes32 _slot, bool _isWrite, bytes32 _previousValue, bytes32 _newValue)
+        internal
+        pure
+        returns (VmSafe.StorageAccess memory)
+    {
+        return VmSafe.StorageAccess({
+            account: _account,
+            slot: _slot,
+            isWrite: _isWrite,
+            previousValue: _previousValue,
+            newValue: _newValue,
+            reverted: false
+        });
+    }
+}


### PR DESCRIPTION
Adds a `normalizedStateDiffHash` method to the `AccountAccessParser` library return a normalized state diff hash for a recorded state diff. See the comments above that method for the spec.

There is some currently unimplemented functionality that can be done in a follow up PR, and this puts the scaffolding in place to align on how we normalize state diffs