### PR TITLE
fix(OPCMUpgradeV700): support standard chains in U19 upgrade template

### DIFF
--- a/src/SuperchainAddressRegistry.sol
+++ b/src/SuperchainAddressRegistry.sol
@@ -344,11 +344,9 @@ contract SuperchainAddressRegistry is StdChains {
 
         // EthLockboxProxy cannot be discovered on-chain via a standard getter; read from
         // the registry JSON when present (introduced in op-contracts v7.x).
-        string memory ethLockboxKey =
-            string.concat("$.", vm.toString(chain.chainId), ".EthLockboxProxy");
+        string memory ethLockboxKey = string.concat("$.", vm.toString(chain.chainId), ".EthLockboxProxy");
         if (vm.keyExistsJson(chainAddressesContent, ethLockboxKey)) {
-            address ethLockbox =
-                parseContractAddress(chainAddressesContent, chain.chainId, "EthLockboxProxy");
+            address ethLockbox = parseContractAddress(chainAddressesContent, chain.chainId, "EthLockboxProxy");
             if (ethLockbox != address(0)) saveAddress("EthLockboxProxy", chain, ethLockbox);
         }
     }

--- a/src/SuperchainAddressRegistry.sol
+++ b/src/SuperchainAddressRegistry.sol
@@ -341,14 +341,6 @@ contract SuperchainAddressRegistry is StdChains {
 
         optimismPortalProxy = getOptimismPortalProxy(l1CrossDomainMessengerProxy);
         saveAddress("OptimismPortalProxy", chain, optimismPortalProxy);
-
-        // EthLockboxProxy cannot be discovered on-chain via a standard getter; read from
-        // the registry JSON when present (introduced in op-contracts v7.x).
-        string memory ethLockboxKey = string.concat("$.", vm.toString(chain.chainId), ".EthLockboxProxy");
-        if (vm.keyExistsJson(chainAddressesContent, ethLockboxKey)) {
-            address ethLockbox = parseContractAddress(chainAddressesContent, chain.chainId, "EthLockboxProxy");
-            if (ethLockbox != address(0)) saveAddress("EthLockboxProxy", chain, ethLockbox);
-        }
     }
 
     function _saveProxyAdminEntries(ChainInfo memory chain, address systemConfigProxy) internal {

--- a/src/SuperchainAddressRegistry.sol
+++ b/src/SuperchainAddressRegistry.sol
@@ -341,6 +341,16 @@ contract SuperchainAddressRegistry is StdChains {
 
         optimismPortalProxy = getOptimismPortalProxy(l1CrossDomainMessengerProxy);
         saveAddress("OptimismPortalProxy", chain, optimismPortalProxy);
+
+        // EthLockboxProxy cannot be discovered on-chain via a standard getter; read from
+        // the registry JSON when present (introduced in op-contracts v7.x).
+        string memory ethLockboxKey =
+            string.concat("$.", vm.toString(chain.chainId), ".EthLockboxProxy");
+        if (vm.keyExistsJson(chainAddressesContent, ethLockboxKey)) {
+            address ethLockbox =
+                parseContractAddress(chainAddressesContent, chain.chainId, "EthLockboxProxy");
+            if (ethLockbox != address(0)) saveAddress("EthLockboxProxy", chain, ethLockbox);
+        }
     }
 
     function _saveProxyAdminEntries(ChainInfo memory chain, address systemConfigProxy) internal {

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -345,6 +345,7 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         address sharedSC = superchainAddrRegistry.getAddress("SuperchainConfig", chains[0].chainId);
 
+
         // ERC-1967 implementation slot: keccak256("eip1967.proxy.implementation") - 1
         bytes32 ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
@@ -355,15 +356,6 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         // on the shared SuperchainConfig, so they must rely on a prior task having done it.
         address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, ERC1967_IMPL_SLOT))));
 
-        // The ERC-1967 implementation slot: keccak256("eip1967.proxy.implementation") - 1
-        bytes32 constant ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
-
-        // Skip upgradeSuperchain if the SuperchainConfig proxy is already pointing at the
-        // v7.1.17 implementation. This happens in the stacked execution model when a prior
-        // task (e.g. 086-U19-op with the shared L1PAO) already ran upgradeSuperchain.
-        // Chains with non-standard L1PAOs (e.g. Unichain) cannot authorize ProxyAdmin.upgrade()
-        // on the shared SuperchainConfig, so they must rely on a prior task having done it.
-        address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, ERC1967_IMPL_SLOT))));
         // Decode only the first return value (superchainConfigImpl) from implementations().
         (, bytes memory implData) = address(OPCM).staticcall(abi.encodeWithSignature("implementations()"));
         address targetSCImpl = abi.decode(implData, (address));

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -457,18 +457,16 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
             // Only include true EOAs (no code). Contract addresses (e.g. multisig owners)
             // must not be in the exceptions list — they are handled by the normal allowed
             // storage accesses check instead.
-            address[4] memory candidates = [
-                sc.owner(),
-                sc.unsafeBlockSigner(),
-                sc.batchInbox(),
-                address(uint160(uint256(sc.batcherHash())))
-            ];
+            address[4] memory candidates =
+                [sc.owner(), sc.unsafeBlockSigner(), sc.batchInbox(), address(uint160(uint256(sc.batcherHash())))];
             for (uint256 j = 0; j < 4; j++) {
                 if (candidates[j].code.length == 0) exceptions[cursor++] = candidates[j];
             }
         }
         address[] memory result = new address[](cursor);
-        for (uint256 i = 0; i < cursor; i++) result[i] = exceptions[i];
+        for (uint256 i = 0; i < cursor; i++) {
+            result[i] = exceptions[i];
+        }
         return result;
     }
 }

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -354,10 +354,18 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         // Chains with non-standard L1PAOs (e.g. Unichain) cannot authorize ProxyAdmin.upgrade()
         // on the shared SuperchainConfig, so they must rely on a prior task having done it.
         address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, ERC1967_IMPL_SLOT))));
+
+        // The ERC-1967 implementation slot: keccak256("eip1967.proxy.implementation") - 1
+        bytes32 constant ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+        // Skip upgradeSuperchain if the SuperchainConfig proxy is already pointing at the
+        // v7.1.17 implementation. This happens in the stacked execution model when a prior
+        // task (e.g. 086-U19-op with the shared L1PAO) already ran upgradeSuperchain.
+        // Chains with non-standard L1PAOs (e.g. Unichain) cannot authorize ProxyAdmin.upgrade()
+        // on the shared SuperchainConfig, so they must rely on a prior task having done it.
+        address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, ERC1967_IMPL_SLOT))));
         // Decode only the first return value (superchainConfigImpl) from implementations().
-        (bool implCallSuccess, bytes memory implData) =
-            address(OPCM).staticcall(abi.encodeWithSignature("implementations()"));
-        require(implCallSuccess && implData.length >= 32, "OPCMUpgradeV700: implementations() call failed");
+        (, bytes memory implData) = address(OPCM).staticcall(abi.encodeWithSignature("implementations()"));
         address targetSCImpl = abi.decode(implData, (address));
 
         if (currentSCImpl != targetSCImpl) {
@@ -373,10 +381,11 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
             require(scOk, "OPCMUpgradeV700: upgradeSuperchain failed");
         } else {
             console.log(
-                "OPCMUpgradeV700: skipping upgradeSuperchain - SuperchainConfig already at target impl %s",
+                "OPCMUpgradeV700: skipping upgradeSuperchain - SuperchainConfig proxy already points at target implementation %s",
                 targetSCImpl
             );
         }
+
 
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -345,7 +345,6 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         address sharedSC = superchainAddrRegistry.getAddress("SuperchainConfig", chains[0].chainId);
 
-
         // ERC-1967 implementation slot: keccak256("eip1967.proxy.implementation") - 1
         bytes32 ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
 
@@ -377,7 +376,6 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                 targetSCImpl
             );
         }
-
 
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -466,12 +466,9 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                 if (candidates[j].code.length == 0) exceptions[cursor++] = candidates[j];
             }
         }
-        // Trim to actual length. cursor <= chains.length * 4 = exceptions.length by construction,
-        // so the mstore cannot corrupt adjacent memory.
-        assembly {
-            mstore(exceptions, cursor)
-        }
-        return exceptions;
+        address[] memory result = new address[](cursor);
+        for (uint256 i = 0; i < cursor; i++) result[i] = exceptions[i];
+        return result;
     }
 }
 

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 import {Claim, GameType} from "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 import {VmSafe} from "forge-std/Vm.sol";
+import {console} from "forge-std/console.sol";
 import {stdToml} from "forge-std/StdToml.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
@@ -344,15 +345,19 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         address sharedSC = superchainAddrRegistry.getAddress("SuperchainConfig", chains[0].chainId);
 
+        // ERC-1967 implementation slot: keccak256("eip1967.proxy.implementation") - 1
+        bytes32 ERC1967_IMPL_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
         // Skip upgradeSuperchain if the SuperchainConfig proxy is already pointing at the
         // v7.1.17 implementation. This happens in the stacked execution model when a prior
         // task (e.g. 086-U19-op with the shared L1PAO) already ran upgradeSuperchain.
         // Chains with non-standard L1PAOs (e.g. Unichain) cannot authorize ProxyAdmin.upgrade()
         // on the shared SuperchainConfig, so they must rely on a prior task having done it.
-        bytes32 erc1967Slot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
-        address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, erc1967Slot))));
+        address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, ERC1967_IMPL_SLOT))));
         // Decode only the first return value (superchainConfigImpl) from implementations().
-        (, bytes memory implData) = address(OPCM).staticcall(abi.encodeWithSignature("implementations()"));
+        (bool implCallSuccess, bytes memory implData) =
+            address(OPCM).staticcall(abi.encodeWithSignature("implementations()"));
+        require(implCallSuccess && implData.length >= 32, "OPCMUpgradeV700: implementations() call failed");
         address targetSCImpl = abi.decode(implData, (address));
 
         if (currentSCImpl != targetSCImpl) {
@@ -366,6 +371,11 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                 )
             );
             require(scOk, "OPCMUpgradeV700: upgradeSuperchain failed");
+        } else {
+            console.log(
+                "OPCMUpgradeV700: skipping upgradeSuperchain - SuperchainConfig already at target impl %s",
+                targetSCImpl
+            );
         }
 
         for (uint256 i = 0; i < chains.length; i++) {
@@ -456,8 +466,9 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                 if (candidates[j].code.length == 0) exceptions[cursor++] = candidates[j];
             }
         }
-        // Trim to actual length.
+        // Trim to actual length (cursor <= exceptions.length by construction).
         assembly {
+            if gt(cursor, mload(exceptions)) { revert(0, 0) }
             mstore(exceptions, cursor)
         }
         return exceptions;

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -466,9 +466,9 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                 if (candidates[j].code.length == 0) exceptions[cursor++] = candidates[j];
             }
         }
-        // Trim to actual length (cursor <= exceptions.length by construction).
+        // Trim to actual length. cursor <= chains.length * 4 = exceptions.length by construction,
+        // so the mstore cannot corrupt adjacent memory.
         assembly {
-            if gt(cursor, mload(exceptions)) { revert(0, 0) }
             mstore(exceptions, cursor)
         }
         return exceptions;

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -152,10 +152,16 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
             // ProtocolVersions is registered per-chain for betanets (via fallback addresses.json)
             // but only on the sentinel chain for standard superchain-registry chains. Try per-chain
             // first (betanet case), fall back to sentinel chain (standard chain case).
+
             try superchainAddrRegistry.getAddress("ProtocolVersions", chains[i].chainId) returns (address pv) {
                 _allowedStorageAccesses.add(pv);
             } catch {
+                console.log(
+                    "OPCMUpgradeV700: per-chain ProtocolVersions lookup failed for chainId %d, falling back to global ProtocolVersions",
+                    chains[i].chainId
+                );
                 _allowedStorageAccesses.add(superchainAddrRegistry.get("ProtocolVersions"));
+
             }
         }
     }

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -141,12 +141,21 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
     /// sentinel-chain entries hardcoded in `src/addresses.toml` (the OP Sepolia / mainnet
     /// values), so betanet-specific addresses never make it into the allowlist. We re-add
     /// them explicitly per chain so betanet upgrades pass the post-execution check.
+    /// For standard chains, `ProtocolVersions` is only registered on the sentinel chain
+    /// (via addresses.toml), so we fall back to `get()` when per-chain lookup fails.
     function _setAllowedStorageAccesses() internal virtual override {
         super._setAllowedStorageAccesses();
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             _allowedStorageAccesses.add(superchainAddrRegistry.getAddress("SuperchainConfig", chains[i].chainId));
-            _allowedStorageAccesses.add(superchainAddrRegistry.getAddress("ProtocolVersions", chains[i].chainId));
+            // ProtocolVersions is registered per-chain for betanets (via fallback addresses.json)
+            // but only on the sentinel chain for standard superchain-registry chains. Try per-chain
+            // first (betanet case), fall back to sentinel chain (standard chain case).
+            try superchainAddrRegistry.getAddress("ProtocolVersions", chains[i].chainId) returns (address pv) {
+                _allowedStorageAccesses.add(pv);
+            } catch {
+                _allowedStorageAccesses.add(superchainAddrRegistry.get("ProtocolVersions"));
+            }
         }
     }
 
@@ -335,16 +344,29 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         address sharedSC = superchainAddrRegistry.getAddress("SuperchainConfig", chains[0].chainId);
 
-        (bool scOk,) = address(OPCM).delegatecall(
-            abi.encodeCall(
-                IOPContractsManagerV700.upgradeSuperchain,
-                IOPContractsManagerV700.SuperchainUpgradeInput({
-                    superchainConfig: ISuperchainConfig(sharedSC),
-                    extraInstructions: new IOPContractsManagerV700.ExtraInstruction[](0)
-                })
-            )
-        );
-        require(scOk, "OPCMUpgradeV700: upgradeSuperchain failed");
+        // Skip upgradeSuperchain if the SuperchainConfig proxy is already pointing at the
+        // v7.1.17 implementation. This happens in the stacked execution model when a prior
+        // task (e.g. 086-U19-op with the shared L1PAO) already ran upgradeSuperchain.
+        // Chains with non-standard L1PAOs (e.g. Unichain) cannot authorize ProxyAdmin.upgrade()
+        // on the shared SuperchainConfig, so they must rely on a prior task having done it.
+        bytes32 erc1967Slot = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+        address currentSCImpl = address(uint160(uint256(vm.load(sharedSC, erc1967Slot))));
+        // Decode only the first return value (superchainConfigImpl) from implementations().
+        (, bytes memory implData) = address(OPCM).staticcall(abi.encodeWithSignature("implementations()"));
+        address targetSCImpl = abi.decode(implData, (address));
+
+        if (currentSCImpl != targetSCImpl) {
+            (bool scOk,) = address(OPCM).delegatecall(
+                abi.encodeCall(
+                    IOPContractsManagerV700.upgradeSuperchain,
+                    IOPContractsManagerV700.SuperchainUpgradeInput({
+                        superchainConfig: ISuperchainConfig(sharedSC),
+                        extraInstructions: new IOPContractsManagerV700.ExtraInstruction[](0)
+                    })
+                )
+            );
+            require(scOk, "OPCMUpgradeV700: upgradeSuperchain failed");
+        }
 
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
@@ -421,10 +443,22 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         for (uint256 i = 0; i < chains.length; i++) {
             ISystemConfigEOAs sc =
                 ISystemConfigEOAs(superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId));
-            exceptions[cursor++] = sc.owner();
-            exceptions[cursor++] = sc.unsafeBlockSigner();
-            exceptions[cursor++] = sc.batchInbox();
-            exceptions[cursor++] = address(uint160(uint256(sc.batcherHash())));
+            // Only include true EOAs (no code). Contract addresses (e.g. multisig owners)
+            // must not be in the exceptions list — they are handled by the normal allowed
+            // storage accesses check instead.
+            address[4] memory candidates = [
+                sc.owner(),
+                sc.unsafeBlockSigner(),
+                sc.batchInbox(),
+                address(uint160(uint256(sc.batcherHash())))
+            ];
+            for (uint256 j = 0; j < 4; j++) {
+                if (candidates[j].code.length == 0) exceptions[cursor++] = candidates[j];
+            }
+        }
+        // Trim to actual length.
+        assembly {
+            mstore(exceptions, cursor)
         }
         return exceptions;
     }

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -161,7 +161,6 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                     chains[i].chainId
                 );
                 _allowedStorageAccesses.add(superchainAddrRegistry.get("ProtocolVersions"));
-
             }
         }
     }


### PR DESCRIPTION
## Summary

Four fixes discovered while simulating U19 upgrades on standard superchain-registry chains for the first time (all prior `OPCMUpgradeV700` usage was betanet-only):

- **`SuperchainAddressRegistry`**: Register `EthLockboxProxy` per-chain from the registry JSON in `_fetchAndSaveInitialContracts`. The standard on-chain discovery path didn't include it, so it was missing from allowed storage accesses and the state-diff validator rejected valid OPCM upgrade writes.

- **`OPCMUpgradeV700._setAllowedStorageAccesses`**: Wrap `getAddress("ProtocolVersions", chainId)` in try/catch. Standard chains store `ProtocolVersions` on the sentinel chain (via `addresses.toml`), not per L2 chainId, so the per-chain lookup reverted unconditionally for non-betanet tasks.

- **`OPCMUpgradeV700._getCodeExceptions`**: Only include true EOAs (no code). Some chains (e.g. Ink) use a multisig Safe as `SystemConfig.owner()`. Adding a contract address to the EOA exceptions list caused `"unexpected code"` validation failures when the OPCM re-initializes `SystemConfig` and writes the owner to storage.

- **`OPCMUpgradeV700._build`**: Skip `upgradeSuperchain()` if `SuperchainConfig` is already at the v7.1.17 implementation. Chains with non-standard L1PAOs (e.g. Unichain) cannot authorize `ProxyAdmin.upgrade()` on the shared `SuperchainConfig`. In the stacked execution model a prior shared-L1PAO task runs `upgradeSuperchain` first, so the Unichain task can skip it via this idempotency check.

## Test plan

- [ ] Existing betanet U19 tasks (076, 079) still simulate correctly
- [ ] `just simulate-stack sep 086-U19-op` passes (once sep task PR is opened)
- [ ] `just simulate-stack eth 053-U19-op` passes (once mainnet task PR is opened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)