### PR TITLE
fix: Stacked sim should use ci rpc urls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,6 +243,8 @@ jobs:
         type: string
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    environment:
+      FOUNDRY_PROFILE: ci
     steps:
       - utils/checkout-with-mise
       - run:


### PR DESCRIPTION
The new stacked simulations feature wasn't defaulting to use our internal rpc urls. This change fixes this. 