### PR TITLE
feat(MultisigTask): config-driven per-slot storage-code whitelist

### DIFF
--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -7,6 +7,7 @@ import {Script} from "forge-std/Script.sol";
 import {VmSafe} from "forge-std/Vm.sol";
 import {Test} from "forge-std/Test.sol";
 import {StdStyle} from "forge-std/StdStyle.sol";
+import {stdToml} from "forge-std/StdToml.sol";
 import {IMulticall3} from "forge-std/interfaces/IMulticall3.sol";
 
 import {Signatures} from "@base-contracts/script/universal/Signatures.sol";
@@ -29,6 +30,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
     using AccountAccessParser for VmSafe.AccountAccess[];
     using AccountAccessParser for VmSafe.AccountAccess;
     using StdStyle for string;
+    using stdToml for string;
 
     /// @notice Maximum gas limit for transactions, 15M gas is ~90% of the limit
     uint256 internal constant MAX_GAS_LIMIT = 15_000_000;
@@ -47,6 +49,13 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
     /// @notice struct to store the addresses that are expected to have balance changes
     EnumerableSet.AddressSet internal _allowedBalanceChanges;
+
+    /// @notice (account => slot => allowed) storage slots exempted from the
+    /// `isLikelyAddressThatShouldHaveCode` check. Used for packed slots where the
+    /// low 160 bits are not an independent address (e.g. SystemConfig slot 0x6c
+    /// packs `superchainConfig` with `minBaseFee`). Populated from the task's
+    /// `[storageCodeExceptions]` config section.
+    mapping(address => mapping(bytes32 => bool)) internal _storageCodeExceptions;
 
     /// @notice Snapshot of the chain state before the tasks transaction is executed.
     uint256 private _preExecutionSnapshot;
@@ -469,18 +478,23 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                 if (!storageAccess.isWrite) continue; // Skip SLOADs.
                 uint256 value = uint256(storageAccess.newValue);
                 address account = storageAccess.account;
-                if (Utils.isLikelyAddressThatShouldHaveCode(value, codeExceptions)) {
-                    // Log account, slot, and value if there is no code.
-                    // forgefmt: disable-start
-                    string memory err = string.concat("Likely address in storage has no code\n", "  account: ", vm.toString(account), "\n  slot:    ", vm.toString(storageAccess.slot), "\n  value:   ", vm.toString(bytes32(value)));
-                    // forgefmt: disable-end
-                    require(address(uint160(value)).code.length != 0, err);
-                } else {
-                    // Log account, slot, and value if there is code.
-                    // forgefmt: disable-start
-                    string memory err = string.concat("Likely address in storage has unexpected code\n", "  account: ", vm.toString(account), "\n  slot:    ", vm.toString(storageAccess.slot), "\n  value:   ", vm.toString(bytes32(value)));
-                    // forgefmt: disable-end
-                    require(address(uint160(value)).code.length == 0, err);
+                // Skip the code check for slots explicitly whitelisted via the task's
+                // `[storageCodeExceptions]` config (e.g. packed slots whose low 160 bits
+                // are not an independent address).
+                if (!_storageCodeExceptions[account][storageAccess.slot]) {
+                    if (Utils.isLikelyAddressThatShouldHaveCode(value, codeExceptions)) {
+                        // Log account, slot, and value if there is no code.
+                        // forgefmt: disable-start
+                        string memory err = string.concat("Likely address in storage has no code\n", "  account: ", vm.toString(account), "\n  slot:    ", vm.toString(storageAccess.slot), "\n  value:   ", vm.toString(bytes32(value)));
+                        // forgefmt: disable-end
+                        require(address(uint160(value)).code.length != 0, err);
+                    } else {
+                        // Log account, slot, and value if there is code.
+                        // forgefmt: disable-start
+                        string memory err = string.concat("Likely address in storage has unexpected code\n", "  account: ", vm.toString(account), "\n  slot:    ", vm.toString(storageAccess.slot), "\n  value:   ", vm.toString(bytes32(value)));
+                        // forgefmt: disable-end
+                        require(address(uint160(value)).code.length == 0, err);
+                    }
                 }
                 require(account.code.length != 0, string.concat("Storage account has no code: ", vm.toString(account)));
                 require(!storageAccess.reverted, string.concat("Storage access reverted: ", vm.toString(account)));
@@ -791,6 +805,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         returns (uint256[] memory allOriginalNonces_)
     {
         _setStateOverridesFromConfig(_taskConfigFilePath); // Sets global '_stateOverrides' variable.
+        _setStorageCodeExceptionsFromConfig(_taskConfigFilePath); // Sets '_storageCodeExceptions' mapping.
         allOriginalNonces_ = new uint256[](_allSafes.length);
         for (uint256 i = 0; i < _allSafes.length; i++) {
             allOriginalNonces_[i] = _getNonceOrOverride(_allSafes[i], _taskConfigFilePath);
@@ -802,6 +817,25 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         }
         // We must do this after setting the nonces above. It allows us to make sure we're reading the correct network state when setting the nonces.
         _applyStateOverrides(); // Applies '_stateOverrides' to the current state.
+    }
+
+    /// @notice Read storage code exceptions from a TOML config file.
+    /// Format (slots are exempted from the `isLikelyAddressThatShouldHaveCode` check):
+    ///   [storageCodeExceptions]
+    ///   "0xSystemConfigAddr" = ["0x...006c"]
+    function _setStorageCodeExceptionsFromConfig(string memory _taskConfigFilePath) private {
+        string memory toml = vm.readFile(_taskConfigFilePath);
+        string memory exceptionsKey = ".storageCodeExceptions";
+        if (!toml.keyExists(exceptionsKey)) return;
+
+        string[] memory accountStrings = vm.parseTomlKeys(toml, exceptionsKey);
+        for (uint256 i = 0; i < accountStrings.length; i++) {
+            address account = vm.parseAddress(accountStrings[i]);
+            bytes32[] memory slots = toml.readBytes32Array(string.concat(exceptionsKey, ".", accountStrings[i]));
+            for (uint256 j = 0; j < slots.length; j++) {
+                _storageCodeExceptions[account][slots[j]] = true;
+            }
+        }
     }
 
     /// ==================================================

--- a/test/tasks/NestedMultisigTask.t.sol
+++ b/test/tasks/NestedMultisigTask.t.sol
@@ -268,6 +268,91 @@ contract NestedMultisigTaskTest is Test {
         multisigTask.simulate(configFilePath, Solarray.addresses(SECURITY_COUNCIL_CHILD_MULTISIG));
     }
 
+    /// @notice OptimismPortalProxy address on OP Mainnet at block 23149345 (used by the
+    /// storage-code-exception tests below).
+    address constant OPTIMISM_PORTAL_PROXY = 0xbEb5Fc579115071764c7423A4f12eDde41f106Ed;
+
+    /// @notice Base config for the SetEIP1967Implementation task used by the storage-code-exception
+    /// tests. It writes a no-code, address-shaped value to the EIP-1967 implementation slot, which
+    /// without a `[storageCodeExceptions]` entry trips the `isLikelyAddressThatShouldHaveCode` check
+    /// (see `testSimulateCodeExceptionsCheckReverts`).
+    string constant CODE_EXCEPTION_BASE_TOML = "l2chains = [{name = \"OP Mainnet\", chainId = 10}]\n" "\n"
+        "templateName = \"SetEIP1967Implementation\"\n contractIdentifier = \"OptimismPortalProxy\"\n newImplementation = \"0x0000000FFfFFfffFffFfFffFFFfffffFffFFffFf\"\n";
+
+    /// @notice The exact revert message produced by the code check for the task above at block 23149345.
+    function _codeExceptionRevertMessage() internal pure returns (string memory) {
+        return string.concat(
+            "Likely address in storage has no code\n",
+            "  account: ",
+            vm.toString(OPTIMISM_PORTAL_PROXY),
+            "\n  slot:    ",
+            vm.toString(bytes32(Constants.PROXY_IMPLEMENTATION_ADDRESS)),
+            "\n  value:   ",
+            vm.toString(bytes32(0x0000000000000000000000000000000fffffffffffffffffffffffffffffffff))
+        );
+    }
+
+    /// @notice A `[storageCodeExceptions]` entry for the (account, slot) being written exempts that
+    /// slot from the code check, so the otherwise-reverting task simulates cleanly. The slot is listed
+    /// alongside an unrelated slot to also exercise multi-slot array parsing.
+    function testStorageCodeExceptionWhitelistsSlot() public {
+        vm.createSelectFork("mainnet", 23149345);
+        multisigTask = new SetEIP1967Implementation();
+        string memory toml = string.concat(
+            CODE_EXCEPTION_BASE_TOML,
+            "[storageCodeExceptions]\n",
+            vm.toString(OPTIMISM_PORTAL_PROXY),
+            " = [\"",
+            vm.toString(bytes32(Constants.PROXY_IMPLEMENTATION_ADDRESS)),
+            "\", \"0x0000000000000000000000000000000000000000000000000000000000000000\"]\n"
+        );
+        string memory configFilePath = MultisigTaskTestHelper.createTempTomlFile(toml, TESTING_DIRECTORY, "007");
+
+        // Should NOT revert: the code check is skipped for the whitelisted slot.
+        (,,, address rootSafe) =
+            multisigTask.simulate(configFilePath, Solarray.addresses(SECURITY_COUNCIL_CHILD_MULTISIG));
+        assertTrue(rootSafe != address(0), "Expected task to simulate without reverting");
+        MultisigTaskTestHelper.removeFile(configFilePath);
+    }
+
+    /// @notice A `[storageCodeExceptions]` entry for the correct account but a different slot does NOT
+    /// suppress the check on the slot actually being written: the exception is slot-specific.
+    function testStorageCodeExceptionWrongSlotStillReverts() public {
+        vm.createSelectFork("mainnet", 23149345);
+        multisigTask = new SetEIP1967Implementation();
+        string memory toml = string.concat(
+            CODE_EXCEPTION_BASE_TOML,
+            "[storageCodeExceptions]\n",
+            vm.toString(OPTIMISM_PORTAL_PROXY),
+            " = [\"0x0000000000000000000000000000000000000000000000000000000000000001\"]\n"
+        );
+        string memory configFilePath = MultisigTaskTestHelper.createTempTomlFile(toml, TESTING_DIRECTORY, "008");
+
+        vm.expectRevert(bytes(_codeExceptionRevertMessage()));
+        multisigTask.simulate(configFilePath, Solarray.addresses(SECURITY_COUNCIL_CHILD_MULTISIG));
+        MultisigTaskTestHelper.removeFile(configFilePath);
+    }
+
+    /// @notice A `[storageCodeExceptions]` entry for the correct slot but a different account does NOT
+    /// suppress the check: the exception is account-specific.
+    function testStorageCodeExceptionWrongAccountStillReverts() public {
+        vm.createSelectFork("mainnet", 23149345);
+        multisigTask = new SetEIP1967Implementation();
+        string memory toml = string.concat(
+            CODE_EXCEPTION_BASE_TOML,
+            "[storageCodeExceptions]\n",
+            // Some unrelated account, with the correct slot.
+            "0x000000000000000000000000000000000000dEaD = [\"",
+            vm.toString(bytes32(Constants.PROXY_IMPLEMENTATION_ADDRESS)),
+            "\"]\n"
+        );
+        string memory configFilePath = MultisigTaskTestHelper.createTempTomlFile(toml, TESTING_DIRECTORY, "009");
+
+        vm.expectRevert(bytes(_codeExceptionRevertMessage()));
+        multisigTask.simulate(configFilePath, Solarray.addresses(SECURITY_COUNCIL_CHILD_MULTISIG));
+        MultisigTaskTestHelper.removeFile(configFilePath);
+    }
+
     /// @notice Validate the data to sign for the child multisig.
     function _validateNestedDataToSign(
         address _childMultisig,


### PR DESCRIPTION
## Summary

Adds an opt-in, config-driven per-`(account, slot)` storage-code whitelist to `MultisigTask`, so a task can exempt a specific storage slot from the `isLikelyAddressThatShouldHaveCode` check in `_checkStateDiff`.

This PR is **framework-only** — just the mechanism in `MultisigTask.sol`. The U19 tasks that motivated it live in their own PR.

## The problem

`_checkStateDiff` treats the low 160 bits of every written slot as an address that must (or must not) have code. This is wrong for **packed slots** whose low bits are not an independent address.

Concrete case: `SystemConfig` slot `0x6c` packs `superchainConfig` (an address **with code**, low 160 bits) with `minBaseFee` (`uint64`, upper bits). Once `minBaseFee` is non-zero the full slot value exceeds `type(uint160).max`, the check takes its `else` branch, and `require(low160.code.length == 0)` reverts on the real `SuperchainConfig`:

```
Likely address in storage has unexpected code
  account: 0x...SystemConfigProxy
  slot:    0x...006c
  value:   0x0000000000000000000<minBaseFee><superchainConfig has code>
```

There was no escape hatch: `_getCodeExceptions()` is only consulted *inside* `isLikelyAddressThatShouldHaveCode`, which already returns `false` for packed slots and never reaches the exception list.

## The change

A new optional config section, parsed into `mapping(address => mapping(bytes32 => bool))` and checked in `_checkStateDiff`:

```toml
[storageCodeExceptions]
# SystemConfig slot 0x6c packs superchainConfig (has code) + minBaseFee
0xSystemConfigAddr = ["0x000000000000000000000000000000000000000000000000000000000000006c"]
```

```solidity
if (!_storageCodeExceptions[account][storageAccess.slot]) {
    if (isLikelyAddressThatShouldHaveCode(value, codeExceptions)) { require(code != 0) }
    else { require(code == 0) }
}
```

- Parser `_setStorageCodeExceptionsFromConfig` is called from `_overrideState`, alongside the existing `_setStateOverridesFromConfig`.
- Fully inert when a task has no `[storageCodeExceptions]` section — no behavior change for existing tasks.

## Why per-slot rather than skipping all packed slots

| | Skip all `value > uint160.max` | This whitelist |
|---|---|---|
| Scope | Every packed slot, every task, globally | Only the exact `(contract, slot)` listed |
| Safety | A bad address packed into upper bits slips through everywhere | All other packed slots still checked; opt out one slot at a time |
| Audit trail | None | Exception + rationale live in the task `config.toml`, reviewed with the task |

## Verification

- `forge build` passes.
- Exercised end-to-end on the U19 Unichain Sepolia task: without the exception the simulation reverts on `SystemConfig` slot `0x6c`; with a `[storageCodeExceptions]` entry it simulates cleanly. (That task is not part of this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
