### PR TITLE
Replace deprecated releases.json with fetcher.go reference

### DIFF
--- a/tasks/sep/030-revert-mt-cannon/VALIDATION.md
+++ b/tasks/sep/030-revert-mt-cannon/VALIDATION.md
@@ -125,6 +125,6 @@ Now: "1.2.1"
 In both, there are two changes:
 
 * absolutePrestate() changes from `0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b` to `0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568`. 
-  These can be verified by comparing to the values in [releases.json](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/prestates/releases.json).
+  These can be verified by comparing to the values in [fetcher.go](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/prestates/fetcher.go).
   The old absolute prestate is the cannon64 variant of the 1.4.0 release, the new one is the governance approved, single-threaded cannon version from the same 1.4.0 release.
 * vm - the MIPS.sol version. This reverts from the MIPS64.sol beta version back to the governance approved version 1.2.1 from the contracts/1.8.0 (Holocene) release.

--- a/validation/PRESTATE-VALIDATION.md
+++ b/validation/PRESTATE-VALIDATION.md
@@ -6,7 +6,7 @@ The referenced program should be a valid release of `op-program`.
 
 ## Releases.json
 All `op-program` releases are documented in
-[releases.json](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/prestates/releases.json).
+[fetcher.go](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/prestates/fetcher.go).
 
 For example, here is a subset of documented releases:
 ```json


### PR DESCRIPTION
Replaced broken links to releases.json with references to fetcher.go, which now handles standard prestates.

The old releases.json file no longer exists in the repository, and fetcher.go is the updated source of truth.

If you have a better suggestion for referencing standard prestates, feel free to propose it.