### PR TITLE
perf(retries): Intermittent failures slowing down dev workflow, implement retries for forge scripts

### DIFF
--- a/src/improvements/justfile
+++ b/src/improvements/justfile
@@ -202,6 +202,7 @@ simulate CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     network=$(just --justfile "$root_just_file" _get-network-from-task-path "$TASK_PATH")
     ETH_RPC_URL=$(just _fetch-rpc-url "$network")
     HD_PATH=${HD_PATH:-0}
+    FORGE_RETRIES=5
 
     # Get function signature and arguments using helper
     eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
@@ -213,7 +214,7 @@ simulate CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
     
     echo -e "⏳ Simulating task: $task_name for network: '$network' on $target_safe\n"
-    forge script ${script_name} --sig "$sig" "${args[@]}" --ffi --rpc-url $ETH_RPC_URL --sender ${signer} ${fork_block_args}
+    forge script ${script_name} --sig "$sig" "${args[@]}" --ffi --rpc-url $ETH_RPC_URL --sender ${signer} ${fork_block_args} --fork-retries $FORGE_RETRIES
 
 sign CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     #!/usr/bin/env bash

--- a/src/improvements/script/simulate-task.sh
+++ b/src/improvements/script/simulate-task.sh
@@ -17,9 +17,10 @@ simulate_task() {
         exit 1
     fi
     
+    FORGE_RETRIES=3
     rpcUrl=$("$root_dir"/src/improvements/script/get-rpc-url.sh "$task")
     echo "Task: $task"
-    is_nested=$(forge script "$root_dir"/src/improvements/tasks/TaskManager.sol --sig "isNestedTask(string)" "$task/config.toml" --rpc-url "$rpcUrl" --json | jq -r '.returns["0"].value')
+    is_nested=$(forge script "$root_dir"/src/improvements/tasks/TaskManager.sol --sig "isNestedTask(string)" "$task/config.toml" --rpc-url "$rpcUrl" --fork-retries "$FORGE_RETRIES" --json | jq -r '.returns["0"].value')
     echo "Is nested: $is_nested"
     pushd "$task" > /dev/null
     if [ "$is_nested" = "true" ]; then


### PR DESCRIPTION
We're seeing persistent 502 errors when we run the justfile command `simulate-all-templates` in CI. After some debugging, we believe the error is upstream in GCP. Therefore, we're going to implement a simple retry attempt on our end. We only need this for the `simulate` step in the `justfile`.