### PR TITLE
fix: remove Mode and metal CI simulations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,14 +410,6 @@ workflows:
       - just_simulate_sc_rehearsal_4:
           context:
             - circleci-repo-readonly-authenticated-github-token
-      - just_simulate_nested:
-          task: "/eth/metal-002-fp-upgrade"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
-      - just_simulate_nested:
-          task: "/eth/mode-002-fp-upgrade"
-          context:
-            - circleci-repo-readonly-authenticated-github-token
 
       - simulate_sequence:
           name: simulate_sequence_eth


### PR DESCRIPTION
Both tasks have been executed so these should be removed from CI. 