### PR TITLE
fix: Not Adding a balance check to newly deployed contracts

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -1250,10 +1250,20 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
             }
 
             if (!_allowedBalanceChanges.contains(accountAccess.account)) {
-                require(
-                    !accountAccess.containsValueTransfer(),
-                    string.concat("Unexpected balance change: ", vm.toString(accountAccess.account))
-                );
+                if (_isNewContract(accountAccess.account, newContracts)) {
+                    console.log(
+                        string.concat(
+                            string("[INFO]").green().bold(),
+                            " Skipping balance change check for new contract: ",
+                            vm.toString(accountAccess.account)
+                        )
+                    );
+                } else {
+                    require(
+                        !accountAccess.containsValueTransfer(),
+                        string.concat("Unexpected balance change: ", vm.toString(accountAccess.account))
+                    );
+                }
             }
 
             require(

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -1250,15 +1250,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager {
             }
 
             if (!_allowedBalanceChanges.contains(accountAccess.account)) {
-                if (_isNewContract(accountAccess.account, newContracts)) {
-                    console.log(
-                        string.concat(
-                            string("[INFO]").green().bold(),
-                            " Skipping balance change check for new contract: ",
-                            vm.toString(accountAccess.account)
-                        )
-                    );
-                } else {
+                // Skip balance change checks for newly deployed contracts.
+                // Ensure that existing contracts, that haven't been allow listed, do not contain a value transfer.
+                if (!_isNewContract(accountAccess.account, newContracts)) {
                     require(
                         !accountAccess.containsValueTransfer(),
                         string.concat("Unexpected balance change: ", vm.toString(accountAccess.account))

--- a/src/improvements/template/OPCMUpgradeV400.sol
+++ b/src/improvements/template/OPCMUpgradeV400.sol
@@ -52,9 +52,9 @@ contract OPCMUpgradeV400 is OPCMTaskBase {
     /// Contracts with these names are expected to have their balance changes during the task.
     /// By default returns an empty array. Override this function if your task expects balance changes.
     function _taskBalanceChanges() internal view virtual override returns (string[] memory) {
-        string[] memory balanceChanges = new string[](2);
+        string[] memory balanceChanges = new string[](1);
         balanceChanges[0] = "OptimismPortalProxy";
-        balanceChanges[1] = "EthLockboxProxy";
+        // Not adding EthLockboxProxy because we do not perform balance checks on newly deployed contracts.
         return balanceChanges;
     }
 


### PR DESCRIPTION
We're doing this because we would have to exhaustively list all possible contracts in the template. We had a similar situation with the storage access checks before: https://github.com/ethereum-optimism/superchain-ops/blob/main/src/improvements/tasks/MultisigTask.sol#L639