### PR TITLE
docs: natspec update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 > 🚨 Deprecation Notice (Effective Q1 2025)
 > We’re migrating all task definitions from the old superchain-ops repo (`tasks/`) into the new improvements repo (`src/improvements/tasks/`).
 >
-> • New tasks: please use the improvements flow.
+> • New tasks: please use the [improvements flow](./src/improvements) and refer to the [README](./src/improvements/README.md) for more information.
 > • Need help? Reach out in [#superchain-ops](https://discord.com/channels/1244729134312198194/1342572064175030293) on Discord.
 >
 > The old flow will be retired as soon as we don't need the old tasks anymore.

--- a/src/improvements/SimpleAddressRegistry.sol
+++ b/src/improvements/SimpleAddressRegistry.sol
@@ -6,7 +6,7 @@ import {stdToml} from "forge-std/StdToml.sol";
 import {StdChains} from "forge-std/StdChains.sol";
 
 /// @notice This contract provides a simple key-value store for addresses which are read in from
-/// the config TOML file. It expects an `[addresses]` section in the TOML file, with each key
+/// the config TOML file. It expects an `[addresses]` section in the `config.toml` file, with each key
 /// being the identifier for the address, and the value being the address.
 contract SimpleAddressRegistry is StdChains {
     using stdToml for string;

--- a/src/improvements/tasks/types/L2TaskBase.sol
+++ b/src/improvements/tasks/types/L2TaskBase.sol
@@ -8,10 +8,12 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {console} from "forge-std/console.sol";
 import {StdStyle} from "forge-std/StdStyle.sol";
 
+/// @notice This contract is used for all L2 task types. It overrides various functions in the MultisigTask contract.
 abstract contract L2TaskBase is MultisigTask {
     using EnumerableSet for EnumerableSet.AddressSet;
     using StdStyle for string;
 
+    /// @notice The superchain address registry.
     SuperchainAddressRegistry public superchainAddrRegistry;
 
     /// @notice Returns the type of task. L2TaskBase.
@@ -84,7 +86,11 @@ abstract contract L2TaskBase is MultisigTask {
         }
     }
 
-    /// @notice Helper to try adding an address to the target set for a given key and chain
+    /// @notice Attempts to add an address to the target set for a given key and chain.
+    /// The order of resolution is important: we first call `superchainAddrRegistry.get()`,
+    /// which checks config-defined addresses (e.g. `[addresses]` in `config.toml` or `addresses.toml`).
+    /// If that fails, we fall back to `superchainAddrRegistry.getAddress()`, which discovers addresses onchain.
+    /// This ensures config-defined addresses take precedence over onchain discovery.
     function _tryAddAddress(
         string memory key,
         SuperchainAddressRegistry.ChainInfo memory chain,
@@ -92,9 +98,7 @@ abstract contract L2TaskBase is MultisigTask {
         string memory context
     ) private {
         require(gasleft() > 500_000, "MultisigTask: Insufficient gas for initial getAddress() call"); // Ensure try/catch is EIP-150 safe.
-        //Addresses that are not discovered automatically (e.g. OPCM, StandardValidator, or safes missing from addresses.toml).
-        //IMPORTANT: If an address is defined in the config.toml and also discovered onchain, this value takes precedence.
-
+        // Addresses that are not discovered automatically (e.g. OPCM, StandardValidator, or safes missing from addresses.toml).
         try superchainAddrRegistry.get(key) returns (address addr) {
             targetSet.add(addr);
         } catch {

--- a/src/improvements/tasks/types/OPCMTaskBase.sol
+++ b/src/improvements/tasks/types/OPCMTaskBase.sol
@@ -12,7 +12,7 @@ import {AccountAccessParser} from "src/libraries/AccountAccessParser.sol";
 import {MultisigTask, AddressRegistry} from "src/improvements/tasks/MultisigTask.sol";
 import {L2TaskBase} from "src/improvements/tasks/types/L2TaskBase.sol";
 
-/// @notice base task for making calls to the Optimism Contracts Manager
+/// @notice This contract is used for all OPCM task types. It overrides various functions in the L2TaskBase contract.
 abstract contract OPCMTaskBase is L2TaskBase {
     using stdStorage for StdStorage;
     using AccountAccessParser for VmSafe.AccountAccess[];

--- a/src/improvements/tasks/types/SimpleTaskBase.sol
+++ b/src/improvements/tasks/types/SimpleTaskBase.sol
@@ -6,6 +6,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
 import {SimpleAddressRegistry} from "src/improvements/SimpleAddressRegistry.sol";
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 
+/// @notice This contract is used for all simple task types. It overrides various functions in the MultisigTask contract.
 abstract contract SimpleTaskBase is MultisigTask {
     using EnumerableSet for EnumerableSet.AddressSet;
 


### PR DESCRIPTION
Better comments around order of operations for L2TaskBase superchain address regristy. 