### PR TITLE
refactor(types): Remove redundant type.

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -22,7 +22,6 @@ import {MultisigTaskPrinter} from "src/libraries/MultisigTaskPrinter.sol";
 import {TaskManager} from "src/improvements/tasks/TaskManager.sol";
 import {Solarray} from "lib/optimism/packages/contracts-bedrock/scripts/libraries/Solarray.sol";
 
-
 type AddressRegistry is address;
 
 abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManager {
@@ -317,7 +316,12 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
         for (uint256 i; i < calls.length; i++) {
             require(targets[i] != address(0), "Invalid target for multisig");
-            calls[i] = IMulticall3.Call3Value({target: targets[i], allowFailure: false, value: values[i], callData: arguments[i]});
+            calls[i] = IMulticall3.Call3Value({
+                target: targets[i],
+                allowFailure: false,
+                value: values[i],
+                callData: arguments[i]
+            });
         }
 
         // Generate calldata
@@ -626,7 +630,8 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
             Signatures.genPrevalidatedSignature(MULTICALL3_ADDRESS),
             MULTICALL3_ADDRESS
         );
-        calls[0] = IMulticall3.Call3Value({target: childMultisig, allowFailure: false, value: 0, callData: approveHashExec});
+        calls[0] =
+            IMulticall3.Call3Value({target: childMultisig, allowFailure: false, value: 0, callData: approveHashExec});
 
         bytes memory customExec = _execTransactionCalldata(
             parentMultisig,

--- a/src/libraries/MultisigTypes.sol
+++ b/src/libraries/MultisigTypes.sol
@@ -17,18 +17,6 @@ struct Action {
     string description;
 }
 
-/// @notice This type is from the Multicall3 contract.
-/// @param target The address of the target contract to call.
-/// @param allowFailure When true, the call is allowed to fail without reverting the entire transaction.
-/// @param value The amount of ETH to send with the call.
-/// @param callData The calldata to call on the target contract.
-struct Call3Value {
-    address target;
-    bool allowFailure;
-    uint256 value;
-    bytes callData;
-}
-
 /// @notice Struct to store information about a token/Eth transfer
 /// @param to The address of the recipient
 /// @param value The amount of tokens/Eth to transfer


### PR DESCRIPTION
# Use IMulticall3.Call3Value instead of local Call3Value struct

This PR removes the redundant `Call3Value` struct from `MultisigTypes.sol` and replaces all usages with the imported `IMulticall3.Call3Value` struct from forge-std. This eliminates duplicate code and ensures we're using the standard interface definition.