### PR TITLE
chore: clarify Base Simulation Link Instructions in NESTED.md and SINGLE.md

### DIFF
--- a/NESTED.md
+++ b/NESTED.md
@@ -73,11 +73,12 @@ just \
 
 You will see a "Simulation link" from the output.
 
-Paste this URL in your browser. A prompt may ask you to choose a
-project, any project will do. You can create one if necessary.
-
-Click "Simulate Transaction". Please note that in some cases, when the calldata is very large, you may have to complete an additional step. 
-This involves copying and pasting the 'Raw Input data' field from the terminal into the Raw input data field in the Tenderly simulation, then clicking "Simulate Transaction".
+If you are running a simulation on Base and the output also includes a message like:
+```
+Insert the following hex into the 'Raw input data' field:
+<hex data>
+```
+you should open the simulation link in your browser, paste the provided hex data into the "Raw input data" field in the Tenderly UI, and then click "Simulate Transaction" to proceed. This step is required for Base simulations with large calldata, as the full calldata cannot be embedded in the URL.
 
 We will be performing 3 validations and extract the domain hash and
 message hash to approve on your Ledger:

--- a/SINGLE.md
+++ b/SINGLE.md
@@ -56,6 +56,13 @@ just \
 
 You will see a "Simulation link" from the output.
 
+If you are running a simulation on Base and the output also includes a message like:
+```
+Insert the following hex into the 'Raw input data' field:
+<hex data>
+```
+you should open the simulation link in your browser, paste the provided hex data into the "Raw input data" field in the Tenderly UI, and then click "Simulate Transaction" to proceed. This step is required for Base simulations with large calldata, as the full calldata cannot be embedded in the URL.
+
 Paste this URL in your browser. A prompt may ask you to choose a
 project, any project will do. You can create one if necessary.
 


### PR DESCRIPTION

**Description of changes:**

I updated the `NESTED.md` and `SINGLE.md` files to clarify the simulation process for transactions on the Base network. The documentation now explains, in a straightforward and instructional way, that if you see a message in the terminal asking you to insert hex data into the "Raw input data" field, you should copy that data into the Tenderly UI before clicking "Simulate Transaction." This step is required for Base simulations with large calldata, as the full calldata cannot be included directly in the simulation link.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

Fixes #789 
