### PR TITLE
feat: ensure signer is owner on safe before signing

### DIFF
--- a/src/improvements/nested.just
+++ b/src/improvements/nested.just
@@ -79,6 +79,9 @@ sign whichSafe hdPath='0':
   echo "Signing with: ${signer}"
   echo ""
 
+  # Reverts if signer is not an owner on the safe.
+  forge script TaskManager --rpc-url ${rpcUrl} --sig "requireSignerOnSafe(address,address)" $signer $safe
+
   echo "⏳ Task signing in progress. Some tasks take longer than others..."
   forge build
   # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.

--- a/src/improvements/single.just
+++ b/src/improvements/single.just
@@ -77,6 +77,9 @@ sign hdPath='0':
   echo "Signing with: ${signer}"
   echo ""
 
+  # Reverts if signer is not an owner on the safe which executes this transaction.
+  forge script TaskManager --rpc-url ${rpcUrl} --sig "requireSignerOnSafe(address,string)" $signer $TASK_PATH
+
   echo "⏳ Task signing in progress. Some tasks take longer than others..."
   forge build
   # Using the eip712sign within the repo folder since eip712sign was installed there in ./justfile.

--- a/src/improvements/tasks/TaskManager.sol
+++ b/src/improvements/tasks/TaskManager.sol
@@ -165,6 +165,23 @@ contract TaskManager is Script {
         }
     }
 
+    /// @notice Requires that a signer is an owner on a safe.
+    function requireSignerOnSafe(address signer, string memory taskPath) public {
+        TaskConfig memory config = parseConfig(taskPath);
+        requireSignerOnSafe(signer, config.parentMultisig);
+    }
+
+    /// @notice Requires that a signer is an owner on a safe.
+    function requireSignerOnSafe(address signer, address safe) public view {
+        address[] memory owners = IGnosisSafe(safe).getOwners();
+        require(
+            contains(owners, signer),
+            string.concat(
+                "TaskManager: signer ", vm.toString(signer), " is not an owner on the safe: ", vm.toString(safe)
+            )
+        );
+    }
+
     /// @notice Sets the TENDERLY_GAS environment variable for the task if it exists.
     function setTenderlyGasEnv(string memory basePath) public {
         string memory envFile = string.concat(basePath, "/", ".env");


### PR DESCRIPTION
It is possible to accidentally sign for a safe with the wrong key. This functionality performs a check before signing to make sure the signer is using the correct signing key.