### PR TITLE
Updating Uni Sep L1 role transfers status to "ready to sign"

### DIFF
--- a/src/improvements/tasks/sep/013-l1-ownership-transfers-uni/README.md
+++ b/src/improvements/tasks/sep/013-l1-ownership-transfers-uni/README.md
@@ -1,6 +1,6 @@
 # 013-l1-ownership-transfers-uni: Transfer L1 owners for Unichain Sepolia (DGF, PermissionlessWETH, PermissionedWETH and L1PAO)
 
-Status: [DRAFT]()
+Status: [READY TO SIGN]()
 
 ## Objective
 


### PR DESCRIPTION
Updating Unichain Sepolia's L1 role transfer task to be "ready to sign". After rotation of the challenger role in the PDG and setting the implementation to the new contract on the DGF, this task is ready to sign and execute.

