### PR TITLE
fix: CircleCI retries on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,9 +240,15 @@ workflows:
       - forge_test:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          retry:
+            automatic:
+              - limit: 3
       - template_regression_tests:
           context:
             - circleci-repo-readonly-authenticated-github-token
+          retry:
+            automatic:
+              - limit: 3
       - just_new_recipe_tests
       - shellcheck:
           context:
@@ -263,6 +269,9 @@ workflows:
           network: "eth"
           context:
             - circleci-repo-readonly-authenticated-github-token
+          retry:
+            automatic:
+              - limit: 3
 
       # Stacked simulations for superchain-ops on Sepolia.
       - stacked_simulation:
@@ -270,6 +279,9 @@ workflows:
           network: "sep"
           context:
             - circleci-repo-readonly-authenticated-github-token
+          retry:
+            automatic:
+              - limit: 3
 
   close-issue-workflow:
     when:


### PR DESCRIPTION
We see a lot of flakiness from our CI RPC nodes. To counteract this, we're going to retry 3 times on failure. If the job still fails then we can assume it's a legitimate error. 