### PR TITLE
fix: v800 support upgrading permissioned to permissionless

### DIFF
--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -92,6 +92,10 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
                 Claim.unwrap(_upgrades[i].cannonKonaPrestate) != bytes32(0),
                 "OPCMUpgradeV800: cannonKonaPrestate is zero"
             );
+            require(
+                _upgrades[i].startingRespectedGameType != CANNON,
+                "OPCMUpgradeV800: startingRespectedGameType cannot be CANNON"
+            );
             chainsToUpgrade.push(_upgrades[i].chainId);
             upgrades[_upgrades[i].chainId] = _upgrades[i];
         }

--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -165,7 +165,12 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     }
 
     /// @notice Returns whether a dispute game should be enabled based on the existing factory state.
-    function _isGameTypeEnabled(IDisputeGameFactory disputeGameFactory, uint32 gt) internal view returns (bool) {
+    function _isGameTypeEnabled(IDisputeGameFactory disputeGameFactory, uint32 gt, uint32 startingRespectedGameType)
+        internal
+        view
+        returns (bool)
+    {
+        if (gt == startingRespectedGameType) return true;
         if (gt == CANNON) return false;
         if (gt == PERMISSIONED_CANNON) return false;
         if (gt == CANNON_KONA) return false;
@@ -173,7 +178,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
             return address(disputeGameFactory.gameImpls(GameType.wrap(CANNON))) != address(0);
         }
         if (gt == SUPER_PERMISSIONED_CANNON) {
-            return address(disputeGameFactory.gameImpls(GameType.wrap(PERMISSIONED_CANNON))) != address(0);
+            return true;
         }
         if (gt == SUPER_CANNON_KONA) {
             return address(disputeGameFactory.gameImpls(GameType.wrap(CANNON_KONA))) != address(0);
@@ -197,9 +202,10 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         uint32 gt,
         bytes32 cannonPre,
         bytes32 cannonKonaPre,
-        uint256 bond
+        uint256 bond,
+        uint32 startingRespectedGameType
     ) internal view returns (IOPContractsManagerV800.DisputeGameConfig memory) {
-        bool enabled = _isGameTypeEnabled(a.factory, gt);
+        bool enabled = _isGameTypeEnabled(a.factory, gt, startingRespectedGameType);
         bytes memory gameArgs;
         if (enabled) {
             bool isPermissioned = gt == PERMISSIONED_CANNON || gt == SUPER_PERMISSIONED_CANNON;
@@ -234,6 +240,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         bytes32 cannonPre = Claim.unwrap(upgrades[chainId].cannonPrestate);
         bytes32 cannonKonaPre = Claim.unwrap(upgrades[chainId].cannonKonaPrestate);
         uint256 bond = upgrades[chainId].initBond;
+        uint32 startingRespectedGameType = upgrades[chainId].startingRespectedGameType;
 
         IOPContractsManagerV800.DisputeGameConfig[] memory cfgs = new IOPContractsManagerV800.DisputeGameConfig[](7);
         uint32[7] memory gts = [
@@ -246,7 +253,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
             ZK_DISPUTE_GAME
         ];
         for (uint256 i = 0; i < 7; i++) {
-            cfgs[i] = _buildOneGameConfig(a, gts[i], cannonPre, cannonKonaPre, bond);
+            cfgs[i] = _buildOneGameConfig(a, gts[i], cannonPre, cannonKonaPre, bond, startingRespectedGameType);
         }
         return cfgs;
     }

--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -174,10 +174,10 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         view
         returns (bool)
     {
-        if (gt == startingRespectedGameType) return true;
         if (gt == CANNON) return false;
         if (gt == PERMISSIONED_CANNON) return false;
         if (gt == CANNON_KONA) return false;
+        if (gt == startingRespectedGameType) return true;
         if (gt == SUPER_CANNON) {
             return address(disputeGameFactory.gameImpls(GameType.wrap(CANNON))) != address(0);
         }

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -5,7 +5,7 @@ import {Claim} from "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 import {Test} from "forge-std/Test.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {IGnosisSafe, Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
-import {IOPContractsManagerV800, OPCMUpgradeV800} from "src/template/OPCMUpgradeV800.sol";
+import {IDisputeGameFactory, IOPContractsManagerV800, OPCMUpgradeV800} from "src/template/OPCMUpgradeV800.sol";
 import {SuperchainAddressRegistry} from "src/SuperchainAddressRegistry.sol";
 import {Action} from "src/libraries/MultisigTypes.sol";
 
@@ -77,6 +77,32 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
                 }
             }
         }
+    }
+
+    function test_starting_respected_game_type_overrides_disabled_guard() public {
+        upgrades[CHAIN_ID].startingRespectedGameType = 8;
+
+        IOPContractsManagerV800.DisputeGameConfig[] memory configs = _buildGameConfigs(CHAIN_ID);
+
+        assertEq(configs[0].gameType, 0);
+        assertFalse(configs[0].enabled);
+        assertEq(configs[0].initBond, 0);
+        assertEq(configs[0].gameArgs.length, 0);
+
+        assertEq(configs[1].gameType, 1);
+        assertFalse(configs[1].enabled);
+        assertEq(configs[1].initBond, 0);
+        assertEq(configs[1].gameArgs.length, 0);
+
+        assertEq(configs[2].gameType, 8);
+        assertTrue(configs[2].enabled);
+        assertEq(configs[2].initBond, upgrades[CHAIN_ID].initBond);
+        bytes32 prestate = abi.decode(configs[2].gameArgs, (bytes32));
+        assertEq(prestate, Claim.unwrap(upgrades[CHAIN_ID].cannonKonaPrestate));
+    }
+
+    function test_super_permissioned_cannon_is_enabled_by_default() public view {
+        assertTrue(_isGameTypeEnabled(IDisputeGameFactory(address(0)), 5, 0));
     }
 
     function test_upgrade_sepolia() public {

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -27,13 +27,12 @@ contract OPCMUpgradeV800SetupHarness is OPCMUpgradeV800 {
 
 contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
     string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
-    string constant INVALID_CONFIG = ".context/opcm-upgrade-v800-cannon-starting-game-type.toml";
+    string constant INVALID_CONFIG = "test/tasks/example/sep/035-opcm-upgrade-v800/opcm-upgrade-v800-cannon-starting-game-type.toml";
 
     function test_rejects_cannon_starting_respected_game_type() public {
         vm.createSelectFork(vm.rpcUrl("sepolia"));
         string memory config = vm.readFile(string.concat(FIXTURES, "config.toml"));
         config = vm.replace(config, "startingRespectedGameType = 9", "startingRespectedGameType = 0");
-        vm.createDir(".context", false);
         vm.writeFile(INVALID_CONFIG, config);
 
         OPCMUpgradeV800SetupHarness harness = new OPCMUpgradeV800SetupHarness();

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -103,28 +103,6 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         }
     }
 
-    function test_starting_respected_game_type_overrides_disabled_guard() public {
-        upgrades[CHAIN_ID].startingRespectedGameType = 8;
-
-        IOPContractsManagerV800.DisputeGameConfig[] memory configs = _buildGameConfigs(CHAIN_ID);
-
-        assertEq(configs[0].gameType, 0);
-        assertFalse(configs[0].enabled);
-        assertEq(configs[0].initBond, 0);
-        assertEq(configs[0].gameArgs.length, 0);
-
-        assertEq(configs[1].gameType, 1);
-        assertFalse(configs[1].enabled);
-        assertEq(configs[1].initBond, 0);
-        assertEq(configs[1].gameArgs.length, 0);
-
-        assertEq(configs[2].gameType, 8);
-        assertTrue(configs[2].enabled);
-        assertEq(configs[2].initBond, upgrades[CHAIN_ID].initBond);
-        bytes32 prestate = abi.decode(configs[2].gameArgs, (bytes32));
-        assertEq(prestate, Claim.unwrap(upgrades[CHAIN_ID].cannonKonaPrestate));
-    }
-
     function test_super_permissioned_cannon_is_enabled_by_default() public view {
         assertTrue(_isGameTypeEnabled(IDisputeGameFactory(address(0)), 5, 0));
     }

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -27,7 +27,8 @@ contract OPCMUpgradeV800SetupHarness is OPCMUpgradeV800 {
 
 contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
     string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
-    string constant INVALID_CONFIG = "test/tasks/example/sep/035-opcm-upgrade-v800/opcm-upgrade-v800-cannon-starting-game-type.toml";
+    string constant INVALID_CONFIG =
+        "test/tasks/example/sep/035-opcm-upgrade-v800/opcm-upgrade-v800-cannon-starting-game-type.toml";
 
     function test_rejects_cannon_starting_respected_game_type() public {
         vm.createSelectFork(vm.rpcUrl("sepolia"));

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -33,6 +33,7 @@ contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
         vm.createSelectFork(vm.rpcUrl("sepolia"));
         string memory config = vm.readFile(string.concat(FIXTURES, "config.toml"));
         config = vm.replace(config, "startingRespectedGameType = 9", "startingRespectedGameType = 0");
+        vm.createDir(".context", false);
         vm.writeFile(INVALID_CONFIG, config);
 
         OPCMUpgradeV800SetupHarness harness = new OPCMUpgradeV800SetupHarness();

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -18,6 +18,29 @@ interface ISystemConfigExt {
     function superchainConfig() external view returns (address);
 }
 
+contract OPCMUpgradeV800SetupHarness is OPCMUpgradeV800 {
+    function setupForTest(string memory configPath) external {
+        superchainAddrRegistry = new SuperchainAddressRegistry(configPath);
+        _templateSetup(configPath, address(0));
+    }
+}
+
+contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
+    string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
+    string constant INVALID_CONFIG = ".context/opcm-upgrade-v800-cannon-starting-game-type.toml";
+
+    function test_rejects_cannon_starting_respected_game_type() public {
+        vm.createSelectFork(vm.rpcUrl("sepolia"));
+        string memory config = vm.readFile(string.concat(FIXTURES, "config.toml"));
+        config = vm.replace(config, "startingRespectedGameType = 9", "startingRespectedGameType = 0");
+        vm.writeFile(INVALID_CONFIG, config);
+
+        OPCMUpgradeV800SetupHarness harness = new OPCMUpgradeV800SetupHarness();
+        vm.expectRevert("OPCMUpgradeV800: startingRespectedGameType cannot be CANNON");
+        harness.setupForTest(INVALID_CONFIG);
+    }
+}
+
 contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
     string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
     uint256 internal constant CHAIN_ID = 11155420;
@@ -103,6 +126,50 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
 
     function test_super_permissioned_cannon_is_enabled_by_default() public view {
         assertTrue(_isGameTypeEnabled(IDisputeGameFactory(address(0)), 5, 0));
+    }
+
+    /// @notice Exercises the upgrade where a chain currently respecting
+    /// SUPER_PERMISSIONED_CANNON (gt=5) transitions to SUPER_CANNON_KONA (gt=9).
+    /// SUPER_CANNON_KONA must be enabled via the startingRespectedGameType override
+    /// even when CANNON_KONA isn't yet wired into the factory, while
+    /// SUPER_PERMISSIONED_CANNON remains enabled for the transition window.
+    function test_upgrade_super_permissioned_to_super_cannon_kona() public {
+        upgrades[CHAIN_ID].startingRespectedGameType = 9;
+
+        IOPContractsManagerV800.DisputeGameConfig[] memory configs = _buildGameConfigs(CHAIN_ID);
+
+        // _buildGameConfigs order: [CANNON, PERMISSIONED_CANNON, CANNON_KONA,
+        // SUPER_CANNON, SUPER_PERMISSIONED_CANNON, SUPER_CANNON_KONA, ZK_DISPUTE_GAME]
+        assertEq(configs.length, 7);
+
+        // Base games stay disabled.
+        assertEq(configs[0].gameType, 0);
+        assertFalse(configs[0].enabled);
+        assertEq(configs[0].initBond, 0);
+        assertEq(configs[0].gameArgs.length, 0);
+
+        assertEq(configs[1].gameType, 1);
+        assertFalse(configs[1].enabled);
+        assertEq(configs[1].initBond, 0);
+        assertEq(configs[1].gameArgs.length, 0);
+
+        // SUPER_PERMISSIONED_CANNON (gt=5) is always enabled and keeps permissioned encoding.
+        assertEq(configs[4].gameType, 5);
+        assertTrue(configs[4].enabled);
+        assertEq(configs[4].initBond, upgrades[CHAIN_ID].initBond);
+        (bytes32 permPrestate, address proposer, address challenger) =
+            abi.decode(configs[4].gameArgs, (bytes32, address, address));
+        assertEq(permPrestate, Claim.unwrap(upgrades[CHAIN_ID].cannonPrestate));
+        assertEq(proposer, superchainAddrRegistry.getAddress("Proposer", CHAIN_ID));
+        assertEq(challenger, superchainAddrRegistry.getAddress("Challenger", CHAIN_ID));
+
+        // SUPER_CANNON_KONA (gt=9) is enabled because gt == startingRespectedGameType,
+        // even though CANNON_KONA impl is not in the factory. Permissionless encoding.
+        assertEq(configs[5].gameType, 9);
+        assertTrue(configs[5].enabled);
+        assertEq(configs[5].initBond, upgrades[CHAIN_ID].initBond);
+        bytes32 konaPrestate = abi.decode(configs[5].gameArgs, (bytes32));
+        assertEq(konaPrestate, Claim.unwrap(upgrades[CHAIN_ID].cannonKonaPrestate));
     }
 
     function test_upgrade_sepolia() public {


### PR DESCRIPTION
## Summary

Updates the V800 upgrade template so the configured starting respected game type is enabled.

`SUPER_PERMISSIONED_CANNON` enabled by default and adds integration coverage for both behaviors.

Allow setting SUPER_CANNON_KONA as starting respected game type to support upgrading from SUPER_PERMISSIONED_CANNON to SUPER_CANNON_KONA

## Additional context

Validated with `forge test --match-contract SuperRootUpgradeTest`.

fixes https://github.com/ethereum-optimism/optimism/issues/20562
