### PR TITLE
mark 022-U16a-opcm-upgrade-v410-base as READY TO SIGN

### DIFF
--- a/src/tasks/eth/022-U16a-opcm-upgrade-v410-base/README.md
+++ b/src/tasks/eth/022-U16a-opcm-upgrade-v410-base/README.md
@@ -1,6 +1,6 @@
 # 022-U16a-opcm-upgrade-v410-base: Upgrades Base Mainnet to `op-contracts/v4.1.0` (i.e. U16a)
 
-Status: [DRAFT, NOT READY TO SIGN]()
+Status: [READY TO SIGN]()
 
 ## Objective
 


### PR DESCRIPTION
This PR simply mark's the Base U16a Mainnet Upgrade (`022-U16a-opcm-upgrade-v410-base`) as `READY TO SIGN` in the instructions `README.md`.