### PR TITLE
bug: All child multisig safes have their nonces checked.

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -1115,8 +1115,15 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
     function _overrideState(string memory taskConfigFilePath) private {
         _setStateOverridesFromConfig(taskConfigFilePath); // Sets global '_stateOverrides' variable.
         nonce = _getNonceOrOverride(address(parentMultisig));
+        address[] memory owners = IGnosisSafe(parentMultisig).getOwners();
         if (childMultisig != address(0)) {
-            childNonce = _getNonceOrOverride(address(childMultisig));
+            for (uint256 i = 0; i < owners.length; i++) {
+                if (owners[i] == childMultisig) {
+                    childNonce = _getNonceOrOverride(address(childMultisig));
+                } else {
+                    _getNonceOrOverride(owners[i]); // Nonce safety checks need to be performed for each owner.
+                }
+            }
         }
         // We must do this after setting the nonces above. It allows us to make sure we're reading the correct network state when setting the nonces.
         _applyStateOverrides(); // Applies '_stateOverrides' to the current state.


### PR DESCRIPTION
I realized there was a bug in the nonce checking on the new stacked simulations. The fix is simple, I just need to call `_getNonceOrOverride` for _all_ owners in a nested multisig.