### PR TITLE
fix(tests): race condition with TOML file creation causing flakes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ broadcast/*
 
 # Stacked simulation test files
 test/tasks/stacked-sim-testing/
+
+# tmp config.toml files for testing
+test-config-files/

--- a/test/registry/SuperchainAddressRegistry.t.sol
+++ b/test/registry/SuperchainAddressRegistry.t.sol
@@ -20,6 +20,8 @@ abstract contract SuperchainAddressRegistryTest_Base is Test {
     uint256 public modeChainId;
     uint256 public unichainChainId;
 
+    string constant TESTING_DIRECTORY = "superchain-address-registry-testing";
+
     function setUp() public {
         (string memory configPath, string memory chainName) = config();
 
@@ -207,7 +209,7 @@ abstract contract SuperchainAddressRegistryTest_Base is Test {
 
     function testRunFailsNoL2ChainsKey() public {
         string memory invalidToml = "templateName = \"RandomTemplate\"\n";
-        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(invalidToml);
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(invalidToml, TESTING_DIRECTORY, "000");
         vm.expectRevert("SuperchainAddressRegistry: .l2chains must be present in the config.toml file.");
         new SuperchainAddressRegistry(fileName);
         MultisigTaskTestHelper.removeFile(fileName);
@@ -215,7 +217,7 @@ abstract contract SuperchainAddressRegistryTest_Base is Test {
 
     function testRunFailsEmptyL2ChainsKey() public {
         string memory invalidToml = "l2chains = [] \n" "templateName = \"RandomTemplate\"\n";
-        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(invalidToml);
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(invalidToml, TESTING_DIRECTORY, "001");
         vm.expectRevert("SuperchainAddressRegistry: .l2chains list is empty");
         new SuperchainAddressRegistry(fileName);
         MultisigTaskTestHelper.removeFile(fileName);
@@ -239,7 +241,7 @@ abstract contract SuperchainAddressRegistryTest_Base is Test {
             localJsonPath,
             '"'
         );
-        string memory configFileName = MultisigTaskTestHelper.createTempTomlFile(tomlContent);
+        string memory configFileName = MultisigTaskTestHelper.createTempTomlFile(tomlContent, TESTING_DIRECTORY, "002");
         SuperchainAddressRegistry localRegistry = new SuperchainAddressRegistry(configFileName);
         assertTrue(localRegistry.seenL2ChainIds(12345), "Local chain ID 12345 not seen");
 
@@ -272,7 +274,7 @@ abstract contract SuperchainAddressRegistryTest_Base is Test {
         vm.createSelectFork("mainnet");
         string memory tomlContent =
             string.concat('l2chains = [{name = "MyLocalChain", chainId = 12345}]\n', 'fallbackAddressesJsonPath = ""');
-        string memory configFileName = MultisigTaskTestHelper.createTempTomlFile(tomlContent);
+        string memory configFileName = MultisigTaskTestHelper.createTempTomlFile(tomlContent, TESTING_DIRECTORY, "003");
         vm.expectRevert(
             "SuperchainAddressRegistry: Chain does not exist in superchain registry and fallback path is empty."
         );
@@ -285,7 +287,7 @@ abstract contract SuperchainAddressRegistryTest_Base is Test {
             'l2chains = [{name = "MyLocalChain", chainId = 12345}]\n',
             'fallbackAddressesJsonPath = "test/registry/non-existent-file.json"'
         );
-        string memory configFileName = MultisigTaskTestHelper.createTempTomlFile(tomlContent);
+        string memory configFileName = MultisigTaskTestHelper.createTempTomlFile(tomlContent, TESTING_DIRECTORY, "004");
         vm.expectRevert();
         new SuperchainAddressRegistry(configFileName);
         MultisigTaskTestHelper.removeFile(configFileName);

--- a/test/tasks/MultisigTask.t.sol
+++ b/test/tasks/MultisigTask.t.sol
@@ -14,12 +14,14 @@ import {SuperchainAddressRegistry} from "src/improvements/SuperchainAddressRegis
 import {Action} from "src/libraries/MultisigTypes.sol";
 import {MockMultisigTask} from "test/tasks/mock/MockMultisigTask.sol";
 import {MockTarget} from "test/tasks/mock/MockTarget.sol";
+import {console} from "forge-std/console.sol";
 
 contract MultisigTaskUnitTest is Test {
     using stdStorage for StdStorage;
 
     SuperchainAddressRegistry public addrRegistry;
     MultisigTask public task;
+    string constant TESTING_DIRECTORY = "multisig-task-testing";
 
     string constant commonToml =
         "l2chains = [{name = \"OP Mainnet\", chainId = 10}]\n" "\n" "templateName = \"MockMultisigTask\"\n" "\n";
@@ -33,12 +35,13 @@ contract MultisigTaskUnitTest is Test {
     /// and all other storage variables. We do not call this function in some of
     /// the tests, so we have to set the storage variables manually when we do
     /// not call the run function.
-
     function setUp() public {
         vm.createSelectFork("mainnet");
 
         // We want the SuperchainAddressRegistry to be initialized with the OP Mainnet config
-        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml);
+        string memory fileName =
+            MultisigTaskTestHelper.createTempTomlFile(commonToml, string.concat(TESTING_DIRECTORY), "000");
+        console.log("fileName", fileName);
         // Instantiate the SuperchainAddressRegistry contract
         addrRegistry = new SuperchainAddressRegistry(fileName);
         MultisigTaskTestHelper.removeFile(fileName);
@@ -92,7 +95,7 @@ contract MultisigTaskUnitTest is Test {
     }
 
     function testSimulateFailsHashMismatch() public {
-        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml);
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml, TESTING_DIRECTORY, "001");
         MultisigTask taskHashMismatch = MultisigTask(new MockMultisigTask());
 
         address rootSafe = addrRegistry.getAddress("ProxyAdminOwner", getChain("optimism").chainId);
@@ -191,7 +194,8 @@ contract MultisigTaskUnitTest is Test {
     }
 
     function testSimulateFailsTxAlreadyExecuted() public {
-        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml);
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml, TESTING_DIRECTORY, "002");
+        console.log("fileName", fileName);
         (VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions) =
             runTestSimulation(fileName, securityCouncilChildMultisig);
 
@@ -204,7 +208,8 @@ contract MultisigTaskUnitTest is Test {
     }
 
     function testGetCalldata() public {
-        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml);
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(commonToml, TESTING_DIRECTORY, "003");
+        console.log("fileName", fileName);
         (, Action[] memory actions) = runTestSimulation(fileName, securityCouncilChildMultisig);
         MultisigTaskTestHelper.removeFile(fileName);
 
@@ -402,9 +407,17 @@ library MultisigTaskTestHelper {
     address internal constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
     Vm internal constant vm = Vm(VM_ADDRESS);
 
-    function createTempTomlFile(string memory tomlContent) internal returns (string memory) {
-        string memory randomBytes = LibString.toHexString(uint256(bytes32(vm.randomBytes(32))));
-        string memory fileName = string.concat(randomBytes, ".toml");
+    /// @notice This function is used to create a temporary toml file for a test. The 'salt' parameter is used to ensure
+    /// that the file name is unique for each test.
+    function createTempTomlFile(string memory tomlContent, string memory directory, string memory salt)
+        internal
+        returns (string memory)
+    {
+        string memory randomFileName = vm.toString(keccak256(abi.encodePacked(vm.randomBytes(32), salt)));
+        string memory testConfigFilesDirectory = "test-config-files"; // This directory is in the .gitignore file.
+        string memory fullDirectory = string.concat(testConfigFilesDirectory, "/", directory);
+        vm.createDir(fullDirectory, true);
+        string memory fileName = string.concat(fullDirectory, "/", randomFileName, ".toml");
         vm.writeFile(fileName, tomlContent);
         return fileName;
     }

--- a/test/tasks/NestedMultisigTask.t.sol
+++ b/test/tasks/NestedMultisigTask.t.sol
@@ -36,6 +36,8 @@ contract NestedMultisigTaskTest is Test {
     uint256 public constant OWNER_COUNT_STORAGE_OFFSET = 3;
     uint256 public constant THRESHOLD_STORAGE_OFFSET = 4;
 
+    string constant TESTING_DIRECTORY = "nested-multisig-task-testing";
+
     /// @notice ProxyAdminOwner safe for the task below is a nested multisig for Op mainnet L2 chain.
     string constant taskConfigToml = "l2chains = [{name = \"OP Mainnet\", chainId = 10}]\n" "\n"
         "templateName = \"DisputeGameUpgradeTemplate\"\n" "\n"
@@ -47,7 +49,8 @@ contract NestedMultisigTaskTest is Test {
         returns (VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions)
     {
         multisigTask = new DisputeGameUpgradeTemplate();
-        string memory configFilePath = MultisigTaskTestHelper.createTempTomlFile(taskConfigToml);
+        string memory configFilePath =
+            MultisigTaskTestHelper.createTempTomlFile(taskConfigToml, TESTING_DIRECTORY, "000");
         (accountAccesses, actions,,) = multisigTask.signFromChildMultisig(configFilePath, childMultisig);
         MultisigTaskTestHelper.removeFile(configFilePath);
         addrRegistry = multisigTask.addrRegistry();
@@ -220,7 +223,8 @@ contract NestedMultisigTaskTest is Test {
 
             // execute the approve hash call with the signatures
             multisigTask = new DisputeGameUpgradeTemplate();
-            string memory configFilePath = MultisigTaskTestHelper.createTempTomlFile(taskConfigToml);
+            string memory configFilePath =
+                MultisigTaskTestHelper.createTempTomlFile(taskConfigToml, TESTING_DIRECTORY, "001");
             multisigTask.approveFromChildMultisig(configFilePath, childMultisig, packedSignaturesChild);
             MultisigTaskTestHelper.removeFile(configFilePath);
         }
@@ -231,7 +235,7 @@ contract NestedMultisigTaskTest is Test {
         /// snapshot before running the task so we can roll back to this pre-state
         uint256 newSnapshot = vm.snapshotState();
 
-        string memory config = MultisigTaskTestHelper.createTempTomlFile(taskConfigToml);
+        string memory config = MultisigTaskTestHelper.createTempTomlFile(taskConfigToml, TESTING_DIRECTORY, "002");
         (accountAccesses, actions,,) = multisigTask.signFromChildMultisig(config, SECURITY_COUNCIL_CHILD_MULTISIG);
         MultisigTaskTestHelper.removeFile(config);
 
@@ -247,7 +251,8 @@ contract NestedMultisigTaskTest is Test {
 
         /// Now run the executeRun flow
         vm.revertToState(newSnapshot);
-        string memory taskConfigFilePath = MultisigTaskTestHelper.createTempTomlFile(taskConfigToml);
+        string memory taskConfigFilePath =
+            MultisigTaskTestHelper.createTempTomlFile(taskConfigToml, TESTING_DIRECTORY, "003");
         multisigTask.executeRun(taskConfigFilePath, prepareSignatures(parentMultisig, taskHash));
         MultisigTaskTestHelper.removeFile(taskConfigFilePath);
         addrRegistry = multisigTask.addrRegistry();

--- a/test/tasks/StateOverrideManager.t.sol
+++ b/test/tasks/StateOverrideManager.t.sol
@@ -14,6 +14,8 @@ import {StateOverrideManager} from "src/improvements/tasks/StateOverrideManager.
 import {MultisigTaskTestHelper as helper} from "test/tasks/MultisigTask.t.sol";
 
 contract StateOverrideManagerUnitTest is Test {
+    string constant TESTING_DIRECTORY = "state-override-manager-testing";
+
     function setUp() public {
         vm.createSelectFork("mainnet");
     }
@@ -32,7 +34,7 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = \"0x0000000000000000000000000000000000000000000000000000000000000004\", value = \"0x0000000000000000000000000000000000000000000000000000000000000002\"}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "000");
 
         MultisigTask task = new MockMultisigTask();
         vm.expectRevert(
@@ -52,7 +54,7 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = \"0x0000000000000000000000000000000000000000000000000000000000000005\", value = \"0x0000000000000000000000000000000000000000000000000000000000000AAA\"}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "001");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertNonceIncremented(2730, task);
         helper.removeFile(fileName);
@@ -67,7 +69,7 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = \"0x0000000000000000000000000000000000000000000000000000000000000005\", value = \"0x0000000000000000000000000000000000000000000000000000000000000001\"}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "002");
         MultisigTask task = new MockMultisigTask();
         vm.expectRevert();
         task.simulateRun(fileName);
@@ -84,7 +86,7 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = 5, value = \"0x000000000000000000000000000000000000000000000000000000000000000c\"}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "003");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertNonceIncremented(12, task);
         helper.removeFile(fileName);
@@ -104,7 +106,7 @@ contract StateOverrideManagerUnitTest is Test {
             "\"}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "004");
         createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         address actualImplAddr = address(
             uint160(
@@ -124,14 +126,14 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = 5, value = 101}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "005");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertNonceIncremented(101, task);
         helper.removeFile(fileName);
     }
 
     function testOnlyDefaultTenderlyStateOverridesApplied() public {
-        string memory fileName = helper.createTempTomlFile(commonToml);
+        string memory fileName = helper.createTempTomlFile(commonToml, TESTING_DIRECTORY, "006");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         assertDefaultStateOverrides(2, task, SECURITY_COUNCIL_CHILD_MULTISIG);
         helper.removeFile(fileName);
@@ -139,7 +141,7 @@ contract StateOverrideManagerUnitTest is Test {
 
     /// @notice This test verifies that user-defined overrides take precedence over default overrides.
     function testUserTenderlyStateOverridesTakePrecedence() public {
-        string memory noStateOverridesFileName = helper.createTempTomlFile(commonToml);
+        string memory noStateOverridesFileName = helper.createTempTomlFile(commonToml, TESTING_DIRECTORY, "007");
         MultisigTask noStateOverridesTask = createAndRunTask(noStateOverridesFileName, SECURITY_COUNCIL_CHILD_MULTISIG);
         uint256 expectedNonce = noStateOverridesTask.nonce();
         assertDefaultStateOverrides(2, noStateOverridesTask, SECURITY_COUNCIL_CHILD_MULTISIG);
@@ -152,7 +154,7 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = 6, value = 1025}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "008");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
 
         uint256 expectedUserOverrideNonce = 1024;
@@ -192,7 +194,7 @@ contract StateOverrideManagerUnitTest is Test {
             "\", value = 9999}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "009");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
 
         uint256 expectedTotalOverrides = 2;
@@ -220,7 +222,7 @@ contract StateOverrideManagerUnitTest is Test {
             "\", value = 8888}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "010");
         MultisigTask task = createAndRunTask(fileName, SECURITY_COUNCIL_CHILD_MULTISIG);
 
         uint256 expectedTotalOverrides = 3; // i.e. (2 default + 1 user defined)
@@ -269,7 +271,7 @@ contract StateOverrideManagerUnitTest is Test {
         string memory nonNestedSafeToml = "l2chains = [{name = \"Base Sepolia Testnet\", chainId = 84532}]\n" "\n"
             "templateName = \"DisputeGameUpgradeTemplate\"\n" "\n"
             "implementations = [{gameType = 0, implementation = \"0x0000000FFfFFfffFffFfFffFFFfffffFffFFffFf\", l2ChainId = 84532}]\n";
-        string memory fileName = helper.createTempTomlFile(nonNestedSafeToml);
+        string memory fileName = helper.createTempTomlFile(nonNestedSafeToml, TESTING_DIRECTORY, "011");
         MockDisputeGameTask dgt = new MockDisputeGameTask();
         dgt.simulateRun(fileName);
 
@@ -426,7 +428,7 @@ contract StateOverrideManagerUnitTest is Test {
             "    {key = 5, value = \"101\"}\n",
             "]"
         );
-        string memory fileName = helper.createTempTomlFile(toml);
+        string memory fileName = helper.createTempTomlFile(toml, TESTING_DIRECTORY, "012");
         MultisigTask task = new MockMultisigTask();
         vm.expectRevert(
             "StateOverrideManager: Failed to reencode overrides, ensure any decimal numbers are not in quotes"


### PR DESCRIPTION
### TL;DR

Improve temporary file handling in tests by organizing test config files into dedicated directories.

### What changed?

- Updated `.gitignore` to exclude the new `test-config-files/` directory
- Enhanced `MultisigTaskTestHelper.createTempTomlFile()` to:
  - Accept a directory parameter for better organization
  - Use a salt parameter to ensure unique filenames
  - Create nested directories as needed
- Added constants for test directories in each test file:
  - `superchain-address-registry-testing`
  - `multisig-task-testing`
  - `nested-multisig-task-testing`
  - `state-override-manager-testing`
- Updated all test files to use the improved file creation method with appropriate directories and salts

### How to test?

1. Run the test suite to verify all tests pass with the new file handling
2. Verify that temporary files are created in the appropriate subdirectories under `test-config-files/`
3. Check that temporary files are properly cleaned up after tests

### Why make this change?

The previous approach to temporary file creation used random filenames but placed all files in the root directory, which could lead to:
- File collisions between concurrent test runs
- Difficulty tracking which test created which file
- Leftover files cluttering the project root