### PR TITLE
fix: balance change improvements/fixes

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -23,6 +23,7 @@ type AddressRegistry is address;
 abstract contract MultisigTask is Test, Script, StateOverrideManager {
     using EnumerableSet for EnumerableSet.AddressSet;
     using AccountAccessParser for VmSafe.AccountAccess[];
+    using AccountAccessParser for VmSafe.AccountAccess;
     using StdStyle for string;
 
     /// @notice Parent nonce used for generating the safe transaction.
@@ -1250,7 +1251,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
 
             if (!_allowedBalanceChanges.contains(accountAccess.account)) {
                 require(
-                    accountAccess.oldBalance == accountAccess.newBalance,
+                    !accountAccess.containsValueTransfer(),
                     string.concat("Unexpected balance change: ", vm.toString(accountAccess.account))
                 );
             }

--- a/src/improvements/template/OPCMUpgradeV400.sol
+++ b/src/improvements/template/OPCMUpgradeV400.sol
@@ -52,10 +52,9 @@ contract OPCMUpgradeV400 is OPCMTaskBase {
     /// Contracts with these names are expected to have their balance changes during the task.
     /// By default returns an empty array. Override this function if your task expects balance changes.
     function _taskBalanceChanges() internal view virtual override returns (string[] memory) {
-        string[] memory balanceChanges = new string[](3);
+        string[] memory balanceChanges = new string[](2);
         balanceChanges[0] = "OptimismPortalProxy";
-        balanceChanges[1] = "OptimismPortalImpl";
-        balanceChanges[2] = "EthLockboxProxy";
+        balanceChanges[1] = "EthLockboxProxy";
         return balanceChanges;
     }
 

--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -625,10 +625,15 @@ library AccountAccessParser {
         }
     }
 
+    /// @notice Given an account access record, returns true if it contains a value transfer. Either an ETH transfer or an ERC20 transfer.
+    function containsValueTransfer(VmSafe.AccountAccess memory access) internal pure returns (bool) {
+        return getETHTransfer(access).value != 0 || getERC20Transfer(access).value != 0;
+    }
+
     /// @notice Decodes an ETH transfer from an account access record, and returns an empty struct
     /// if no transfer occurred.
     function getETHTransfer(VmSafe.AccountAccess memory access) internal pure returns (DecodedTransfer memory) {
-        return access.value != 0 && !access.reverted
+        return access.value != 0 && !access.reverted && access.oldBalance != access.newBalance
             ? DecodedTransfer({from: access.accessor, to: access.account, value: access.value, tokenAddress: ETHER})
             : DecodedTransfer({from: ZERO, to: ZERO, value: 0, tokenAddress: ZERO});
     }

--- a/test/tasks/example/sep/008-opcm-upgrade-stage1/config.toml
+++ b/test/tasks/example/sep/008-opcm-upgrade-stage1/config.toml
@@ -15,4 +15,3 @@ expectedValidationErrors = "PDDG-40,PLDG-40"
 OPCM = "0x355fd2a98fc11f5e4a91d9aa4c0041d252a77583" # Freshly deployed on Sepolia
 StandardValidatorV400 = "0xd0233aa63b11c2b93f68e306a16f2786fb11d0d1" # Freshly deployed on Sepolia
 EthLockboxProxy = "0x40B7b580090D22727aed809B3845559aDcf15711" # Freshly deployed on Sepolia
-OptimismPortalImpl = "0x72C07874FD9EEDAD233D3A93881f9dc768f3e5d3" # Freshly deployed on Sepolia


### PR DESCRIPTION
The current balance check functionality ignored ERC20 transfers. I've added a helper function in `AccountAccessParser` to be able to determine if the access is a 'value transfer' or not.