### PR TITLE
fix: CI alerts on forge test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
   github-event-action:
     type: string
     default: "__not_set__"
-  github-event-action:
+  github-event-base64:
     type: string
     default: "__not_set__"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,25 +14,13 @@ parameters:
   default_docker_image:
     type: string
     default: cimg/base:2024.01
-  l1_mainnet_rpc_url:
-    type: string
-    default: "https://ci-mainnet-l1-archive.optimism.io"
-  l1_sepolia_rpc_url:
-    type: string
-    default: "https://ci-sepolia-l1.optimism.io"
-  l2_mainnet_rpc_url:
-    type: string
-    default: "https://mainnet.optimism.io"
-  l2_sepolia_rpc_url:
-    type: string
-    default: "https://sepolia.optimism.io"
   github-event-type:
     type: string
     default: "__not_set__"
   github-event-action:
     type: string
     default: "__not_set__"
-  github-event-base64:
+  github-event-action:
     type: string
     default: "__not_set__"
 
@@ -146,6 +134,8 @@ jobs:
             just install
             forge --version
             forge test -vvv
+      - notify-failures-on-main:
+          mentions: "@evm-safety-team"
 
   template_regression_tests:
     circleci_ip_ranges: true


### PR DESCRIPTION
We weren't getting slack alerts when forge test failed. We want to be alerted if there are any broken tests on main. Note: this is prone to 502 errors so we will need to keep an eye on this. 

I've also removed rpc urls that aren't being used. RPC urls are included in the `foundry.toml` file instead of the circle ci yaml file. 