### PR TITLE
fix: mise go version update

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 # Core dependencies
-go = "1.22.7"
+go = "1.24.6"
 just = "1.37.0"
 shellcheck = "0.10.0"
 yq = "4.44.5"


### PR DESCRIPTION
Moving from `1.22.7` to `1.24.6` based on warning message when trying to run `just install-eip712sign`:

> go: github.com/base/eip712sign@v0.0.11 requires go >= 1.23.0; switching to go1.24.6