### PR TITLE
Update Sepolia OPCM and Standard Validator addresses to rc.8

### DIFF
--- a/src/improvements/tasks/sep/014-U16-opcm-upgrade-v400-op-ink/VALIDATION.md
+++ b/src/improvements/tasks/sep/014-U16-opcm-upgrade-v400-op-ink/VALIDATION.md
@@ -10,11 +10,11 @@ the values printed to the terminal when you run the task.
 > ### Nested Safe 1 (Foundation): `0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B`
 >
 > - Domain Hash: `0x37e1f5dd3b92a004a23589b741196c8a214629d4ea3a690ec8e41ae45c689cbb`
-> - Message Hash: `0xf5b4f9b47c6baa410f8e6fe0faded0521d36845765c3fc8d25ae919b2ff66946`
+> - Message Hash: `0xc7cfbb96124f4c0e3c0f73ae1aaa55746b7497d5416c4d5c1c792eef6e493c2e`
 
 ## Normalized State Diff Hash Attestation
 
 The normalized state diff hash MUST match the hash created by the state changes attested to in the state diff audit report.
 As a signer, you are responsible for making sure this hash is correct. Please compare the hash below with the hash in the audit report.
 
-**Normalized hash:** `0x0da1db92bd8f79154a501a96ee872918190af5c663b495ce17c811748de4af6b`
+**Normalized hash:** `0xf21c08ee68df610b38634605eee5395ba375c61f84898dbc5e72a8697ed65610`

--- a/src/improvements/tasks/sep/014-U16-opcm-upgrade-v400-op-ink/config.toml
+++ b/src/improvements/tasks/sep/014-U16-opcm-upgrade-v400-op-ink/config.toml
@@ -22,8 +22,9 @@ absolutePrestate = "0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b7
 expectedValidationErrors = ""
 
 [addresses]
-OPCM = "0x44c191ce5ce35131e703532af75fa9ca221e2398" # Freshly deployed on Sepolia
-StandardValidatorV400 = "0xA8a1529547306FEC7A32a001705160f2110451aE" # Freshly deployed on Sepolia
+# https://oplabs.notion.site/Sepolia-Release-Checklist-op-contracts-v4-0-0-rc-8-216f153ee1628095ba5be322a0bf9364
+OPCM = "0x1ac76f0833bbfccc732cadcc3ba8a3bbd0e89c3d" # Freshly deployed on Sepolia
+StandardValidatorV400 = "0xaaabe70a4198ab9e99e1a22b1afa0a43cc7f2c79" # Freshly deployed on Sepolia
 
 [stateOverrides]
 0x1Eb2fFc903729a0F03966B917003800b145F56E2 = [

--- a/src/improvements/tasks/sep/015-U16-opcm-upgrade-v400-soneium/VALIDATION.md
+++ b/src/improvements/tasks/sep/015-U16-opcm-upgrade-v400-soneium/VALIDATION.md
@@ -10,11 +10,11 @@ the values printed to the terminal when you run the task.
 > ### Nested Safe 1 (Foundation): `0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B`
 >
 > - Domain Hash: `0x37e1f5dd3b92a004a23589b741196c8a214629d4ea3a690ec8e41ae45c689cbb`
-> - Message Hash: `0x14c003f46937838071f6e65672b6e1302225af6b2081bf1e954247938eb3037e`
+> - Message Hash: `0x2cd75220c7abdf2917440cc98017cbae98ac36818925569b3493f0c6e0a84338`
 
 ## Normalized State Diff Hash Attestation
 
 The normalized state diff hash MUST match the hash created by the state changes attested to in the state diff audit report.
 As a signer, you are responsible for making sure this hash is correct. Please compare the hash below with the hash in the audit report.
 
-**Normalized hash:** `0xfbb5d8981ed49c9645cf8d0a1e5364a1b10f97a4453e070a7879c39ae2845a8a`
+**Normalized hash:** `0xa0e4e0b77250520faf7057e117d834a646791fc847bf443c8d42d54c3ea8460e`

--- a/src/improvements/tasks/sep/015-U16-opcm-upgrade-v400-soneium/config.toml
+++ b/src/improvements/tasks/sep/015-U16-opcm-upgrade-v400-soneium/config.toml
@@ -15,8 +15,9 @@ absolutePrestate = "0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b7
 expectedValidationErrors = "PDDG-130,PLDG-10"
 
 [addresses]
-OPCM = "0x44c191ce5ce35131e703532af75fa9ca221e2398" # Freshly deployed on Sepolia
-StandardValidatorV400 = "0xA8a1529547306FEC7A32a001705160f2110451aE" # Freshly deployed on Sepolia
+# https://oplabs.notion.site/Sepolia-Release-Checklist-op-contracts-v4-0-0-rc-8-216f153ee1628095ba5be322a0bf9364
+OPCM = "0x1ac76f0833bbfccc732cadcc3ba8a3bbd0e89c3d" # Freshly deployed on Sepolia
+StandardValidatorV400 = "0xaaabe70a4198ab9e99e1a22b1afa0a43cc7f2c79" # Freshly deployed on Sepolia
 
 [stateOverrides]
 0x1Eb2fFc903729a0F03966B917003800b145F56E2 = [

--- a/src/improvements/tasks/sep/016-U16-opcm-upgrade-v400-uni/VALIDATION.md
+++ b/src/improvements/tasks/sep/016-U16-opcm-upgrade-v400-uni/VALIDATION.md
@@ -10,11 +10,11 @@ the values printed to the terminal when you run the task.
 > ### Nested Safe 1 (L1ProxyAdminOwner): `0xd363339eE47775888Df411A163c586a8BdEA9dbf` - This safe is not nested.
 >
 > - Domain Hash: `0x2fedecce87979400ff00d5cec4c77da942d43ab3b9db4a5ffc51bb2ef498f30b`
-> - Message Hash: `0xae6d9637055732e9bd9fd79d6874d616171381a3eea0516e15165a3fefee1a60` 
+> - Message Hash: `0x0664b06c2fd13236ac557f5115f6c73fc72405593648f58ab48cf198d4f1c3dc`
 
 ## Normalized State Diff Hash Attestation
 
 The normalized state diff hash MUST match the hash created by the state changes attested to in the state diff audit report.
 As a signer, you are responsible for making sure this hash is correct. Please compare the hash below with the hash in the audit report.
 
-**Normalized hash:** `0x7c4f49c86766549f938fd0850aa4bf0ca4300116c0b4a6a154e4856147da754c`
+**Normalized hash:** `0x8763756674cf7638da9caa8196e90cb641fa6a1f364a25e7590eb5a66252bf5b`

--- a/src/improvements/tasks/sep/016-U16-opcm-upgrade-v400-uni/config.toml
+++ b/src/improvements/tasks/sep/016-U16-opcm-upgrade-v400-uni/config.toml
@@ -18,8 +18,9 @@ absolutePrestate = "0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b7
 expectedValidationErrors = "PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30"
 
 [addresses]
-OPCM = "0x44c191ce5ce35131e703532af75fa9ca221e2398" # Freshly deployed on Sepolia
-StandardValidatorV400 = "0xA8a1529547306FEC7A32a001705160f2110451aE" # Freshly deployed on Sepolia
+# https://oplabs.notion.site/Sepolia-Release-Checklist-op-contracts-v4-0-0-rc-8-216f153ee1628095ba5be322a0bf9364
+OPCM = "0x1ac76f0833bbfccc732cadcc3ba8a3bbd0e89c3d" # Freshly deployed on Sepolia
+StandardValidatorV400 = "0xaaabe70a4198ab9e99e1a22b1afa0a43cc7f2c79" # Freshly deployed on Sepolia
 
 [stateOverrides]
 0xd363339eE47775888Df411A163c586a8BdEA9dbf = [

--- a/src/improvements/tasks/sep/017-U16-opcm-upgrade-v400-base/VALIDATION.md
+++ b/src/improvements/tasks/sep/017-U16-opcm-upgrade-v400-base/VALIDATION.md
@@ -10,11 +10,11 @@ the values printed to the terminal when you run the task.
 > ### Nested Safe 1 (BaseOperationSafe): `0x6AF0674791925f767060Dd52f7fB20984E8639d8`
 >
 > - Domain Hash: `0x6f25427e79742a1eb82c103e2bf43c85fc59509274ec258ad6ed841c4a0048aa`
-> - Message Hash: `0xb0e9321759da6930944ceaffe44bd595c5954557a8a244dca3de0e420b28c9c7`
+> - Message Hash: `0xa2ee651b40adf1e6777d8212dad3f25e3f33ca60884538433b5641941dc05697`
 
 ## Normalized State Diff Hash Attestation
 
 The normalized state diff hash MUST match the hash created by the state changes attested to in the state diff audit report.
 As a signer, you are responsible for making sure this hash is correct. Please compare the hash below with the hash in the audit report.
 
-**Normalized hash:** `0xb3b4982d0ea5d06db03f60b97cfa696bfa215b5fdc63bd2c5221f4e3b452f856`
+**Normalized hash:** `0x1a82465ee90d8ea2776a61797d9c134cac943e96f3314cf90beb2e3cd6cb3c84`

--- a/src/improvements/tasks/sep/017-U16-opcm-upgrade-v400-base/config.toml
+++ b/src/improvements/tasks/sep/017-U16-opcm-upgrade-v400-base/config.toml
@@ -17,8 +17,9 @@ absolutePrestate = "0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b7
 expectedValidationErrors = "PROXYA-10,DF-30,PDDG-DWETH-30,PDDG-130,PLDG-DWETH-30"
 
 [addresses]
-OPCM = "0x44c191ce5ce35131e703532af75fa9ca221e2398" # Freshly deployed on Sepolia
-StandardValidatorV400 = "0xA8a1529547306FEC7A32a001705160f2110451aE" # Freshly deployed on Sepolia
+# https://oplabs.notion.site/Sepolia-Release-Checklist-op-contracts-v4-0-0-rc-8-216f153ee1628095ba5be322a0bf9364
+OPCM = "0x1ac76f0833bbfccc732cadcc3ba8a3bbd0e89c3d" # Freshly deployed on Sepolia
+StandardValidatorV400 = "0xaaabe70a4198ab9e99e1a22b1afa0a43cc7f2c79" # Freshly deployed on Sepolia
 
 [stateOverrides]
 0x0fe884546476dDd290eC46318785046ef68a0BA9 = [

--- a/test/tasks/example/sep/008-opcm-upgrade-v400/config.toml
+++ b/test/tasks/example/sep/008-opcm-upgrade-v400/config.toml
@@ -13,5 +13,5 @@ absolutePrestate = "0x03eb07101fbdeaf3f04d9fb76526362c1eea2824e4c6e970bdb19675b7
 expectedValidationErrors = ""
 
 [addresses]
-OPCM = "0x44c191ce5ce35131e703532af75fa9ca221e2398" # Freshly deployed on Sepolia
-StandardValidatorV400 = "0xA8a1529547306FEC7A32a001705160f2110451aE" # Freshly deployed on Sepolia
+OPCM = "0x1ac76f0833bbfccc732cadcc3ba8a3bbd0e89c3d" # Freshly deployed on Sepolia
+StandardValidatorV400 = "0xaaabe70a4198ab9e99e1a22b1afa0a43cc7f2c79" # Freshly deployed on Sepolia


### PR DESCRIPTION
The new addresses are attested to here: https://oplabs.notion.site/Sepolia-Release-Checklist-op-contracts-v4-0-0-rc-8-216f153ee1628095ba5be322a0bf9364