### PR TITLE
fix(mise): Replace deprecated alias section

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -18,7 +18,7 @@ forge = "v1.1.0" # https://github.com/foundry-rs/foundry/releases/tag/v1.1.0
 cast = "v1.1.0"
 anvil = "v1.1.0"
 
-[alias]
+[tool_alias]
 forge = "ubi:foundry-rs/foundry[exe=forge]"
 cast = "ubi:foundry-rs/foundry[exe=cast]"
 anvil = "ubi:foundry-rs/foundry[exe=anvil]"


### PR DESCRIPTION
Working on superchain-ops with a recent version of mise results in the following warning in the shell prompt:
```
 mise WARN  deprecated [alias]: [alias] is deprecated, use [tool_alias] instead in ~/optimism/superchain-ops/mise.toml      10:49:13
mise WARN  deprecated [alias]: [alias] is deprecated, use [tool_alias] instead in ~/optimism/superchain-ops/mise.toml
```

This change replaces the deprecated `[alias]` syntax with `[tool_alias]` to silence the warning.
Users on older versions of mise may need to update, but since tool_alias was introduced nearly a year ago, breakage is unlikely.