### PR TITLE
Set `EXECUTED` UnPause SuperchainConfig

### DIFF
--- a/src/improvements/tasks/eth/012-unpause-superchainConfig/README.md
+++ b/src/improvements/tasks/eth/012-unpause-superchainConfig/README.md
@@ -1,6 +1,6 @@
 # 012 - Unpause the SuperchainConfig
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://etherscan.io/tx/0x758b4196114928b4e43c2f3b6d65e0737dde9f1ed6f346eac16843f5fd3fac74)
 
 ## Objective
 


### PR DESCRIPTION
Execute the Unpause of the superchainConfig on Mainnet from today!