### PR TITLE
Remove metal and mode from legacy simulation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ workflows:
       - simulate_sequence:
           name: simulate_sequence_eth
           network: "eth"
-          tasks: "metal-002 mode-002"
+          tasks: ""
           block_number: "" # If not specified, the latest block number is used.
           context:
             - circleci-repo-readonly-authenticated-github-token


### PR DESCRIPTION
The tasks are not yet complete, but the approval from the FUS has gone through, which breaks the nonce check. They will execute tomorrow.
