### PR TITLE
validation-docs: Update link to standard prestates

### DIFF
--- a/validation/PRESTATE-VALIDATION.md
+++ b/validation/PRESTATE-VALIDATION.md
@@ -6,41 +6,34 @@ The referenced program should be a valid release of `op-program`.
 
 ## Releases.json
 All `op-program` releases are documented in
-[releases.json](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/prestates/releases.json).
+[standard-prestates.toml in the superchain-registry](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml).
 
 For example, here is a subset of documented releases:
-```json
-[
-    {
-    "version": "1.4.0",
-    "hash": "0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b",
-    "type": "cannon64"
-    },
-    {
-    "version": "1.4.0",
-    "hash": "0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568",
-    "governanceApproved": true
-    },
-    {
-    "version": "1.4.0-rc.3",
-    "hash": "0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b",
-    "type": "cannon64"
-    },
-    {
-    "version": "1.4.0-rc.3",
-    "hash": "0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568"
-    }
-]
+```toml
+[[prestates."1.4.0"]]
+type = "cannon64"
+hash = "0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b"
+
+[[prestates."1.4.0"]]
+type = "cannon32"
+hash = "0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568"
+
+[[prestates."1.4.0-rc.3"]]
+type = "cannon64"
+hash = "0x03b7eaa4e3cbce90381921a4b48008f4769871d64f93d113fcadca08ecee503b"
+
+[[prestates."1.4.0-rc.3"]]
+type = "cannon32"
+hash = "0x03f89406817db1ed7fd8b31e13300444652cdb0b9c509a674de43483b2f83568"
 ```
 
 There are a few features to notice here:
 * Each "hash" field is a prestate.
 * Finalized releases are formatted as `<major>.<minor>.<patch>`. For example: `1.4.0`.
 * Release candidates are formatted as `<major>.<minor>.<patch>-rc.<counter>`. For example: `1.4.0-rc.3`.
-* Governance-approved releases have a "governanceApproved" field set to `true`.
-* Some entries have a "type" field:
+* Each entry has a "type" field:
   * If this is set to "cannon64", this defines a 64-bit program meant for [64-bit Multithreaded Cannon](https://specs.optimism.io/experimental/cannon-fault-proof-vm-mt.html). These programs must execute on `MIPS64.sol`.
-  * If the field is not set, this defines a 32-bit program mean for the [original 32-bit Cannon FPVM](https://github.com/ethereum-optimism/specs/blob/86d043705a7eb65295e15feaeea248fda38b9b8a/specs/fault-proof/cannon-fault-proof-vm.md).  These programs must execute on `MIPS.sol`.
+  * If this is set to "cannon32", this defines a 32-bit program meant for the [original 32-bit Cannon FPVM](https://github.com/ethereum-optimism/specs/blob/86d043705a7eb65295e15feaeea248fda38b9b8a/specs/fault-proof/cannon-fault-proof-vm.md).  These programs must execute on `MIPS.sol`.
 
 ## Calculating the absolute prestate
 
@@ -73,4 +66,4 @@ To calculate the prestates associated with a given `op-program` release (for exa
   * The "Cannon" hash is the 32-bit prestate.
   * The "Cannon64" hash is the 64-bit prestate.
 * Verify that your target prestate was calculated as expected and matches the corresponding entry in
-  [releases.json](https://github.com/ethereum-optimism/optimism/blob/develop/op-program/prestates/releases.json).
+  [standard-prestates.toml](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-prestates.toml).


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Update `PRESTATE-VALIDATION.md` to point to the new `standard-prestates.toml` file in superchain-registry. 
