### PR TITLE
refactor(part1): Consolidate simulate command.

### DIFF
--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -178,20 +178,7 @@ simulate-stack NETWORK="" TASK="" OWNER_ADDRESS="0x00000000000000000000000000000
     }
 
     export FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-default}"
-
-    case "{{NETWORK}}" in
-        sep)
-            ETH_RPC_URL=$(yq eval ".profile.\"${FOUNDRY_PROFILE}\".rpc_endpoints.sepolia" "${root_dir}/foundry.toml")
-            ;;
-        eth)
-            ETH_RPC_URL=$(yq eval ".profile.\"${FOUNDRY_PROFILE}\".rpc_endpoints.mainnet" "${root_dir}/foundry.toml")
-            ;;
-        *)
-            echo -e "\n\033[31mError: Invalid network '{{NETWORK}}'\033[0m"
-            show_usage
-            exit 1
-            ;;
-    esac
+    ETH_RPC_URL=$(just _fetch-rpc-url "{{NETWORK}}")
     
     echo -e "\n⏳ Stacked Task simulation in progress. This may take a while..."
     if [ -z "{{TASK}}" ]; then
@@ -237,7 +224,102 @@ list-stack NETWORK="" TASK="":
         forge script ${root_dir}/src/improvements/tasks/StackedSimulator.sol:StackedSimulator --sig "listStack(string,string)" {{NETWORK}} {{TASK}}
     fi
 
+########################
+## Simulate command ##
+########################
+
+# This command is used to simulate a task. It automatically figures out if the safe is nested or not.
+[no-cd] # This means that the $PWD is wherever this command is executed from.
+simulate whichSafe="" hdPath="0":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root_dir=$(git rev-parse --show-toplevel)
+
+    echo -e "\033[42m                                         \033[0m"
+    echo -e "\033[42m     superchain-ops task simulation      \033[0m"
+    echo -e "\033[42m                                         \033[0m"
+
+    show_usage() {
+        echo
+        echo "Usage: just simulate [safe-name] [hd-path]"
+        echo "Available arguments:"
+        echo "  • [safe-name]  - e.g. foundation, council, chain-governor, foundation-operations, base-operations"
+        echo "  • [hd-path]    - e.g. '0' for 'm/44'/60'/[hd-path]'/0/0' "
+        echo ""
+        echo "Environment variables:"
+        echo "  • SIMULATE_WITHOUT_LEDGER - If set, the simulation will not use a ledger account. Instead, it will use the default foundry account (e.g. '1' or 'true')."
+        echo "  • FORK_BLOCK_NUMBER - If set, the simulation will use a specific block number for the fork. Otherwise, it will use the latest block. (e.g. '22420467')"
+    }
+
+    if [ "{{whichSafe}}" = "-h" ] || [ "{{whichSafe}}" = "--help" ]; then
+        show_usage
+        exit 0
+    fi
+
+    network=$(basename "$(dirname "$PWD")")
+    export FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-default}"
+    ETH_RPC_URL=$(just _fetch-rpc-url $network)
+    safe=$(just _fetch-safe "{{whichSafe}}")
+    signer=$(just _fetch-signer "{{hdPath}}")
+    fork_block_arg=$(just _fetch-fork-block-number)
+    task_path=$(PWD)
+
+    echo "⏳ Task simulation in progress. Some tasks take longer than others..."
+    if [ -n "$task_path" ]; then
+        echo -e "⏳ You are simulating task: $task_path\n"
+        forge script ${root_dir}/src/improvements/tasks/StackedSimulator.sol:StackedSimulator --sig "simulateTask(string,address)" $task_path $safe --ffi --rpc-url $ETH_RPC_URL --sender $signer $fork_block_arg 
+    fi
+
 test:
     forge build
     forge test
     just simulate-all-templates
+
+########################
+## Helper functions ##
+########################
+# not intended for end users
+_fetch-rpc-url NETWORK="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    profile="${FOUNDRY_PROFILE:-default}"
+    case "{{NETWORK}}" in
+      sep)  yq eval ".profile.\"${profile}\".rpc_endpoints.sepolia" "$(git rev-parse --show-toplevel)/foundry.toml" ;;
+      eth)  yq eval ".profile.\"${profile}\".rpc_endpoints.mainnet" "$(git rev-parse --show-toplevel)/foundry.toml" ;;
+      *)    echo "Error: Invalid network '{{NETWORK}}'" >&2; exit 1 ;;
+    esac
+
+_fetch-fork-block-number:
+    #!/usr/bin/env bash
+    FORK_BLOCK_NUMBER=${FORK_BLOCK_NUMBER:-"-1"}
+    if [ "${FORK_BLOCK_NUMBER}" = "-1" ]; then
+        fork_block_arg=""
+    else
+        echo "⏳ Using fork block number from env: ${FORK_BLOCK_NUMBER}" >&2
+        echo "--fork-block-number ${FORK_BLOCK_NUMBER}"
+    fi
+
+_fetch-signer hdPath:
+    #!/usr/bin/env bash
+    SIMULATE_WITHOUT_LEDGER=${SIMULATE_WITHOUT_LEDGER:-}
+    if [ -z "${SIMULATE_WITHOUT_LEDGER}" ]; then
+        signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
+        echo "⏳ Simulating with ledger account: ${signer}" >&2
+    else
+        # Default signer: address(uint160(uint256(keccak256("foundry default caller"))))
+        signer="0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38"
+        echo "⏳ Simulating without ledger using the default foundry account: ${signer}" >&2
+    fi
+    echo "${signer}"
+
+[no-cd] 
+_fetch-safe whichSafe:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root_dir=$(git rev-parse --show-toplevel)
+    safe="0x0000000000000000000000000000000000000000" # Default to zero address for non-nested safes
+    if [ -n "{{whichSafe}}" ]; then
+        safe=$(bash ${root_dir}/src/improvements/script/get-safe.sh $PWD "{{whichSafe}}")
+        echo "⏳ You're simulating as safe: $safe ({{whichSafe}})" >&2
+    fi
+    echo "${safe}"

--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -264,7 +264,7 @@ simulate whichSafe="" hdPath="0":
     safe=$(just --justfile="$root_just_file" _fetch-safe "{{whichSafe}}")
     signer=$(just --justfile="$root_just_file" _fetch-signer "{{hdPath}}")
     fork_block_arg=$(just --justfile="$root_just_file" _fetch-fork-block-number)
-    task_path=$(PWD)
+    task_path="$PWD"
 
     echo "⏳ Task simulation in progress. Some tasks take longer than others..."
     if [ -n "$task_path" ]; then

--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -234,6 +234,7 @@ simulate whichSafe="" hdPath="0":
     #!/usr/bin/env bash
     set -euo pipefail
     root_dir=$(git rev-parse --show-toplevel)
+    root_just_file="${root_dir}/src/improvements/justfile"
 
     echo -e "\033[42m                                         \033[0m"
     echo -e "\033[42m     superchain-ops task simulation      \033[0m"
@@ -258,10 +259,11 @@ simulate whichSafe="" hdPath="0":
 
     network=$(basename "$(dirname "$PWD")")
     export FOUNDRY_PROFILE="${FOUNDRY_PROFILE:-default}"
-    ETH_RPC_URL=$(just _fetch-rpc-url $network)
-    safe=$(just _fetch-safe "{{whichSafe}}")
-    signer=$(just _fetch-signer "{{hdPath}}")
-    fork_block_arg=$(just _fetch-fork-block-number)
+    # ETH_RPC_URL=$(just _fetch-rpc-url $network)
+    ETH_RPC_URL=$(just --justfile="$root_just_file" _fetch-rpc-url "$network")
+    safe=$(just --justfile="$root_just_file" _fetch-safe "{{whichSafe}}")
+    signer=$(just --justfile="$root_just_file" _fetch-signer "{{hdPath}}")
+    fork_block_arg=$(just --justfile="$root_just_file" _fetch-fork-block-number)
     task_path=$(PWD)
 
     echo "⏳ Task simulation in progress. Some tasks take longer than others..."

--- a/src/improvements/nested.just
+++ b/src/improvements/nested.just
@@ -22,49 +22,6 @@ export PRIVATE_KEY_OWNER := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efca
 export PRIVATE_KEY_EXECUTOR :="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 export FAKE_SIG :="11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
 
-simulate whichSafe hdPath='0':
-  #!/usr/bin/env bash
-  # Get the appropriate safe address based on whichSafe
-  safe=$(bash ${SCRIPT_PATH}/script/get-safe.sh ${TASK_PATH} "{{whichSafe}}")
-
-  echo "RPC URL: ${rpcUrl}"
-
-  config=${TASK_PATH}/config.toml
-  script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
-
-  echo "Using script ${script}"
-  echo "getting signer address for {{whichSafe}}..."
-  signer=$(cast call ${safe} "getOwners()(address[])" -r ${rpcUrl} | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
-
-  echo "safe: $safe"
-  echo "Simulating call to {{whichSafe}} at ${safe}"
-  if [ -z "$SIMULATE_WITHOUT_LEDGER" ]; then
-    signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-    echo "Simulating with ledger account: ${signer}"
-  else
-      echo "Simulating without ledger using the first owner account: ${signer}"
-  fi
-  echo ""
-
-  # Allow simulating from a specific block by setting FORK_BLOCK_NUMBER in the tasks .env file.
-  # If not set (or set to -1), default to using the latest block.
-  if [ "${forkBlockNumber}" = "-1" ]; then
-    fork_block_arg=""
-  else
-    echo "Using fork block number from env: ${forkBlockNumber}"
-    fork_block_arg="--fork-block-number ${forkBlockNumber}"
-  fi
-
-  echo "⏳ Task simulation in progress. Some tasks take longer than others..."
-  forge build
-  forge script ${script} \
-    ${fork_block_arg} \
-    --rpc-url ${rpcUrl} \
-    --sender ${signer} \
-    --sig "simulateAsSigner(string,address)" \
-    ${config} \
-    ${safe}
-
 sign whichSafe hdPath='0':
   #!/usr/bin/env bash
   # Get the appropriate safe address based on whichSafe

--- a/src/improvements/script/simulate-task.sh
+++ b/src/improvements/script/simulate-task.sh
@@ -27,10 +27,10 @@ simulate_task() {
             echo "Error: this task requires a nested safe name e.g. foundation, council, chain-governor."
             exit 1
         fi
-        SIMULATE_WITHOUT_LEDGER=1 just --justfile "$just_file" simulate "$nested_safe_name"
+        SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path "$(pwd)"/.env --justfile "$just_file" simulate "$nested_safe_name"
     else
         echo "Simulating single task: $task"
-        SIMULATE_WITHOUT_LEDGER=1 just --justfile "$just_file" simulate
+        SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path "$(pwd)"/.env --justfile "$just_file" simulate
     fi
 
     echo -e "\n\nDone simulating task: $task"

--- a/src/improvements/script/simulate-task.sh
+++ b/src/improvements/script/simulate-task.sh
@@ -8,8 +8,7 @@ simulate_task() {
     task=$1
     nested_safe_name=$2
     root_dir=$(git rev-parse --show-toplevel)
-    nested_just_file="${root_dir}/src/improvements/nested.just"
-    single_just_file="${root_dir}/src/improvements/single.just"
+    just_file="${root_dir}/src/improvements/justfile"
 
     if [ -z "$task" ]; then
         echo "Error: task path is required"
@@ -28,10 +27,10 @@ simulate_task() {
             echo "Error: this task requires a nested safe name e.g. foundation, council, chain-governor."
             exit 1
         fi
-        SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path "$(pwd)"/.env --justfile "$nested_just_file" simulate "$nested_safe_name"
+        SIMULATE_WITHOUT_LEDGER=1 just --justfile "$just_file" simulate "$nested_safe_name"
     else
         echo "Simulating single task: $task"
-        SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path "$(pwd)"/.env --justfile "$single_just_file" simulate
+        SIMULATE_WITHOUT_LEDGER=1 just --justfile "$just_file" simulate
     fi
 
     echo -e "\n\nDone simulating task: $task"

--- a/src/improvements/single.just
+++ b/src/improvements/single.just
@@ -18,48 +18,11 @@ export forkBlockNumber := env_var_or_default('FORK_BLOCK_NUMBER', '-1')
 # Default signer: address(uint160(uint256(keccak256("foundry default caller"))))
 export signerAddress := env_var_or_default('SIGNER_ADDRESS', '0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38')
 
-
 # Simulate sequence execution variables
 export ANVIL_LOCALHOST_RPC :="http://localhost:8545"
 export PRIVATE_KEY_OWNER := "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
 export PRIVATE_KEY_EXECUTOR :="0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
 export FAKE_SIG :="11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
-
-simulate hdPath='0':
-  #!/usr/bin/env bash
-
-  config=${TASK_PATH}/config.toml
-  script=${SCRIPT_PATH}/template/${SCRIPT_NAME}.sol
-
-  echo "RPC URL: ${rpcUrl}"
-  echo "Using script ${script}"
-
-  echo "Setting signer address..."
-  if [ -z "$SIMULATE_WITHOUT_LEDGER" ]; then
-    signer=$(cast wallet address --ledger --mnemonic-derivation-path "m/44'/60'/{{hdPath}}'/0/0")
-    echo "Simulating with ledger account: ${signer}"
-  else
-    signer="{{signerAddress}}"
-    echo "Using 'signerAddress' as signer: ${signer}"
-  fi
-  echo ""
-
-  # Allow simulating from a specific block by setting FORK_BLOCK_NUMBER in the tasks .env file.
-  # If not set (or set to -1), default to using the latest block.
-  if [ "${forkBlockNumber}" = "-1" ]; then
-    fork_block_arg=""
-  else
-    echo "Using fork block number from env: ${forkBlockNumber}"
-    fork_block_arg="--fork-block-number ${forkBlockNumber}"
-  fi
-
-  echo "⏳ Task simulation in progress. Some tasks take longer than others..."
-  forge build
-  forge script ${script} \
-    ${fork_block_arg} \
-    --rpc-url ${rpcUrl} \
-    --sender ${signer} \
-    --sig "simulateRun(string)" ${config}
 
 sign hdPath='0':
   #!/usr/bin/env bash

--- a/src/improvements/tasks/StackedSimulator.sol
+++ b/src/improvements/tasks/StackedSimulator.sol
@@ -21,6 +21,7 @@ contract StackedSimulator is Script {
         string name;
     }
 
+    /// @notice Simulates the execution of all non-terminal tasks for a given network.
     function simulateStack(string memory network) public {
         TaskInfo[] memory tasks = getNonTerminalTasks(network);
         if (tasks.length == 0) {
@@ -40,6 +41,20 @@ contract StackedSimulator is Script {
             taskConfigs[i] = taskManager.parseConfig(tasks[i].path);
         }
 
+        simulateTasks(taskConfigs, optionalOwnerAddress);
+    }
+
+    /// @notice Simulates the execution of a single task.
+    function simulateTask(string memory taskPath, address optionalOwnerAddress) public {
+        TaskManager taskManager = new TaskManager();
+        TaskManager.TaskConfig[] memory taskConfigs = new TaskManager.TaskConfig[](1);
+        taskConfigs[0] = taskManager.parseConfig(taskPath);
+        simulateTasks(taskConfigs, optionalOwnerAddress);
+    }
+
+    /// @notice Given a list of task configs, simulates the execution of each task.
+    function simulateTasks(TaskManager.TaskConfig[] memory taskConfigs, address optionalOwnerAddress) public {
+        TaskManager taskManager = new TaskManager();
         // Setting this env variable to reduce logging for stack simulations.
         vm.setEnv("SIGNING_MODE_IN_PROGRESS", "true");
 

--- a/src/improvements/tasks/TaskManager.sol
+++ b/src/improvements/tasks/TaskManager.sol
@@ -142,6 +142,15 @@ contract TaskManager is Script {
             );
 
             address ownerAddress = optionalOwnerAddress != address(0) ? optionalOwnerAddress : owners[0];
+
+            if (optionalOwnerAddress == address(0)) {
+                string memory warn = string("[WARN]").yellow().bold();
+                // forgefmt: disable-start
+                console.log(line.yellow().bold());
+                console.log(string.concat(warn, " No safe specified for nested task. Using first owner address: ", vm.toString(ownerAddress), " ", warn));
+                console.log(line.yellow().bold());
+                // forgefmt: disable-end
+            }
             // forgefmt: disable-start
             console.log(string.concat("SIMULATING NESTED TASK (", taskName, ") FOR OWNER: ", vm.toString(ownerAddress), " ON ", formattedParentMultisig));
             // forgefmt: disable-end
@@ -156,6 +165,7 @@ contract TaskManager is Script {
             );
             (accesses,) = task.signFromChildMultisig(config.configPath, ownerAddress);
         } else {
+            require(optionalOwnerAddress == address(0), "TaskManager: Must not specify a safe for non-nested tasks.");
             // forgefmt: disable-start
             console.log(string.concat("SIMULATING SINGLE TASK: ", taskName, " ON ", formattedParentMultisig));
             console.log(line.green().bold());


### PR DESCRIPTION
The simulate command right now looks something like: 

Nested:
```
SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../nested.just simulate foundation
```
Single:
```
SIMULATE_FROM_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../single.just simulate
```

this PR simplifies the command to be:
Nested:
```
SIMULATE_WITHOUT_LEDGER=1 just simulate foundation
```
Single:
```
SIMULATE_FROM_LEDGER=1 just simulate
```
note: you'll still need to pass through the .env file if needed. 


We can do this for other commands and eventually delete both single.just and nested.just.