### PR TITLE
ci: shard template regression simulations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,7 @@ jobs:
   template_regression_tests:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
+    parallelism: 4
     environment:
       FOUNDRY_PROFILE: ci
     steps:

--- a/src/ci.just
+++ b/src/ci.just
@@ -13,6 +13,8 @@ simulate-all-templates:
     root_dir=$(git rev-parse --show-toplevel)
     forge build
     simulation_count=0
+    node_total="${CIRCLE_NODE_TOTAL:-1}"
+    node_index="${CIRCLE_NODE_INDEX:-0}"
     # When we spawn too many concurrent processes, the simulation fails with 'solc exited with signal: 9 (SIGKILL)'.
     # The batch size should be low enough to not cause issues, but high enough to not make the simulation too slow.
     batch_size=7
@@ -21,7 +23,10 @@ simulate-all-templates:
     # Collect PIDs of each background simulation.
     declare -a pids=()
 
-    for task in "${root_dir}/test/tasks/example/"*/*; do
+    selected_tasks=$("${root_dir}/src/script/list-template-example-tasks.sh" "$root_dir")
+    echo "Template simulation shard $((node_index + 1))/$node_total"
+
+    while IFS= read -r task; do
         if [ -d "$task" ]; then
             echo "Task: $task"
             nested_safe_name_depth_1=""
@@ -53,24 +58,6 @@ simulate-all-templates:
             task_name=$(basename "$task")
             task_path="$root_dir/test/tasks/example/$network/$task_name"
 
-            # Skip tasks that exceed the 15M gas limit
-            # 023-u13-to-u16a: OPCMUpgradeV220toV410 performs 4 sequential upgrades (U13 through U16a)
-            # consuming ~21.7M gas, which exceeds the 15M safety limit for Fusaka EIP-7825 compatibility.
-            # This template is not actively used and can be skipped in CI.
-            if [ "$task_name" = "023-u13-to-u16a" ]; then
-                echo "Skipping $task_name (exceeds 15M gas limit)"
-                continue
-            fi
-
-            # OPCMMigrateV800 requires the target chain to already be upgraded to V800/Super Root.
-            # The raw example task simulation forks current chain state and cannot perform that
-            # prerequisite upgrade before invoking migrate. Coverage lives in SuperRootMigrateTest,
-            # which forks Sepolia, upgrades the chain, then runs migrate in the same forked state.
-            if [ "$task_name" = "036-opcm-migrate-v800" ]; then
-                echo "Skipping $task_name (requires pre-upgraded V800/Super Root chain state)"
-                continue
-            fi
-
             # Launch each simulation in background.
             "${root_dir}/src/script/simulate-task.sh" "$task_path" "$nested_safe_name_depth_1" "$nested_safe_name_depth_2" "$network" & pids+=( "$!" )
             current_batch=$((current_batch + 1))
@@ -90,7 +77,7 @@ simulate-all-templates:
                 echo "Batch completed. Starting next batch..."
             fi
         fi
-    done
+    done <<< "$selected_tasks"
 
     # Wait for any remaining simulations in the final batch
     if [ ${#pids[@]} -gt 0 ]; then

--- a/src/script/list-template-example-tasks.sh
+++ b/src/script/list-template-example-tasks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir=${1:-$(git rev-parse --show-toplevel)}
+node_total=${CIRCLE_NODE_TOTAL:-1}
+node_index=${CIRCLE_NODE_INDEX:-0}
+
+if ! [[ "$node_total" =~ ^[0-9]+$ ]] || [ "$node_total" -lt 1 ]; then
+    echo "CIRCLE_NODE_TOTAL must be a positive integer, got '$node_total'" >&2
+    exit 1
+fi
+
+if ! [[ "$node_index" =~ ^[0-9]+$ ]]; then
+    echo "CIRCLE_NODE_INDEX must be a non-negative integer, got '$node_index'" >&2
+    exit 1
+fi
+
+if [ "$node_index" -ge "$node_total" ]; then
+    echo "CIRCLE_NODE_INDEX ($node_index) must be less than CIRCLE_NODE_TOTAL ($node_total)" >&2
+    exit 1
+fi
+
+task_index=0
+while IFS= read -r task; do
+    task_name=$(basename "$task")
+
+    # 023-u13-to-u16a exceeds the 15M gas limit. 036-opcm-migrate-v800 requires
+    # pre-upgraded chain state and is covered by SuperRootMigrateTest.
+    if [ "$task_name" = "023-u13-to-u16a" ] || [ "$task_name" = "036-opcm-migrate-v800" ]; then
+        continue
+    fi
+
+    if [ $((task_index % node_total)) -eq "$node_index" ]; then
+        echo "$task"
+    fi
+
+    task_index=$((task_index + 1))
+done < <(find "$root_dir/test/tasks/example" -mindepth 2 -maxdepth 2 -type d | sort)

--- a/test/script/test-template-example-task-sharding.sh
+++ b/test/script/test-template-example-task-sharding.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+script="$repo_root/src/script/list-template-example-tasks.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p \
+  "$tmpdir/test/tasks/example/eth/001-alpha" \
+  "$tmpdir/test/tasks/example/eth/002-beta" \
+  "$tmpdir/test/tasks/example/sep/003-gamma" \
+  "$tmpdir/test/tasks/example/sep/023-u13-to-u16a" \
+  "$tmpdir/test/tasks/example/sep/036-opcm-migrate-v800" \
+  "$tmpdir/test/tasks/example/sep/040-delta"
+
+all_tasks=$("$script" "$tmpdir")
+expected_all=$(printf '%s\n' \
+  "$tmpdir/test/tasks/example/eth/001-alpha" \
+  "$tmpdir/test/tasks/example/eth/002-beta" \
+  "$tmpdir/test/tasks/example/sep/003-gamma" \
+  "$tmpdir/test/tasks/example/sep/040-delta")
+
+if [ "$all_tasks" != "$expected_all" ]; then
+  echo "Expected default selection to include every non-skipped task in sort order" >&2
+  printf 'expected:\n%s\n' "$expected_all" >&2
+  printf 'actual:\n%s\n' "$all_tasks" >&2
+  exit 1
+fi
+
+shard_0=$(CIRCLE_NODE_TOTAL=3 CIRCLE_NODE_INDEX=0 "$script" "$tmpdir")
+shard_1=$(CIRCLE_NODE_TOTAL=3 CIRCLE_NODE_INDEX=1 "$script" "$tmpdir")
+shard_2=$(CIRCLE_NODE_TOTAL=3 CIRCLE_NODE_INDEX=2 "$script" "$tmpdir")
+
+expected_shard_0=$(printf '%s\n' \
+  "$tmpdir/test/tasks/example/eth/001-alpha" \
+  "$tmpdir/test/tasks/example/sep/040-delta")
+expected_shard_1="$tmpdir/test/tasks/example/eth/002-beta"
+expected_shard_2="$tmpdir/test/tasks/example/sep/003-gamma"
+
+if [ "$shard_0" != "$expected_shard_0" ]; then
+  echo "Unexpected shard 0 selection" >&2
+  exit 1
+fi
+
+if [ "$shard_1" != "$expected_shard_1" ]; then
+  echo "Unexpected shard 1 selection" >&2
+  exit 1
+fi
+
+if [ "$shard_2" != "$expected_shard_2" ]; then
+  echo "Unexpected shard 2 selection" >&2
+  exit 1
+fi
+
+if CIRCLE_NODE_TOTAL=3 CIRCLE_NODE_INDEX=3 "$script" "$tmpdir" >/dev/null 2>&1; then
+  echo "Expected out-of-range CIRCLE_NODE_INDEX to fail" >&2
+  exit 1
+fi
+
+if CIRCLE_NODE_TOTAL=0 CIRCLE_NODE_INDEX=0 "$script" "$tmpdir" >/dev/null 2>&1; then
+  echo "Expected zero CIRCLE_NODE_TOTAL to fail" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Shards `template_regression_tests` across 4 CircleCI nodes.
- Moves eligible example task selection into `src/script/list-template-example-tasks.sh`.
- Preserves coverage: all 54 eligible example task simulations are still selected exactly once across the 4 shards, and the template coverage check still runs.

## CI history / profile

- Recent `main` CircleCI sample showed `template_regression_tests` consistently at ~8.9-9.9 minutes, while `forge_test` was ~3.8-5.8 minutes and stacked simulations were usually ~2-3 minutes.
- CircleCI build `196531` spent 591s total in `template_regression_tests`, including 561s in `simulate-all-templates`; setup was only about 30s.
- Post-change shard profile with the same `batch_size=7`:
  - before: 54 tasks, 8 simulation batches
  - after: 14 / 14 / 13 / 13 tasks across 4 nodes, 2 batches on the critical path
- PR CI result: `template_regression_tests` passed in 305.8s total on CircleCI build `196763`; the 4 shard simulation actions ran in 206.2s, 220.9s, 220.9s, and 231.9s.

## Test Plan

- [x] `bash test/script/test-template-example-task-sharding.sh`
- [x] `(cd src/script && shellcheck -x *.sh)`
- [x] `shellcheck test/script/test-template-example-task-sharding.sh`
- [x] `forge build --deny-warnings`
- [x] shard union check: all 54 eligible tasks appear exactly once across `CIRCLE_NODE_TOTAL=4`
- [x] `just --justfile src/ci.just --dry-run simulate-all-templates`

Full local `simulate-all-templates` still requires archive RPCs. Running it against public RPC endpoints failed on historical state availability, so the production baseline is taken from CircleCI API timings.
