### PR TITLE
fix(overrides): Apply overrides sooner so devs can assert on them in `_templateSetup`

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -621,6 +621,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         // Appends the root safe. The earlier a safe address appears in the array, the deeper its level of nesting.
         address[] memory allSafes = Solarray.extend(_childSafes, Solarray.addresses(root));
 
+        // Overrides only matter for simulation and signing. It's important this happens before '_templateSetup' so that
+        // template developers can assert that the state overrides are applied correctly.
+        (uint256[] memory allOriginalNonces) = _overrideState(_taskConfigFilePath, allSafes);
         _templateSetup(_taskConfigFilePath, root); // May set variables used in '_taskStorageWrites'.
 
         templateConfig.allowedStorageKeys = _taskStorageWrites();
@@ -629,8 +632,6 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
         _setAllowedStorageAccesses();
         _setAllowedBalanceChanges();
-
-        (uint256[] memory allOriginalNonces) = _overrideState(_taskConfigFilePath, allSafes); // Overrides only matter for simulation and signing.
 
         vm.label(AddressRegistry.unwrap(addrRegistry), "AddrRegistry");
         vm.label(address(this), "MultisigTask");


### PR DESCRIPTION
Small PR that ensures template devs can assert on state overrides in config.toml files in the `_templateSetup` function. 