### PR TITLE
Refactor for-loop to use owner variable for clarity

### DIFF
--- a/script/verification/CouncilFoundationNestedSign.s.sol
+++ b/script/verification/CouncilFoundationNestedSign.s.sol
@@ -23,7 +23,7 @@ contract CouncilFoundationNestedSign is VerificationBase, CommonBase {
         address[] memory securityCouncilSafeOwners = councilSafe.getOwners();
         for (uint256 i = 0; i < securityCouncilSafeOwners.length; i++) {
             address owner = securityCouncilSafeOwners[i];
-            if (securityCouncilSafeOwners[i].code.length == 0) {
+            if (owner.code.length == 0) {
                 addCodeException(owner);
             }
         }
@@ -60,7 +60,7 @@ contract CouncilFoundationGovernorNestedSign is CouncilFoundationNestedSign {
         address[] memory securityCouncilSafeOwners = safe.getOwners();
         for (uint256 i = 0; i < securityCouncilSafeOwners.length; i++) {
             address owner = securityCouncilSafeOwners[i];
-            if (securityCouncilSafeOwners[i].code.length == 0) {
+            if (owner.code.length == 0) {
                 addCodeException(owner);
             }
         }


### PR DESCRIPTION
Updated the for-loop in the _addCodeExceptions function to use the owner variable when checking and adding code exceptions. This improves code readability and maintains consistent style throughout the contract. No functional changes were made.