### PR TITLE
docs: mark Osaki Sepolia tasks 097 & 098 as EXECUTED

### DIFF
--- a/src/tasks/sep/097-osaki-l1-ownership-transfers/README.md
+++ b/src/tasks/sep/097-osaki-l1-ownership-transfers/README.md
@@ -40,6 +40,4 @@ Signing commands for each safe:
 ```bash
 cd src/tasks/sep/097-osaki-l1-ownership-transfers
 just --dotenv-path $(pwd)/.env sign <foundation|council>
-USE_KEYSTORE=1 SIGNATURES=0x just approve <foundation|council>
-USE_KEYSTORE=1 just execute
 ```

--- a/src/tasks/sep/097-osaki-l1-ownership-transfers/README.md
+++ b/src/tasks/sep/097-osaki-l1-ownership-transfers/README.md
@@ -1,6 +1,6 @@
 # 097-osaki-l1-ownership-transfers: Transfer L1 owners for Osaki Sepolia (ProxyAdmin + DisputeGameFactory)
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0xec5c2801dab2f9030df813116835799462d0695de793e971f08fc97c7f8eff3d)
 
 ## Objective
 
@@ -40,4 +40,6 @@ Signing commands for each safe:
 ```bash
 cd src/tasks/sep/097-osaki-l1-ownership-transfers
 just --dotenv-path $(pwd)/.env sign <foundation|council>
+USE_KEYSTORE=1 SIGNATURES=0x just approve <foundation|council>
+USE_KEYSTORE=1 just execute
 ```

--- a/src/tasks/sep/098-osaki-l2pao-transfer/README.md
+++ b/src/tasks/sep/098-osaki-l2pao-transfer/README.md
@@ -1,6 +1,6 @@
 # 098-osaki-l2pao-transfer: Transfer L2 ProxyAdmin Owner for Osaki Sepolia
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x871edc6bf21c381ba84b848d82c539ccdb7760852cc68b73c53b68b1801169f7)
 
 ## Objective
 


### PR DESCRIPTION
## Summary

Updates the status of the Osaki Sepolia ownership-transfer tasks from `READY TO SIGN` to `EXECUTED`, linking the on-chain execution transactions.

- **097-osaki-l1-ownership-transfers** → [EXECUTED](https://sepolia.etherscan.io/tx/0xec5c2801dab2f9030df813116835799462d0695de793e971f08fc97c7f8eff3d) (L1 ProxyAdmin + DisputeGameFactory ownership transfers)
- **098-osaki-l2pao-transfer** → [EXECUTED](https://sepolia.etherscan.io/tx/0x871edc6bf21c381ba84b848d82c539ccdb7760852cc68b73c53b68b1801169f7) (L2 ProxyAdmin owner transfer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)