### PR TITLE
fix(utils): only inspect last 20 bytes in isLikelyAddressThatShouldHaveCode

### DIFF
--- a/src/libraries/Utils.sol
+++ b/src/libraries/Utils.sol
@@ -32,20 +32,23 @@ library Utils {
     }
 
     /// @notice Checks that values have code on this chain.
-    /// This method is not storage-layout-aware and therefore is not perfect. It may return erroneous
-    /// results for cases like packed slots, and silently show that things are okay when they are not.
+    /// This method is not storage-layout-aware and therefore is not perfect. It only inspects the
+    /// last 20 bytes (low 160 bits) of the slot value, ignoring any higher-order bytes that may be
+    /// packed into the same storage slot, so it may return erroneous results for packed slots.
     function isLikelyAddressThatShouldHaveCode(uint256 value, address[] memory codeExceptions)
         internal
         pure
         returns (bool)
     {
+        // Only consider the last 20 bytes of the slot value, ignoring any higher-order bytes packed
+        // into the same storage slot.
+        uint160 addr = uint160(value);
         // If out of range (fairly arbitrary lower bound), return false.
-        if (value > type(uint160).max) return false;
-        if (value < uint256(uint160(0x00000000fFFFffffffFfFfFFffFfFffFFFfFffff))) return false;
+        if (addr < uint160(0x00000000fFFFffffffFfFfFFffFfFffFFFfFffff)) return false;
         // If the value is a L2 predeploy address it won't have code on this chain, so return false.
         if (
-            value >= uint256(uint160(0x4200000000000000000000000000000000000000))
-                && value <= uint256(uint160(0x420000000000000000000000000000000000FffF))
+            addr >= uint160(0x4200000000000000000000000000000000000000)
+                && addr <= uint160(0x420000000000000000000000000000000000FffF)
         ) return false;
         // Allow known EOAs.
         for (uint256 i; i < codeExceptions.length; i++) {
@@ -53,7 +56,7 @@ library Utils {
                 codeExceptions[i] != address(0),
                 "getCodeExceptions includes the zero address, please make sure all entries are populated."
             );
-            if (address(uint160(value)) == codeExceptions[i]) return false;
+            if (address(addr) == codeExceptions[i]) return false;
         }
         // Otherwise, this value looks like an address that we'd expect to have code.
         return true;


### PR DESCRIPTION
## Summary

`Utils.isLikelyAddressThatShouldHaveCode` previously returned `false` for any slot value greater than `type(uint160).max`, which meant it skipped the address check entirely on **packed storage slots** (where higher-order bytes hold other fields).

This change makes the function inspect **only the last 20 bytes** (low 160 bits) of the slot value:

- Drops the `if (value > type(uint160).max) return false;` early return.
- Masks once with `uint160 addr = uint160(value);` and runs the lower-bound, L2-predeploy-range, and code-exception checks against `addr`.

## Behavior change

For packed slots whose low 20 bytes fall in a plausible address range, the embedded address is now evaluated instead of being silently ignored. This reduces false negatives (a real address packed alongside other data is no longer skipped) at the cost of possibly flagging numeric/packed slots whose low bytes coincidentally look like an address.

Used by `MultisigTask.sol` to flag storage changes that should point to a contract with code.

## Testing

- `forge build` passes.

based on this 


```
  ASCII — the whole 32 bytes of slot 0x6c

                           SystemConfig storage slot 108  (0x6c)
                           32 bytes, big-endian (MSB left → LSB right)

    byte:  31  30  29  28 │ 27  26  25  24  23  22  21  20 │ 19 18 ... 02 01 00
          ┌───┬───┬───┬───┼───┬───┬───┬───┬───┬───┬───┬───┼──────────────────────┐
          │ 00  00  00  00 │            minBaseFee         │   superchainConfig   │
          │   (unused)     │           uint64 (8 B)        │     address (20 B)   │
          └───┴───┴───┴───┴───────────────────────────────┴──────────────────────┘
           offset 31..28        offset 27 .......... 20      offset 19 ........ 0
            4 bytes zero            8 bytes                      20 bytes
          └──────────────┘ └───────────────────────────┘ └──────────────────────┘
              padding            minBaseFee (wei)            SuperchainConfig addr
                MSB ◄─────────────────────────────────────────────────► LSB


    Example word (minBaseFee = 1 gwei = 0x3B9ACA00, scconf = 0xC2Be75...0d5c):

      0x  00000000  000000003B9ACA00  C2Be75506d5724086DEB7245bd260Cc9753911Be
          └─pad──┘  └──minBaseFee───┘  └─────────superchainConfig─────────────┘

```