### PR TITLE
Add support for older safe versions

### DIFF
--- a/src/improvements/template/DisableModule.sol
+++ b/src/improvements/template/DisableModule.sol
@@ -68,12 +68,13 @@ contract DisableModule is SimpleTaskBase {
             ModuleManager(parentMultisig).getModulesPaginated(SENTINEL_MODULE, 100);
         if (keccak256(abi.encodePacked(ISafe(parentMultisig).VERSION())) == keccak256(abi.encodePacked("1.1.1"))) {
             // console.log("[INFO] Old version of safe detected 1.1.1.");
-            (address[] memory array, address next) = ModuleManager(parentMultisig).getModulesPaginated(SENTINEL_MODULE, 100);
-            if(next != SENTINEL_MODULE) {
+            (address[] memory array, address next) =
+                ModuleManager(parentMultisig).getModulesPaginated(SENTINEL_MODULE, 100);
+            if (next != SENTINEL_MODULE) {
                 revert("More than 100 modules found, what are you even doing?");
             }
-            for(uint256 i = 0; i < array.length; i++) {
-                if(array[i] == moduleToDisable) {
+            for (uint256 i = 0; i < array.length; i++) {
+                if (array[i] == moduleToDisable) {
                     revert("Module not disabled");
                 }
             }


### PR DESCRIPTION
Use `getModulesPaginated()` if `isModuleEnabled()` is not available.