### PR TITLE
fix(MultisigTask): tolerate negative per-call gas refund

### DIFF
--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -535,12 +535,14 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
         // Check that the transaction did not exceed the maximum gas limit.
         // We must check gas consumed BEFORE refunds, because the EVM requires enough gas upfront,
-        // therefore we check gasTotalUsed + gasRefunded
-        // Note: gasRefunded is int64, but should always be >= 0 in practice, unsure why this is
-        // an int64 in forge.
+        // therefore we check gasTotalUsed + gasRefunded.
+        // Note: gasRefunded is int64 and can legitimately be negative. It is the per-call EIP-3529
+        // refund delta, not the tx-level counter (which floors at 0), so a call frame whose SSTORE
+        // refund removals outweigh its grants reports a negative value. See
+        // https://github.com/paradigmxyz/revm-inspectors/issues/267. We therefore clamp it to 0 for
+        // the gas-cap accounting below rather than treating a negative value as an error.
         VmSafe.Gas memory gasInfo = vm.lastCallGas();
-        require(gasInfo.gasRefunded >= 0, "MultisigTask: negative gas refund is invalid");
-        uint256 gasRefunded = uint256(uint64(gasInfo.gasRefunded));
+        uint256 gasRefunded = gasInfo.gasRefunded > 0 ? uint256(uint64(gasInfo.gasRefunded)) : 0;
         uint256 gasConsumedBeforeRefund = uint256(gasInfo.gasTotalUsed) + gasRefunded;
         if (gasConsumedBeforeRefund > MAX_GAS_LIMIT) {
             console.log("Gas consumed before refund:", gasConsumedBeforeRefund);


### PR DESCRIPTION
## Problem

`MultisigTask._execTransaction` guards the simulated `execTransaction` with:

```solidity
require(gasInfo.gasRefunded >= 0, "MultisigTask: negative gas refund is invalid");
```

where `gasInfo = vm.lastCallGas()`. The existing comment even flagged the uncertainty: *"gasRefunded is int64, but should always be >= 0 in practice, unsure why this is an int64 in forge."*

That assumption is incorrect. `lastCallGas().gasRefunded` is the **per-call** EIP-3529 refund delta, **not** the transaction-level refund counter (which floors at 0). A call frame whose SSTORE refund *removals* outweigh its *grants* legitimately reports a **negative** value.

This is documented upstream in **[paradigmxyz/revm-inspectors#267](https://github.com/paradigmxyz/revm-inspectors/issues/267)**, which changed the refund counter to `i64` precisely because *"revm's refund function returns the refund per call which can go negative."* That answers the "unsure why this is an int64 in forge" note — it is an `i64` by design.

## Impact

This reproduces on a heavy OPCM (U19) upgrade simulation: the root-safe `execTransaction` frame nets a negative per-call refund, and the task aborts with `MultisigTask: negative gas refund is invalid` even though the transaction is valid. It is gas-limit independent (reproduced at both 15M and 30M `TENDERLY_GAS`). On-chain the refund floors at 0, so nothing actually reverts — only the simulation guard does, which blocks `simulate-stack`/`sign-stack` from completing through such a task.

## Fix

Drop the `require` and clamp the value to 0 for the gas-cap accounting (the only thing it feeds). Behavior is unchanged for non-negative refunds.

```solidity
uint256 gasRefunded = gasInfo.gasRefunded > 0 ? uint256(uint64(gasInfo.gasRefunded)) : 0;
```

The `txHash`/data-to-sign are computed before this block, so signing values are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)