### PR TITLE
feat: sep/074 deputy pause key rotation

### DIFF
--- a/src/tasks/sep/074-deputy-pause-key-rotation/README.md
+++ b/src/tasks/sep/074-deputy-pause-key-rotation/README.md
@@ -1,0 +1,26 @@
+# 074-deputy-pause-key-rotation
+
+Status: READY TO SIGN
+
+## Objective
+
+Rotates the `DeputyPauseModule` Deputy EOA from `0x6A07d585eddBa8F9A4E17587F4Ea5378De1c3bAc` to `0x8D2AAe4009418Ef6D83F1F2c90D4dAc3cE2b5D4f`.
+To achieve this, we will use the `setDeputy` function of the `DeputyPauseModule` contract deployed at `0xc6f7C07047ba37116A3FdC444Afb5018f6Df5758`.
+
+## Simulation
+
+Please see the "Simulating and Verifying the Transaction" instructions in [SINGLE.md](../../../SINGLE.md).
+When simulating, ensure the logs say `Using script /your/path/to/superchain-ops/src/template/DeputyPauseKeyRotationTemplate.sol`.
+This ensures all safety checks are run. If the default `SignFromJson.s.sol` script is shown (without the full path), something is wrong and the safety checks will not run.
+
+## State Validation
+
+Please see the instructions for [validation](./VALIDATION.md).
+
+## Execution
+
+Rotates the `DeputyPauseModule` Deputy EOA from `0x6A07d585eddBa8F9A4E17587F4Ea5378De1c3bAc` to `0x8D2AAe4009418Ef6D83F1F2c90D4dAc3cE2b5D4f` in the [DeputyPauseModule](https://sepolia.etherscan.io/address/0xc6f7C07047ba37116A3FdC444Afb5018f6Df5758#code).
+
+## Signing and execution
+
+This task has to be signed by the [FakeFoundationOperationsSafe](https://sepolia.etherscan.io/address/0x837DE453AD5F21E89771e3c06239d8236c0EFd5E).

--- a/src/tasks/sep/074-deputy-pause-key-rotation/VALIDATION.md
+++ b/src/tasks/sep/074-deputy-pause-key-rotation/VALIDATION.md
@@ -1,0 +1,60 @@
+# Validation
+
+This document can be used to validate the state diff resulting from the execution of the upgrade
+transaction.
+
+For each contract listed in the state diff, please verify that no contracts or state changes shown in the Tenderly diff are missing from this document. Additionally, please verify that for each contract:
+
+- The following state changes (and none others) are made to that contract. This validates that no unexpected state changes occur.
+- All addresses (in section headers and storage values) match the provided name, using the Etherscan and Superchain Registry links provided. This validates the bytecode deployed at the addresses contains the correct logic.
+- All key values match the semantic meaning provided, which can be validated using the storage layout links provided.
+
+## Expected Domain and Message Hashes
+
+> [!CAUTION]
+> Before signing, ensure the below hashes match what is on your ledger.
+>
+> ### Optimism Foundation
+>
+> Domain Hash: 0xe84ad8db37faa1651b140c17c70e4c48eaa47a635e0db097ddf4ce1cc14b9ecb
+> Message Hash: 0xafab6e4cffa2647bb9f26cf85d2cb60c7ad6b9a2d4904abd7ac0f0af4279958a
+
+## State Overrides
+
+The following state overrides should be seen:
+
+### `0x837DE453AD5F21E89771e3c06239d8236c0EFd5E` (The Optimism Foundation Operations Safe)
+
+Links:
+
+- [Etherscan](https://sepolia.etherscan.io/address/0x837DE453AD5F21E89771e3c06239d8236c0EFd5E)
+
+Enables the simulation by setting the threshold to 1:
+
+- **Key:** `0x0000000000000000000000000000000000000000000000000000000000000004` <br/>
+  **Value:** `0x0000000000000000000000000000000000000000000000000000000000000001`
+
+## State Changes
+
+### `0x837de453ad5f21e89771e3c06239d8236c0efd5e` (Foundation Operations Safe)
+
+- **Key:** `0x0000000000000000000000000000000000000000000000000000000000000005`
+  - **Decoded Kind:** `uint256`
+  - **Before:** `11`
+  - **After:** `12`
+  - **Summary:** nonce
+  - **Detail:**
+
+This updates the nonce of the Foundation Operations Safe.
+
+---
+
+### `0xc6f7c07047ba37116a3fdc444afb5018f6df5758` (DeputyPauseModule)
+
+- **Key:** `0x0000000000000000000000000000000000000000000000000000000000000002`
+  - **Before:** `0x0000000000000000000000006a07d585eddba8f9a4e17587f4ea5378de1c3bac`
+  - **After:** `0x0000000000000000000000008d2aae4009418ef6d83f1f2c90d4dac3ce2b5d4f`
+  - **Summary:**
+  - **Detail:**
+
+This updates the previous deputy `0x6A07d585eddBa8F9A4E17587F4Ea5378De1c3bAc` to `0x8D2AAe4009418Ef6D83F1F2c90D4dAc3cE2b5D4f`.

--- a/src/tasks/sep/074-deputy-pause-key-rotation/config.toml
+++ b/src/tasks/sep/074-deputy-pause-key-rotation/config.toml
@@ -1,0 +1,12 @@
+l2chains = [{name = "OP Sepolia Testnet", chainId = 11155420}]
+templateName = "DeputyPauseKeyRotationTemplate"
+
+newDeputy = "0x8D2AAe4009418Ef6D83F1F2c90D4dAc3cE2b5D4f"
+
+newDeputySignature = "0x3d3d1206bfb51e9d6db5ab1d474619cffa44907b5f2055966fa26cc85c6783f45f78cdfb0300f89763e29357c9f077f1ae83cc83a2711f51f1b4c84478287e8e1c"
+
+[stateOverrides]
+# Nonce override for simulation (storage slot 0x5 is the nonce)
+0x837DE453AD5F21E89771e3c06239d8236c0EFd5E = [
+    {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = 11}
+]


### PR DESCRIPTION
## Summary

Split from #1396 — this PR contains **only** the Sepolia deputy pause key rotation task so it can land and execute independently of mainnet.

- `src/tasks/sep/074-deputy-pause-key-rotation/` — rotates `DeputyPauseModule` Deputy EOA on OP Sepolia from `0x6A07d585eddBa8F9A4E17587F4Ea5378De1c3bAc` to `0x8D2AAe4009418Ef6D83F1F2c90D4dAc3cE2b5D4f` via `setDeputy()` on the DeputyPauseModule at `0xc6f7C07047ba37116A3FdC444Afb5018f6Df5758`.
- Signed by the FakeFoundationOperationsSafe (`0x837DE453AD5F21E89771e3c06239d8236c0EFd5E`).

Mainnet counterpart lives in a separate PR so we can sign/execute sepolia first, confirm, then proceed with mainnet without being blocked by any sepolia fix-ups.

Original PR: #1396 (to be closed once both splits land).
Authored by @JosepBove, split into separate PRs at review request.

## Test plan

- [ ] Simulate with `just simulate src/tasks/sep/074-deputy-pause-key-rotation` and confirm the logs say `Using script .../DeputyPauseKeyRotationTemplate.sol`
- [ ] Verify the Tenderly state diff matches `VALIDATION.md`:
  - nonce bump on `0x837de453ad5f21e89771e3c06239d8236c0efd5e` (11 → 12)
  - deputy storage slot `0x2` on `0xc6f7c07047ba37116a3fdc444afb5018f6df5758` updated
- [ ] Confirm domain/message hashes on the ledger match `VALIDATION.md`