### PR TITLE
chore: change statuses

### DIFF
--- a/src/improvements/tasks/sep/027-U16a-opcm-upgrade-v410-op-soneium-ink/README.md
+++ b/src/improvements/tasks/sep/027-U16a-opcm-upgrade-v410-op-soneium-ink/README.md
@@ -1,5 +1,5 @@
 # 027-U16a-opcm-upgrade-v410-op-soneium-ink: Upgrade 16a: OP, Soneium, Ink on Sepolia
-Status: [DRAFT, NOT READY TO SIGN]()
+Status: [READY TO SIGN]()
 
 ## Objective
 

--- a/src/improvements/tasks/sep/028-U16a-opcm-upgrade-v410-unichain/README.md
+++ b/src/improvements/tasks/sep/028-U16a-opcm-upgrade-v410-unichain/README.md
@@ -1,5 +1,5 @@
 # 028-U16a-opcm-upgrade-v410-unichain: Upgrade 16a: Unichain Sepolia on Sepolia
-Status: [DRAFT, NOT READY TO SIGN]()
+Status: [READY TO SIGN]()
 
 ## Objective
 


### PR DESCRIPTION
Change statuses of the v410 opcm tasks of unichain and op/ink/soneium to ready to sign