### PR TITLE
perf: account access decoding/printing significantly impacts performance

### DIFF
--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -21,7 +21,6 @@ import {Utils} from "src/libraries/Utils.sol";
 import {MultisigTaskPrinter} from "src/libraries/MultisigTaskPrinter.sol";
 import {TaskManager} from "src/improvements/tasks/TaskManager.sol";
 import {Solarray} from "lib/optimism/packages/contracts-bedrock/scripts/libraries/Solarray.sol";
-import {LibString} from "@solady/utils/LibString.sol";
 
 type AddressRegistry is address;
 
@@ -30,7 +29,6 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
     using AccountAccessParser for VmSafe.AccountAccess[];
     using AccountAccessParser for VmSafe.AccountAccess;
     using StdStyle for string;
-    using LibString for string;
 
     /// @notice AddressesRegistry contract
     AddressRegistry public addrRegistry;
@@ -798,9 +796,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                     break;
                 }
             }
-            if (!Utils.isCiFoundryProfile()) {
-                _printTenderlySimulationData(payload);
-            }
+            _printTenderlySimulationData(payload);
         }
         normalizedHash_ = AccountAccessParser.normalizedStateDiffHash(accountAccesses, rootSafe.safe, txHash);
         MultisigTaskPrinter.printAuditReportInfo(normalizedHash_);

--- a/src/improvements/tasks/MultisigTask.sol
+++ b/src/improvements/tasks/MultisigTask.sol
@@ -772,7 +772,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         SafeData memory rootSafe = Utils.getSafeData(payload, payload.safes.length - 1);
         // Decoding account accesses and printing to the console significantly impacts performance.
         // Performance only becomes a concern when we're running many tasks in CI.
-        if (!vm.envOr("FOUNDRY_PROFILE", string("")).eq("ci")) {
+        if (!Utils.isCiFoundryProfile()) {
             accountAccesses.decodeAndPrint(rootSafe.safe, txHash);
         }
         MultisigTaskPrinter.printTaskCalldata(rootSafe.callData);
@@ -798,7 +798,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                     break;
                 }
             }
-            _printTenderlySimulationData(payload);
+            if (!Utils.isCiFoundryProfile()) {
+                _printTenderlySimulationData(payload);
+            }
         }
         normalizedHash_ = AccountAccessParser.normalizedStateDiffHash(accountAccesses, rootSafe.safe, txHash);
         MultisigTaskPrinter.printAuditReportInfo(normalizedHash_);

--- a/src/libraries/Utils.sol
+++ b/src/libraries/Utils.sol
@@ -7,6 +7,8 @@ import {LibString} from "@solady/utils/LibString.sol";
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 
 library Utils {
+    using LibString for string;
+
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     /// @notice Helper function to simplify feature-flagging by reading an environment variable
@@ -14,6 +16,10 @@ library Utils {
     /// @return bool True if the feature is enabled (env var is true or 1), false otherwise
     function isFeatureEnabled(string memory _feature) internal view returns (bool) {
         return vm.envOr(_feature, false) || vm.envOr(_feature, uint256(0)) == 1;
+    }
+
+    function isCiFoundryProfile() internal view returns (bool) {
+        return vm.envOr("FOUNDRY_PROFILE", string("")).eq("ci");
     }
 
     /// @notice Checks that values have code on this chain.


### PR DESCRIPTION
Currently, without this change the `template_regression_tests` CI job takes [~10 mins 52 sec](https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops/12793/workflows/08da7257-ee55-4da2-9ec6-545e22d42300/jobs/145737). By not performing the [`decodeAndPrint`](https://github.com/ethereum-optimism/superchain-ops/blob/main/src/improvements/tasks/MultisigTask.sol#L772) functionality, the same job takes: [~6 min 37 sec](https://app.circleci.com/pipelines/github/ethereum-optimism/superchain-ops/12797/workflows/7635b617-ad48-422f-81ed-64d0380fe59a/jobs/145746). 