### PR TITLE
refactor: CLI improvements and CI update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,7 +496,8 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           filters:
             paths:
-              only: ["test/tasks/example/**"]
+              only:
+                - "test/tasks/example/**"
       - just_new_recipe_tests
       - shellcheck:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,10 +499,6 @@ workflows:
       - template_regression_tests:
           context:
             - circleci-repo-readonly-authenticated-github-token
-          filters:
-            paths:
-              only:
-                - "test/tasks/example/**"
       - just_new_recipe_tests
       - shellcheck:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,12 @@ jobs:
       - run:
           name: Make sure all templates can be simulated.
           command: |
-            (cd src/improvements && just simulate-all-templates)
+            if git diff --name-only $CIRCLE_SHA1 $CIRCLE_SHA1~1 \
+               | grep -q '^test/tasks/example/'; then
+              (cd src/improvements && just simulate-all-templates)
+            else
+              echo "No changes in test/tasks/example/, skipping regression tests."
+            fi
 
   just_new_recipe_tests:
     circleci_ip_ranges: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,12 +399,7 @@ jobs:
       - run:
           name: Make sure all templates can be simulated.
           command: |
-            if git diff --name-only $CIRCLE_SHA1 $CIRCLE_SHA1~1 \
-               | grep -q '^test/tasks/example/'; then
-              (cd src/improvements && just simulate-all-templates)
-            else
-              echo "No changes in test/tasks/example/, skipping regression tests."
-            fi
+            (cd src/improvements && just simulate-all-templates)
 
   just_new_recipe_tests:
     circleci_ip_ranges: true
@@ -494,11 +489,15 @@ workflows:
       - forge_test:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      # This is a long running job, so we only run it when files inside the `test/tasks/example` directory are changed.
-      # Possible future improvements: https://github.com/foundry-rs/foundry/issues/5363.
+      # This is a long running job, so we only run it on the main branch. It's encouraged that task
+      # developers run this locally before pushing changes. We should keep this job running on main 
+      # until we have performance improvements to the job (e.g. https://github.com/foundry-rs/foundry/issues/5363).
       - template_regression_tests:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          filters:
+            branches:
+              only: main
       - just_new_recipe_tests
       - shellcheck:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,15 +489,15 @@ workflows:
       - forge_test:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      # This is a long running job, so we only run it on the main branch. It's encouraged that task
-      # developers run this locally before pushing changes. We should keep this job running on main 
-      # until we have performance improvements to the job (e.g. https://github.com/foundry-rs/foundry/issues/5363).
+      # This is a long running job, so we only run it when files inside the `test/tasks/example` directory are changed.
+      # Possible future improvements: https://github.com/foundry-rs/foundry/issues/5363.
       - template_regression_tests:
           context:
             - circleci-repo-readonly-authenticated-github-token
           filters:
-            branches:
-              only: main
+            paths:
+              only:
+                - "test/tasks/example/**"
       - just_new_recipe_tests
       - shellcheck:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,8 +496,7 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           filters:
             paths:
-              only:
-                - "test/tasks/example/**"
+              only: ["test/tasks/example/**"]
       - just_new_recipe_tests
       - shellcheck:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,7 +489,15 @@ workflows:
       - forge_test:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - template_regression_tests
+      # This is a long running job, so we only run it on the main branch. It's encouraged that task
+      # developers run this locally before pushing changes. We should keep this job running on main 
+      # until we have performance improvements to the job (e.g. https://github.com/foundry-rs/foundry/issues/5363).
+      - template_regression_tests:
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          filters:
+            branches:
+              only: main
       - just_new_recipe_tests
       - shellcheck:
           context:
@@ -599,3 +607,4 @@ workflows:
             This issue will be closed now."
           context:
             - circleci-repo-superchain-ops
+            

--- a/src/improvements/README.md
+++ b/src/improvements/README.md
@@ -34,7 +34,20 @@ just --justfile ../../justfile install
 
 > For more information on `mise`, please refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) guide.
 
-2. Create a new task:
+2. Run tests:
+Run all tests:
+```bash
+cd src/improvements/
+just test # Run this command before asking for a review on any PR.
+```
+
+Run individual test suites:
+```bash
+forge test # Run solidity tests.
+just simulate-all-templates # Run template regression tests.
+```
+
+3. Create a new task:
 ```bash
 cd src/improvements/
 just new task
@@ -44,7 +57,7 @@ Follow the interactive prompts from the `just new task` command to create a new 
 
 > Note: An `.env` file will be created in the new tasks directory. Please make sure to fill out the `TENDERLY_GAS` variable with a high enough value to simulate the task.
 
-3. Configure the task in `config.toml` e.g.
+4. Configure the task in `config.toml` e.g.
 ```toml
 l2chains = [{"name": "OP Mainnet", "chainId": 10}]
 templateName = "<TEMPLATE_NAME>" # e.g. OPCMUpgradeV200
@@ -62,7 +75,7 @@ The `[addresses]` TOML [table](https://toml.io/en/v1.0.0#table) is optional. It 
 
 The `[stateOverrides]` TOML table is optional, but in most cases we use it to specify the nonces of the multisig safes involved in an upgrade. Selecting the correct nonce is important and requires careful consideration. You can see an example of its use in this [task](./tasks/eth/009-opcm-update-prestate-v300-op+ink/config.toml).
 
-4. Simulate the task:
+5. Simulate the task:
 ```bash
 # Nested
 SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../nested.just simulate <foundation|council|chain-governor|foundation-operations|base-operations|[custom-safe-name]>
@@ -75,7 +88,7 @@ SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../nes
 SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../single.just simulate
 ```
 
-5. Fill out the `README.md` and `VALIDATION.md` files.
+6. Fill out the `README.md` and `VALIDATION.md` files.
     - If your task status is not `EXECUTED` or `CANCELLED`, it is considered non-terminal and will automatically be included in stacked simulations (which run on the main branch).
 
 ### How do I run a task that depends on another task?

--- a/src/improvements/doc/NEW_TEMPLATE_GUIDE.md
+++ b/src/improvements/doc/NEW_TEMPLATE_GUIDE.md
@@ -23,6 +23,8 @@ Once a new template has been created and tested from the command line as a forge
 4. Make sure to pin the block number in the test case to avoid intermittent failures (you can do this using the `.env` file).
 5. Run the regression test suite to ensure the new template passes all tests.
 
+> ⚠️ Note: The CI job `template_regression_tests` will fail if you do not include an example task for your new template. This job only runs on the `main` branch because it is a long running job. It's encouraged that task developers run this locally before pushing changes. You can do this by running `just simulate-all-templates` from `src/improvements/`.
+
 ## Existing Templates
 
 Existing templates can be found in the [`src/improvements/template/`](../template) directory. These templates can be used as a reference for creating new templates.

--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -236,3 +236,8 @@ list-stack NETWORK="" TASK="":
         echo "Listing all tasks for network: {{NETWORK}} up to task: {{TASK}}"
         forge script ${root_dir}/src/improvements/tasks/StackedSimulator.sol:StackedSimulator --sig "listStack(string,string)" {{NETWORK}} {{TASK}}
     fi
+
+test:
+    forge build
+    forge test
+    just simulate-all-templates

--- a/src/improvements/script/create-task.sh
+++ b/src/improvements/script/create-task.sh
@@ -35,16 +35,32 @@ create_task() {
         done
     done
 
-    # This is an ordered list of all the tasks for a given network.
-    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    sorted_existing_dirs=$("$script_dir/sorted-tasks.sh" "$network")
+    echo ""
+    # Prompt the user (Enter → No by default)
+    read -r -p "Is this a test task (i.e. lives in test/tasks/example/$network directory)? Type 'y' to confirm, or press Enter for No: " is_test_task
 
     echo ""
-    if [[ -z "$sorted_existing_dirs" || $(echo "$sorted_existing_dirs" | wc -l) -eq 1 ]]; then
-        suggestion="Note: this is the first task for this network. Please choose a name that's lexicographically sensible"
-    else
-        most_recent_task_dir=$(echo "$sorted_existing_dirs" | tail -n1)
-        suggestion="lexicographically after: $(basename "$most_recent_task_dir")"
+    if [[ "$is_test_task" == "Y" || "$is_test_task" == "y" || "$is_test_task" == "yes" ]]; then
+        echo -e "\033[32mYou selected: Yes\033[0m"
+        dest_dir="../../test/tasks/example"
+        suggestion="This is a test task"
+        is_test_task="true"
+        echo ""
+    else 
+        echo -e "\033[32mYou selected: No\033[0m"
+        dest_dir="tasks"
+        # This is an ordered list of all the tasks for a given network.
+        script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        sorted_existing_dirs=$("$script_dir/sorted-tasks.sh" "$network")
+
+        echo ""
+        if [[ -z "$sorted_existing_dirs" || $(echo "$sorted_existing_dirs" | wc -l) -eq 1 ]]; then
+            suggestion="Note: this is the first task for this network. Please choose a name that's lexicographically sensible"
+        else
+            most_recent_task_dir=$(echo "$sorted_existing_dirs" | tail -n1)
+            suggestion="lexicographically after: $(basename "$most_recent_task_dir")"
+        fi
+        is_test_task="false"
     fi
 
     while true; do
@@ -71,7 +87,7 @@ create_task() {
         short_description=": $short_description"
     fi
 
-    task_path="tasks/${network}/${dirname}"
+    task_path="${dest_dir}/${network}/${dirname}"
     mkdir -p "$task_path"
     config_path="$task_path/config.toml"
     
@@ -81,22 +97,31 @@ create_task() {
     readme_path="$task_path/README.md" 
     cp "template/boilerplate/README.template.md" "$readme_path"
 
-    navigate_to_task_command="cd src/improvements/tasks/$network/$dirname"
+    # Write empty readme and validation files for test tasks
+    if [[ "$is_test_task" == "true" ]]; then
+        echo "" > "$readme_path"
+        echo "" > "$validation_path"
+    else
+        navigate_to_task_command="cd src/improvements/${dest_dir}/${network}/${dirname}"
+        sed -e "s|<task-name>|$dirname|g" \
+        -e "s|<short-description>|$short_description|g" \
+        -e "s|<navigate-to-simulation-command>|$navigate_to_task_command|g" \
+        -e "s|<navigate-to-signing-command>|$navigate_to_task_command|g" \
+        "$readme_path" > "${readme_path}.tmp" \
+        && mv "${readme_path}.tmp" "$readme_path"
 
-    sed -e "s|<task-name>|$dirname|g" \
-    -e "s|<short-description>|$short_description|g" \
-    -e "s|<navigate-to-simulation-command>|$navigate_to_task_command|g" \
-    -e "s|<navigate-to-signing-command>|$navigate_to_task_command|g" \
-    "$readme_path" > "${readme_path}.tmp" \
-    && mv "${readme_path}.tmp" "$readme_path"
+        # copy the validation template to validation_path
+        validation_path="$task_path/VALIDATION.md"
+        cp "template/boilerplate/VALIDATION.template.md" "$validation_path"
+    fi
 
-    # copy the validation template to validation_path
-    validation_path="$task_path/VALIDATION.md"
-    cp "template/boilerplate/VALIDATION.template.md" "$validation_path"
-
-    # make .env file with TENDERLY_GAS set to 10000000 
+    # Make .env file with TENDERLY_GAS set to 10000000 
     env_path="$task_path/.env"
     echo "TENDERLY_GAS=10000000" > "$env_path"
+    if [[ "$is_test_task" == "true" ]]; then
+        # Only add a fork block number if this is a test task. We want the test task to consistently use the same block number.
+        echo "FORK_BLOCK_NUMBER=" >> "$env_path"
+    fi
 
     echo "Created task directory '${dirname}' for network: ${network}"
     absolute_path=$(realpath "$task_path")

--- a/src/improvements/script/create-template.sh
+++ b/src/improvements/script/create-template.sh
@@ -19,7 +19,14 @@ create_template() {
     while true; do
         if [ -t 0 ]; then
             echo ""
-            read -r -p "Enter template file name (e.g. <template_name>.sol): " filename
+            echo -e "Enter template file name (e.g.\033[33m <template_name>.sol\033[0m)."
+            echo "    - Make the name generic enough so that other developers know it is reusable."
+            echo "    - Follow single responsibility: one task per template (see: TransferL1PAO and TransferL2PAO)."
+            echo "    - Ideally, the name should start with a verb like 'Transfer', 'Update', 'Set'."
+            echo "    - Avoid using 'Template' in the name."
+            echo -e "\033[33mTip: Name with future reuse in mind.\033[0m"
+            echo ""
+            read -r -p "Filename: " filename
         else
             read -r filename
         fi


### PR DESCRIPTION

1. Misc documentation updates.
2. Only running regression tests on main due to the time it takes to run on each PR (see `config.yml` file).
3. `src/improvements/script/create-task.sh` now allows users to create a task in the tests directory. Useful for when you want to test a new template you just created. You can see this by running `just new task`.
4. `src/improvements/script/create-template.sh` - better messaging for when someone is creating a template. You can see this by running `just new template`.