### PR TITLE
fix: Support odd OPCM behavior during checkStateDiff

### DIFF
--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -433,10 +433,20 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
             // All touched accounts should have code, with the exception of precompiles.
             bool isPrecompile = accountAccess.account >= address(0x1) && accountAccess.account <= address(0xa);
             if (!isPrecompile) {
-                require(
-                    accountAccess.account.code.length != 0,
-                    string.concat("Account has no code: ", vm.toString(accountAccess.account))
-                );
+                // HACK: Allow OPCM Migrate usage of loadOrDeployProxy(address(0), bytes4(0), ...)
+                // Where loadOrDeployProxy makes a staticcall to the zero address
+                if (
+                    !(
+                        accountAccess.account == address(0) && accountAccess.data.length == 4
+                            && bytes4(accountAccess.data) == bytes4(0)
+                            && accountAccess.kind == VmSafe.AccountAccessKind.StaticCall
+                    )
+                ) {
+                    require(
+                        accountAccess.account.code.length != 0,
+                        string.concat("Account has no code: ", vm.toString(accountAccess.account))
+                    );
+                }
             }
 
             if (!_allowedBalanceChanges.contains(accountAccess.account)) {


### PR DESCRIPTION
## Summary

The MultisigTask.checkStateDiff function fails when executing OPCMv2 migrate. This is because the OPCM Migration will [`loadOrDeploy` proxies for ETHLockBox using the zero address](https://github.com/ethereum-optimism/optimism/blob/4b3c09600b26d0ac666f09e07c1c61557f8a3abe/packages/contracts-bedrock/src/L1/opcm/OPContractsManagerMigrator.sol#L144C1-L152C11) - as its intent is to always deploy a new ETHLockBox proxy. As such, the checkStateDiff flags the ensuing staticall to the  zero address to be unexpected; failing the simulation.

This patch adds a special case to ignore such account accesses from the state diff check. Note that this patch still retains other checks such as balance changes and storage accesses to the zero address. We only relax checks to allow the specific access pattern that OPCM Migrate relies on.