### PR TITLE
ci: remove circleci_ip_ranges flag and route fork-sim RPCs via secrets context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ jobs:
     parameters:
       network:
         type: string
-    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
@@ -120,7 +119,6 @@ jobs:
             forge fmt --check
 
   forge_test:
-    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
@@ -144,7 +142,6 @@ jobs:
           mentions: "@security-oncall"
 
   template_regression_tests:
-    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     environment:
@@ -161,7 +158,6 @@ jobs:
           mentions: "@security-oncall"
 
   just_new_recipe_tests:
-    circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
@@ -347,9 +343,11 @@ workflows:
       - forge_test:
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
       - template_regression_tests:
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
       - just_new_recipe_tests
       - shellcheck:
           context:
@@ -370,6 +368,7 @@ workflows:
           network: "eth"
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
 
       # Stacked simulations for superchain-ops on Sepolia.
       - stacked_simulation:
@@ -377,6 +376,7 @@ workflows:
           network: "sep"
           context:
             - circleci-repo-readonly-authenticated-github-token
+            - circleci-repo-rpc-secrets
 
   close-issue-workflow:
     when:

--- a/foundry.toml
+++ b/foundry.toml
@@ -27,10 +27,10 @@ remappings = [
 deny_warnings = true
 
 [profile.ci.rpc_endpoints]
-mainnet = "https://ci-mainnet-l1-archive.optimism.io" 
-sepolia = "https://ci-sepolia-l1-archive.optimism.io" 
-opSepolia = "https://ci-sepolia-l2.optimism.io"
-opMainnet = "https://mainnet.optimism.io" # We eventually need a CI L2 RPC URL for this.
+mainnet = "${OP_CI_MAINNET_L1_ARCHIVE_RPC_URL}"
+sepolia = "${OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL}"
+opSepolia = "${OP_CI_SEPOLIA_L2_RPC_URL}"
+opMainnet = "${OP_CI_MAINNET_L2_RPC_URL}"
 
 [profile.default.rpc_endpoints]
 localhost = "http://127.0.0.1:8545"


### PR DESCRIPTION
## Summary

Removes `circleci_ip_ranges: true` from all 4 jobs in `superchain-ops` that carry it, and migrates the fork-simulation jobs to the `circleci-repo-rpc-secrets` context. Follow-on to ethereum-optimism/optimism#20455 and ethereum-optimism/optimism#20465; part of the org-wide cleanup tracked in ethereum-optimism/core-team#2564.

## Audit chain

`circleci_ip_ranges: true` routes job egress through CircleCI's 21 published static IPs at the cost of 450 credits/GB on top of compute. Inside OP Labs infrastructure that allowlist is consumed by exactly one Traefik middleware (`ci-ip-whitelist` in `ethereum-optimism/k8s`), which gates the `ci-*.optimism.io` RPC and beacon endpoints. Each job in this repo currently using the flag falls into one of two cases:

| Job | What it does network-wise | Tier |
|---|---|---|
| `forge_test` | `forge test --skip Integration` — integration tests (the RPC-using ones) are explicitly skipped via `--skip` | A |
| `just_new_recipe_tests` | `test/script/test-just-new.sh` exercises `just new` CLI parsing only; no network calls | A |
| `stacked_simulation` (eth + sep) | `simulate-task.sh` → `forge script --fork-url $rpcUrl`, resolved via `[profile.ci.rpc_endpoints]` in `foundry.toml` | B |
| `template_regression_tests` | `simulate-all-templates` → `simulate-task.sh` → same `forge --fork-url` path | B |

### Tier A — flag removal only

`just_new_recipe_tests` makes zero network calls; the flag is vestigial and is removed without further changes.

`forge_test` is also classified Tier A (today, no non-Integration test reaches a `[profile.ci]` endpoint), but it additionally receives the `circleci-repo-rpc-secrets` context defensively. The job sets `FOUNDRY_PROFILE: ci` and will resolve `[profile.ci.rpc_endpoints]` at startup; binding the context now means a future contributor adding a non-Integration test that uses one of those endpoints won't hit a confusing "endpoint is empty" error. Cost is one workflow line.

### Tier B — context migration

`stacked_simulation` and `template_regression_tests` both reach allowlisted hostnames indirectly: forge resolves the network name (`mainnet`, `sepolia`, `opSepolia`, `opMainnet`) against `[profile.ci.rpc_endpoints]` in `foundry.toml`. The actual coupling therefore lives in `foundry.toml`, not in the per-job step blocks.

The fix is a single change in `foundry.toml`: replace the four hardcoded `ci-*.optimism.io` URLs with the corresponding `OP_CI_*` env vars provided by `circleci-repo-rpc-secrets`. The jobs themselves get the context added and the flag removed.

This also resolves a long-standing TODO in `foundry.toml`: `opMainnet` previously pointed at the public `mainnet.optimism.io` URL with the comment "We eventually need a CI L2 RPC URL for this." It now uses `OP_CI_MAINNET_L2_RPC_URL`.

## Changes

1. **`foundry.toml`** — four URL → env var swaps in `[profile.ci.rpc_endpoints]`:
   - `mainnet` → `${OP_CI_MAINNET_L1_ARCHIVE_RPC_URL}`
   - `sepolia` → `${OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL}`
   - `opSepolia` → `${OP_CI_SEPOLIA_L2_RPC_URL}`
   - `opMainnet` → `${OP_CI_MAINNET_L2_RPC_URL}` (also closes the pre-existing TODO)

2. **`.circleci/config.yml`**:
   - Remove `circleci_ip_ranges: true` from: `stacked_simulation`, `forge_test`, `template_regression_tests`, `just_new_recipe_tests`.
   - Add `- circleci-repo-rpc-secrets` to the workflow `context:` block for: `forge_test`, `template_regression_tests`, and both `stacked_simulation` workflow entries (`eth`, `sep`).

## Verification

This is a draft PR. Watching CI before marking ready for review. Looking for:
- All four touched jobs pass
- `stacked_simulation` (both networks) and `template_regression_tests` exercise the new RPC URLs without 403s/timeouts
- `forge_test` and `just_new_recipe_tests` pass unchanged

## Reviewer notes

- The `circleci-repo-rpc-secrets` context contains all 6 expected `OP_CI_*` env vars and has no project restrictions (available to all projects in the org by default).
- The pattern matches the monorepo precedent established by ethereum-optimism/optimism#20465.
- One of nine repos slated for this cleanup under ethereum-optimism/core-team#2564.