### PR TITLE
fix: CirclCI no output in terminal timeout increased.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,8 @@ jobs:
       - utils/checkout-with-mise
       - run:
           name: "Run stacked simulation for network: <<parameters.network>>"
+          # This may need to be increased in the future. We should focus on fixing the performance first before bumping this.
+          no_output_timeout: 30m 
           command: |
             just install
             cd src/improvements


### PR DESCRIPTION
We're getting timeouts on `main` and it's because we have long running jobs that don't output to the terminal. 

- Error: https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops/9822/workflows/82de4dff-e46b-4431-9f12-6fa8ef193b2a/jobs/130053
- Doc describing fix: https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-Hit-Timeout-Limit