### PR TITLE
docs: README.md update for stacked simulation inclusion.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,22 +545,6 @@ workflows:
       - just_simulate_sc_rehearsal_4:
           context:
             - circleci-repo-readonly-authenticated-github-token
-
-      - simulate_sequence:
-          name: simulate_sequence_eth
-          network: "eth"
-          tasks: ""
-          block_number: "" # If not specified, the latest block number is used.
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-
-      - simulate_sequence:
-          name: simulate_sequence_sep
-          network: "sep"
-          tasks: ""
-          block_number: "" # If not specified, the latest block number is used.
-          context:
-            - circleci-repo-readonly-authenticated-github-token
             
       # Stacked simulations for superchain-ops on Mainnet.
       - stacked_simulation:

--- a/src/improvements/README.md
+++ b/src/improvements/README.md
@@ -58,6 +58,7 @@ SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../sin
 ```
 
 4. Fill out the `README.md` and `VALIDATION.md` files.
+    - If your task status is not `EXECUTED` or `CANCELLED`, it is considered non-terminal and will automatically be included in stacked simulations (which run on the main branch).
 
 ### How do I run a task that depends on another task?
 


### PR DESCRIPTION
Clarifying _when_ a task gets added to the stacked simulation execution and where (`main` branch). 