### PR TITLE
feat: Enable audit hashing and txverify

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -6,6 +6,7 @@ import {console} from "forge-std/console.sol";
 import {Script} from "forge-std/Script.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {Test} from "forge-std/Test.sol";
+import {StdStyle} from "forge-std/StdStyle.sol";
 
 import {Signatures} from "@base-contracts/script/universal/Signatures.sol";
 import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
@@ -22,6 +23,7 @@ type AddressRegistry is address;
 abstract contract MultisigTask is Test, Script, StateOverrideManager {
     using EnumerableSet for EnumerableSet.AddressSet;
     using AccountAccessParser for VmSafe.AccountAccess[];
+    using StdStyle for string;
 
     /// @notice Parent nonce used for generating the safe transaction.
     uint256 public nonce;
@@ -338,8 +340,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     function printTitle(string memory title) private pure {
         // forgefmt: disable-start
         console.log("");
-        console.log(string.concat("\x1b[1m\x1b[36m", vm.toUppercase(title), "\x1b[0m"));
-        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
+        console.log(vm.toUppercase(title).cyan().bold());
+        string memory line = unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+        console.log(line.cyan().bold());
         // forgefmt: disable-end
     }
 
@@ -674,9 +677,10 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     ) public view {
         console.log("");
         // forgefmt: disable-start
-        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
-        console.log("\x1b[1m\x1b[36m                 WELCOME TO SUPERCHAIN-OPS\x1b[0m");
-        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
+        string memory line = unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+        console.log(line.cyan().bold());
+        console.log("                 WELCOME TO SUPERCHAIN-OPS");
+        console.log(line.cyan().bold());
         if (!Utils.isFeatureEnabled("SIGNING_MODE_IN_PROGRESS")) {
             printTitle("ATTENTION TASK DEVELOPERS");
             console.log("To properly document the task state changes, please follow these steps:");
@@ -701,7 +705,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
         console.log("");
         printTitle("AUDIT REPORT INFORMATION");
         // forgefmt: disable-start
-        console.log("The normalized state diff hash MUST match the hash created by the state changes attested to in the audit report.");
+        console.log("The normalized state diff hash MUST match the hash created by the state changes attested to in the state diff audit report.");
         console.log("As a signer, you are responsible for making sure this hash is correct. Please compare the hash below with the hash in the audit report.");
         bytes32 normalizedHash = AccountAccessParser.normalizedStateDiffHash(_accAccesses, _parentMultisig, _txHash);
         console.log("");

--- a/src/improvements/tasks/types/L2TaskBase.sol
+++ b/src/improvements/tasks/types/L2TaskBase.sol
@@ -6,9 +6,11 @@ import {SuperchainAddressRegistry} from "src/improvements/SuperchainAddressRegis
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import {console} from "forge-std/console.sol";
+import {StdStyle} from "forge-std/StdStyle.sol";
 
 abstract contract L2TaskBase is MultisigTask {
     using EnumerableSet for EnumerableSet.AddressSet;
+    using StdStyle for string;
 
     SuperchainAddressRegistry public superchainAddrRegistry;
 

--- a/src/improvements/tasks/types/L2TaskBase.sol
+++ b/src/improvements/tasks/types/L2TaskBase.sol
@@ -73,16 +73,11 @@ abstract contract L2TaskBase is MultisigTask {
                     try superchainAddrRegistry.get(config.allowedStorageKeys[i]) returns (address addr) {
                         _allowedStorageAccesses.add(addr);
                     } catch {
-                        console.log(
-                            "\x1B[33m[WARN]\x1B[0m Contract: %s not found for chain: '%s'",
-                            config.allowedStorageKeys[i],
-                            chains[j].name
-                        );
-                        console.log(
-                            "\x1B[33m[WARN]\x1B[0m Contract will not be added to allowed storage accesses: '%s' for chain: '%s'",
-                            config.allowedStorageKeys[i],
-                            chains[j].name
-                        );
+                        string memory warn = string("[WARN]").yellow().bold();
+                        // forgefmt: disable-start
+                        console.log(string.concat(warn, " Contract: ", config.allowedStorageKeys[i], " not found for chain: ", chains[j].name));
+                        console.log(string.concat(warn, " Contract will not be added to allowed storage accesses: ", config.allowedStorageKeys[i], " for chain: ", chains[j].name));
+                        // forgefmt: disable-end
                     }
                 }
             }

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -351,11 +351,6 @@ library AccountAccessParser {
         bytes32[] memory hashSlots = calculateApproveHashSlots(IGnosisSafe(_parentMultisig).getOwners(), _txHash);
         for (uint256 i = 0; i < hashSlots.length; i++) {
             if (_diff.slot == hashSlots[i]) {
-                console.log("approve hash slot found");
-                console.logBytes32(_diff.slot);
-                console.logBytes32(hashSlots[i]);
-                console.logBytes32(_diff.oldValue);
-                console.logBytes32(_diff.newValue);
                 require(
                     (_diff.oldValue == bytes32(0) && _diff.newValue == bytes32(uint256(1)))
                     // Some Gnosis Safe versions set approvedHashes to zero upon execution e.g. mainnet FoundationOperationsSafe.

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -532,7 +532,11 @@ library AccountAccessParser {
         address _parentMultisig,
         bytes32 _txHash
     ) internal view noGasMetering {
-        console.log("\n----------------- Task Transfers -------------------");
+        console.log("");
+        console.log(string.concat("\x1b[36mTASK TRANSFERS\x1b[0m"));
+        // forgefmt: disable-start
+        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
+        // forgefmt: disable-end
         if (_transfers.length == 0) {
             console.log("No ETH or ERC20 transfers.");
         } else {
@@ -546,11 +550,21 @@ library AccountAccessParser {
             }
         }
 
-        console.log("\n----------------- Task State Changes -------------------");
-        console.log("\n--- Attention: Copy content below this line into the VALIDATION.md file. ---");
+        console.log("");
+        console.log(string.concat("\x1b[36mTASK STATE CHANGES\x1b[0m"));
+        // forgefmt: disable-start
+        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
+        // forgefmt: disable-end
+        printCopyHelper("below");
         require(_stateDiffs.length > 0, "No state changes found, this is unexpected.");
         printMarkdown(_stateDiffs, _parentMultisig, _txHash);
-        console.log("\n\n --- Attention: Copy content above this line into the VALIDATION.md file. ---");
+        printCopyHelper("above");
+    }
+
+    function printCopyHelper(string memory _text) internal view noGasMetering {
+        // forgefmt: disable-start
+        console.log(string.concat("\x1b[33m", unicode"━━━━━", " Attention: Copy content ", _text, " this line into the VALIDATION.md file. ", unicode"━━━━━", "\x1b[0m"));
+        // forgefmt: disable-end
     }
 
     /// @notice Prints the decoded state diffs to the console in markdown format.

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -5,6 +5,7 @@ import {Vm, VmSafe} from "forge-std/Vm.sol";
 import {console} from "forge-std/console.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {StdStyle} from "forge-std/StdStyle.sol";
 import {LibString} from "@solady/utils/LibString.sol";
 import {LibSort} from "@solady/utils/LibSort.sol";
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
@@ -42,6 +43,7 @@ import {Utils} from "src/libraries/Utils.sol";
 library AccountAccessParser {
     using LibString for string;
     using stdJson for string;
+    using StdStyle for string;
 
     address internal constant ETHER = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     address internal constant ZERO = address(0);
@@ -311,20 +313,20 @@ library AccountAccessParser {
         view
         returns (bool)
     {
-        // 1. If the state change is an EOA nonce increment, remove it.
         if (isEOANonceIncrement(account, diff)) {
+            // 1. If the state change is an EOA nonce increment, remove it.
             return false;
-            // 2. Remove Gnosis Safe nonce increment and approve hash changes.
         } else if (isGnosisSafe(account)) {
-            // 2.1 Nonce increment or 2.2 Setting an approve hash in storage.
+            // 2. Remove Gnosis Safe nonce increment and approve hash changes.
             if (isGnosisSafeNonceIncrement(diff) || isGnosisSafeApproveHash(diff, _parentMultisig, _txHash)) {
+                // 2.1 Nonce increment or 2.2 Setting an approve hash in storage.
                 return false;
             }
-            // 3. If the slot contains a timestamp, normalize it to zeroes.
         } else if (slotContainsTimestamp(account, diff)) {
+            // 3. If the slot contains a timestamp, normalize it to zeroes.
             diff = normalizeTimestamp(diff);
-            // 4. If the slot is on the LivenessGuard, don't include it.
         } else if (isLivenessGuardTimestamp(account, diff, _parentMultisig)) {
+            // 4. If the slot is on the LivenessGuard, don't include it.
             return false;
         }
         return true;
@@ -533,10 +535,9 @@ library AccountAccessParser {
         bytes32 _txHash
     ) internal view noGasMetering {
         console.log("");
-        console.log(string.concat("\x1b[36mTASK TRANSFERS\x1b[0m"));
-        // forgefmt: disable-start
-        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
-        // forgefmt: disable-end
+        string memory line = unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+        console.log(string("TASK TRANSFERS").cyan().bold());
+        console.log(line.cyan().bold());
         if (_transfers.length == 0) {
             console.log("No ETH or ERC20 transfers.");
         } else {
@@ -551,10 +552,8 @@ library AccountAccessParser {
         }
 
         console.log("");
-        console.log(string.concat("\x1b[36mTASK STATE CHANGES\x1b[0m"));
-        // forgefmt: disable-start
-        console.log(string.concat("\x1b[36m", unicode"━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", "\x1b[0m"));
-        // forgefmt: disable-end
+        console.log(string("TASK STATE CHANGES").cyan().bold());
+        console.log(line.cyan().bold());
         printCopyHelper("below");
         require(_stateDiffs.length > 0, "No state changes found, this is unexpected.");
         printMarkdown(_stateDiffs, _parentMultisig, _txHash);
@@ -562,9 +561,11 @@ library AccountAccessParser {
     }
 
     function printCopyHelper(string memory _text) internal view noGasMetering {
+        string memory line = unicode"━━━━━";
         // forgefmt: disable-start
-        console.log(string.concat("\x1b[33m", unicode"━━━━━", " Attention: Copy content ", _text, " this line into the VALIDATION.md file. ", unicode"━━━━━", "\x1b[0m"));
+        string memory helper = string.concat(line, " Attention: Copy content ", _text, " this line into the VALIDATION.md file. ", line);
         // forgefmt: disable-end
+        console.log(helper.yellow().bold());
     }
 
     /// @notice Prints the decoded state diffs to the console in markdown format.
@@ -881,7 +882,7 @@ library AccountAccessParser {
         try vm.readFile(path) returns (string memory result) {
             storageLayout = result;
         } catch {
-            console.log("\x1B[33m[WARN]\x1B[0m Failed to read storage layout file at %s", path);
+            console.log(string.concat(string("[WARN]").yellow().bold(), "Failed to read storage layout file at ", path));
             return DecodedSlot({kind: "", oldValue: "", newValue: "", summary: "", detail: ""});
         }
         bytes memory parsedStorageLayout = vm.parseJson(storageLayout, "$");
@@ -992,8 +993,11 @@ library AccountAccessParser {
         // behind the latest release and it's expected that some addresses are not yet registered.
         if (!Utils.isFeatureEnabled("SIGNING_MODE_IN_PROGRESS")) {
             console.log(
-                "\x1B[33m[WARN]\x1B[0m Target address not found in superchain-registry (this message is safe to ignore): %s",
-                vm.toString(target)
+                string.concat(
+                    string("[WARN]").yellow().bold(),
+                    " Target address not found in superchain-registry (this message is safe to ignore): ",
+                    vm.toString(target)
+                )
             );
         }
         return (0, "");


### PR DESCRIPTION
Tried to add similar formatting/colors as op-txverify. This PR is safe to merge as it is only cosmetic and should be fine for existing in progress tasks in the signing ceremony if CI passes. We can let signers know to ignore the tx verify link along with the hash for now. 

### Screenshots
These screenshots show how the output in the terminal looks for signers. 
![CleanShot 2025-04-22 at 14 13 26@2x](https://github.com/user-attachments/assets/a4b66ea3-dae2-4b74-bfa5-31f5d22762c3)
![CleanShot 2025-04-22 at 14 13 17@2x](https://github.com/user-attachments/assets/3a714c23-8333-4b8e-a3c6-f0420fd44d4d)
