### PR TITLE
fix: fzf added to mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ go = "1.24.6"
 just = "1.37.0"
 shellcheck = "0.10.0"
 yq = "4.44.5"
+fzf = "0.65.0"
 
 # Foundry dependencies
 # Foundry is a special case because it supplies multiple binaries at the same
@@ -20,3 +21,4 @@ anvil = "v1.1.0"
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"
+fzf = "ubi:junegunn/fzf"


### PR DESCRIPTION
`fzf` is used in our justfile [here](https://github.com/ethereum-optimism/superchain-ops/blob/main/src/improvements/justfile#L455) this means it must be added to mise.