### PR TITLE
Update CircleCI config to add conditional execution for slack notific…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ commands:
         type: string
         default: ""
     steps:
+      - when:
+          condition: << pipeline.git.branch >> == "main"
+          steps: []
       - slack/notify:
           channel: << parameters.channel >>
           event: fail


### PR DESCRIPTION
It bugs me a teeny tiny bit that [these jobs](https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops/8316/workflows/5aaf0fac-e574-4b8c-8915-9c5e40d483fe/jobs/116353) run and report success, even though no message was sent to slack:

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/77af7343-d66c-47d2-af61-5a99338cfdaf" />

This PR will ensure that they only run on `main`.
