### PR TITLE
Add support for APPROVE_WITHOUT_LEDGER and EXECUTE_WITHOUT_LEDGER

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -38,6 +38,8 @@ Make sure your ledger is still unlocked and run the following commands depending
 
 Note: during development of the Solidity script, simulations can be run without any Ledger by exporting `SIMULATE_WITHOUT_LEDGER=1` in your shell, or by adding it to the `.env` file.
 
+Similarly, you can run approvals and executions without a Ledger device for testing purposes by using `APPROVE_WITHOUT_LEDGER=1` and `EXECUTE_WITHOUT_LEDGER=1` respectively.
+
 **Note:** Remember that by default the script will assume the derivation path of your address is `m/44'/60'/0'/0/0`.
 If you wish to use a different account, append an `X` to the command to set the derivation path of the address that you want to use. For example by adding a `1` to the end, it will derive the address using `m/44'/60'/1'/0/0` instead.
 
@@ -122,7 +124,7 @@ It will be a concatenation of `0x1901`, the domain hash, and the
 message hash: `0x1901[domain hash][message hash]`.
 
 Sometimes Tenderly can be buggy and may not show this function call in the simulator trace.
-If that happens, try refreshing the simulation link. If it still doesn’t show up, please contact the ceremony facilitator.
+If that happens, try refreshing the simulation link. If it still doesn't show up, please contact the ceremony facilitator.
 Make sure not to confuse this function call with the second `GnosisSafe.checkSignatures` call.
 
 Note down this value. You will need to compare it with the ones

--- a/SINGLE.md
+++ b/SINGLE.md
@@ -46,6 +46,13 @@ Make sure your ledger is still unlocked and run the following command.
 **Note:** Remember that by default the script will assume the derivation path of your address is `m/44'/60'/0'/0/0`.
 If you wish to use a different account, append an `X` to the command to set the derivation path of the address that you want to use. For example by adding a `1` to the end, it will derive the address using `m/44'/60'/1'/0/0` instead.
 
+**Development Note:** During development or testing, you can run simulations, approvals, and executions without a Ledger device by using the following environment variables:
+- `SIMULATE_WITHOUT_LEDGER=1`: Simulates the transaction without requiring a Ledger device
+- `APPROVE_WITHOUT_LEDGER=1`: Approves the transaction without requiring a Ledger device
+- `EXECUTE_WITHOUT_LEDGER=1`: Executes the transaction without requiring a Ledger device
+
+These can be exported in your shell or added to the `.env` file.
+
 ```shell
 just \
    --dotenv-path $(pwd)/.env \

--- a/nested.just
+++ b/nested.just
@@ -60,7 +60,7 @@ simulate whichSafe hdPath='0':
     signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
     echo "Simulating with ledger account: ${signer}"
   else
-      echo "Simulating without ledger using the first owner account: ${signer}"
+    echo "Simulating without ledger using the first owner account: ${signer}"
   fi
   echo ""
 
@@ -96,19 +96,33 @@ sign whichSafe hdPath='0':
     fi
     safe="{{chainGovernorSafe}}"
   fi
-  echo "getting signer address..."
-  signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-  echo "Signing with: ${signer}"
-  echo ""
+  
+  if [ ! -z "$APPROVE_WITHOUT_LEDGER" ]; then
+    signer=$(cast call ${safe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+    echo "Signing without ledger using the first owner account: ${signer}"
+    
+    forge build
+    forge script ${script} \
+      --rpc-url ${rpcUrl} \
+      --sender ${signer} \
+      --sig "signJson(string,address)" \
+      ${bundlePath} \
+      "${safe}"
+  else
+    echo "getting signer address..."
+    signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Signing with: ${signer}"
+    echo ""
 
-  forge build
-  # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.
-  $(git rev-parse --show-toplevel)/bin/eip712sign --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" -- \
-  forge script ${script} \
-    --rpc-url ${rpcUrl} \
-    --sig "signJson(string,address)" \
-    ${bundlePath} \
-    "${safe}"
+    forge build
+    # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.
+    $(git rev-parse --show-toplevel)/bin/eip712sign --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" -- \
+    forge script ${script} \
+      --rpc-url ${rpcUrl} \
+      --sig "signJson(string,address)" \
+      ${bundlePath} \
+      "${safe}"
+  fi
 
 ## approvehash_in_anvil is a function to generate the nested hash and approve the hash for the given safes (SC, or FND) for later executing during the simulation using the execute_in_anvil function.
 approvehash_in_anvil whichSafe hdPath='0':
@@ -253,18 +267,35 @@ approve whichSafe hdPath='0':
     fi
     safe="{{chainGovernorSafe}}"
   fi
-  sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-
-  forge build
-  forge script ${script} \
-    --fork-url ${rpcUrl} \
-    --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
-    --broadcast \
-    --sender ${sender} \
-    --sig "approveJson(string,address,bytes)" \
-    ${bundlePath} \
-    ${safe} \
-    ${signatures}
+  
+  if [ ! -z "$APPROVE_WITHOUT_LEDGER" ]; then
+    sender=$(cast call ${safe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+    echo "Approving without ledger using the first owner account: ${sender}"
+    
+    forge build
+    forge script ${script} \
+      --fork-url ${rpcUrl} \
+      --sender ${sender} \
+      --broadcast \
+      --sig "approveJson(string,address,bytes)" \
+      ${bundlePath} \
+      ${safe} \
+      ${signatures}
+  else
+    sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Approving with ledger account: ${sender}"
+    
+    forge build
+    forge script ${script} \
+      --fork-url ${rpcUrl} \
+      --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
+      --broadcast \
+      --sender ${sender} \
+      --sig "approveJson(string,address,bytes)" \
+      ${bundlePath} \
+      ${safe} \
+      ${signatures}
+  fi
 
 execute hdPath='0':
   #!/usr/bin/env bash
@@ -275,15 +306,30 @@ execute hdPath='0':
     echo "Running script with assertions"
   fi
   echo "Using script ${script}"
-  sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-
-  forge script ${script} \
-    --fork-url ${rpcUrl} \
-    --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
-    --broadcast \
-    --sender ${sender} \
-    --sig "runJson(string)" \
-    ${bundlePath}
+  
+  if [ ! -z "$EXECUTE_WITHOUT_LEDGER" ]; then
+    sender=$(cast call ${ownerSafe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+    echo "Executing without ledger using the first owner account: ${sender}"
+    
+    forge build
+    forge script ${script} \
+      --fork-url ${rpcUrl} \
+      --sender ${sender} \
+      --broadcast \
+      --sig "runJson(string)" \
+      ${bundlePath}
+  else
+    sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Executing with ledger account: ${sender}"
+    
+    forge script ${script} \
+      --fork-url ${rpcUrl} \
+      --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" \
+      --broadcast \
+      --sender ${sender} \
+      --sig "runJson(string)" \
+      ${bundlePath}
+  fi
 
 simulated-run hdPath='0':
   #!/usr/bin/env bash

--- a/single.just
+++ b/single.just
@@ -99,10 +99,11 @@ simulate hdPath='0':
 
   if [ ! -z "$SIMULATE_WITHOUT_LEDGER" ]; then
     signer=$(cast call ${ownerSafe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+    echo "Simulating without ledger using the first owner account: ${signer}"
   else
     signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Simulating with ledger account: ${signer}"
   fi
-  echo "Simulating with: ${signer}"
   echo ""
 
   root_dir=$(git rev-parse --show-toplevel)
@@ -128,18 +129,31 @@ sign hdPath='0':
     script="${taskPath}/SignFromJson.s.sol"
   fi
   echo "Using script ${script}"
-  echo "getting signer address..."
-  signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-  echo "Signing with: ${signer}"
-  echo ""
 
-  forge build
-  # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.
-  $(git rev-parse --show-toplevel)/bin/eip712sign --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" -- \
-  forge script ${script} \
-    --rpc-url ${rpcUrl} \
-    --sig "signJson(string)" \
-    ${bundlePath}
+  if [ ! -z "$APPROVE_WITHOUT_LEDGER" ]; then
+    signer=$(cast call ${ownerSafe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+    echo "Signing without ledger using the first owner account: ${signer}"
+    
+    forge build
+    forge script ${script} \
+      --rpc-url ${rpcUrl} \
+      --sig "signJson(string)" \
+      ${bundlePath} \
+      --sender ${signer}
+  else
+    echo "getting signer address..."
+    signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Signing with: ${signer}"
+    echo ""
+
+    forge build
+    # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.
+    $(git rev-parse --show-toplevel)/bin/eip712sign --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" -- \
+    forge script ${script} \
+      --rpc-url ${rpcUrl} \
+      --sig "signJson(string)" \
+      ${bundlePath}
+  fi
 
 execute_in_anvil hdPath='0':
   #!/usr/bin/env bash
@@ -173,10 +187,22 @@ execute hdPath='0':
     script="${taskPath}/SignFromJson.s.sol"
   fi
   echo "Using script ${script}"
-  sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-
-  forge build
-  forge script --fork-url ${ETH_RPC_URL} ${script} \
-    --sig "runJson(string,bytes)" ${bundlePath} ${SIGNATURES} \
-    --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" --broadcast \
-    --sender ${sender}
+  
+  if [ ! -z "$EXECUTE_WITHOUT_LEDGER" ]; then
+    sender=$(cast call ${ownerSafe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+    echo "Executing without ledger using the first owner account: ${sender}"
+    
+    forge build
+    forge script --fork-url ${rpcUrl} ${script} \
+      --sig "runJson(string,bytes)" ${bundlePath} ${SIGNATURES} \
+      --sender ${sender} --broadcast
+  else
+    sender=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+    echo "Executing with ledger account: ${sender}"
+    
+    forge build
+    forge script --fork-url ${ETH_RPC_URL} ${script} \
+      --sig "runJson(string,bytes)" ${bundlePath} ${SIGNATURES} \
+      --ledger --hd-paths "m/44'/60'/{{hdPath}}'/0/0" --broadcast \
+      --sender ${sender}
+  fi

--- a/src/improvements/NESTED.md
+++ b/src/improvements/NESTED.md
@@ -38,6 +38,8 @@ Make sure your ledger is still unlocked and run the following commands depending
 
 Note: during development of the Solidity script, simulations can be run without any Ledger by exporting `SIMULATE_WITHOUT_LEDGER=1` in your shell, or by adding it to the `.env` file.
 
+Similarly, you can run approvals and executions without a Ledger device for testing purposes by using `APPROVE_WITHOUT_LEDGER=1` and `EXECUTE_WITHOUT_LEDGER=1` respectively.
+
 **Note:** Remember that by default the script will assume the derivation path of your address is `m/44'/60'/0'/0/0`.
 If you wish to use a different account, append an `X` to the command to set the derivation path of the address that you want to use. For example by adding a `1` to the end, it will derive the address using `m/44'/60'/1'/0/0` instead.
 

--- a/src/improvements/SINGLE.md
+++ b/src/improvements/SINGLE.md
@@ -46,6 +46,13 @@ Make sure your ledger is still unlocked and run the following command.
 **Note:** Remember that by default the script will assume the derivation path of your address is `m/44'/60'/0'/0/0`.
 If you wish to use a different account, append an `X` to the command to set the derivation path of the address that you want to use. For example by adding a `1` to the end, it will derive the address using `m/44'/60'/1'/0/0` instead.
 
+**Development Note:** During development or testing, you can run simulations, approvals, and executions without a Ledger device by using the following environment variables:
+- `SIMULATE_WITHOUT_LEDGER=1`: Simulates the transaction without requiring a Ledger device
+- `APPROVE_WITHOUT_LEDGER=1`: Approves the transaction without requiring a Ledger device
+- `EXECUTE_WITHOUT_LEDGER=1`: Executes the transaction without requiring a Ledger device
+
+These can be exported in your shell or added to the `.env` file.
+
 ```shell
 just \
    --dotenv-path $(pwd)/.env \


### PR DESCRIPTION
## Description:
Similar to how the codebase already supports SIMULATE_WITHOUT_LEDGER for simulating transactions without requiring a Ledger device for testing purposes, this PR adds support for APPROVE_WITHOUT_LEDGER and EXECUTE_WITHOUT_LEDGER environment variables to allow approving and executing transactions without a Ledger device.
These environment variables follow the same pattern as SIMULATE_WITHOUT_LEDGER - when set, they use the first owner of the Safe for signing/execution, eliminating the need for a physical Ledger device during development and testing.

## Changes:
Added APPROVE_WITHOUT_LEDGER support to both single.just and nested.just
Added EXECUTE_WITHOUT_LEDGER support to both single.just and nested.just
Updated documentation in both SINGLE.md and NESTED.md files (including their src/improvements versions)
Improved the simulation message outputs to be consistent with the new approve and execute messages

## Testing:
The changes have been tested by running simulate, approve, and execute commands with the environment variables set.