### PR TITLE
fix: mark gas target increase task as cancelled.

### DIFF
--- a/src/improvements/tasks/eth/006-gas-params-op/README.md
+++ b/src/improvements/tasks/eth/006-gas-params-op/README.md
@@ -1,6 +1,8 @@
 # 006-gas-params-op: (Ethereum) Increase gas target : OP Mainnet
 
-Status: [READY TO SIGN]()
+Status: [CANCELLED]()
+
+(This task was cancelled in favor of created two new tasks. The idea is to opt of a more incremental approach to increasing the gas target.)
 
 ## Objective
 


### PR DESCRIPTION
We're going to opt for an approach that slowly increases the gas target instead of doing this increase in one single upgrade. 