### PR TITLE
Mark U16 tasks 016-021 as READY TO SIGN

### DIFF
--- a/src/improvements/tasks/eth/016-U16-enable-dpm/README.md
+++ b/src/improvements/tasks/eth/016-U16-enable-dpm/README.md
@@ -1,6 +1,6 @@
 # 016-U16-enable-dpm: Enable New Deputy Pause Module on Ethereum Mainnet
 
-Status: [DRAFT]()
+Status: [READY TO SIGN]()
 
 ## Objective
 

--- a/src/improvements/tasks/eth/017-U16-opcm-upgrade-v400-op-ink/README.md
+++ b/src/improvements/tasks/eth/017-U16-opcm-upgrade-v400-op-ink/README.md
@@ -1,6 +1,6 @@
 # 017-U16-opcm-upgrade-v400-op-ink: Upgrade 16: OP Mainnet and Ink
 
-Status: [DRAFT]()
+Status: [READY TO SIGN]()
 
 ## Objective
 

--- a/src/improvements/tasks/eth/020-U16-remove-dgm/README.md
+++ b/src/improvements/tasks/eth/020-U16-remove-dgm/README.md
@@ -1,6 +1,6 @@
 # 020-U16-remove-dgm: Remove Deputy Guardian Module on Ethereum Mainnet
 
-Status: [DRAFT]()
+Status: [READY TO SIGN]()
 
 ## Objective
 

--- a/src/improvements/tasks/eth/021-U16-remove-dpm/README.md
+++ b/src/improvements/tasks/eth/021-U16-remove-dpm/README.md
@@ -1,6 +1,6 @@
-# 018-U16-remove-dpm: Remove Old Deputy Pause Module on Sepolia
+# 021-U16-remove-dpm: Remove Old Deputy Pause Module on Ethereum Mainnet
 
-Status: [DRAFT]()
+Status: [READY TO SIGN]()
 
 ## Objective
 


### PR DESCRIPTION
## Summary
- Mark U16 tasks 016-021 as READY TO SIGN by updating status in README files
- Updates task 016-U16-enable-dpm from DRAFT to READY TO SIGN
- Updates task 017-U16-opcm-upgrade-v400-op-ink from DRAFT to READY TO SIGN
- Updates task 020-U16-remove-dgm from DRAFT to READY TO SIGN  
- Updates task 021-U16-remove-dpm from DRAFT to READY TO SIGN

## Test plan
- [x] Verify all task README files now show [READY TO SIGN]() status
- [x] Confirm no other files were modified unintentionally

🤖 Generated with [Claude Code](https://claude.ai/code)