### PR TITLE
migration-src-0: Type A migration exercise tasks (sep)

### DIFF
--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/README.md
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/README.md
@@ -1,6 +1,6 @@
 # 101-migration-src-0-set-batcher-unsafe-signer
 
-Status: [READY TO SIGN]()
+Status: DRAFT, NOT READY TO SIGN
 
 > [!NOTE]
 > Requires the EOA → Safe B `SystemConfig.transferOwnership` (Migration Log step 1) to be executed **outside this repo** before on-chain execution. The hashes in [VALIDATION.md](./VALIDATION.md) were generated with a `SystemConfig.owner → Safe B` simulation override; once the transfer is on-chain the override is a no-op and the hashes hold (re-run `just simulate` to confirm if Safe B's nonce has moved).

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/README.md
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/README.md
@@ -7,14 +7,14 @@ Status: DRAFT, NOT READY TO SIGN
 
 ## Objective
 
-Registers the batcher and unsafe block signer on the `migration-src-0` (chainId 420120140) `SystemConfig` as part of the **Type A chain-migration exercise** that moves `migration-src-0` onto the `migrated-sop-1` operator infrastructure. This batches Migration Log steps **3** (`setBatcherHash`) and **4** (`setUnsafeBlockSigner`) into a single Multicall3 transaction.
+Registers the batcher and unsafe block signer on the `migration-src-0` (chainId 420120140) `SystemConfig` as part of the **Type A chain-migration exercise** that moves `migration-src-0` onto the `migration-dest-0` operator infrastructure. This batches Migration Log steps **3** (`setBatcherHash`) and **4** (`setUnsafeBlockSigner`) into a single Multicall3 transaction.
 
-The receiving infrastructure is `migrated-sop-1` (the FROM side of this exercise); the values below are `migrated-sop-1`'s live batcher / unsafe block signer, read on-chain from its `SystemConfig` (`0xc771958aF69D4fa44deC2555c41c48800Ca1F9Fc`).
+The receiving infrastructure is `migration-dest-0` (the destination operator for this exercise), per [devnets-private `dev/migration-dest-0`](https://github.com/ethereum-optimism/devnets-private/tree/main/dev/migration-dest-0/migration-dest-0); the values below are `migration-dest-0`'s batcher and sequencer (unsafe block signer).
 
-- **Batcher**: `0x9bEE5085CB02BFb26E5838b88F2d3827401865Ce` (migrated-sop-1 infra)
-- **UnsafeBlockSigner**: `0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90` (migrated-sop-1 infra)
+- **Batcher**: `0x04bf2305DC047e9A00AD71c08c9e8DEC502091A2` (migration-dest-0 infra)
+- **UnsafeBlockSigner**: `0x5D2680A041a63376071512eBF6f7fB3380Edad02` (migration-dest-0 infra)
 - **Target**: `SystemConfigProxy` `0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818`
-- **Signer**: OPE Receiving Safe (Safe B) `0xb3228B623da92283280C87aB8019A405967A2B8f` — the same Safe that currently owns `migrated-sop-1`'s SystemConfig.
+- **Signer**: OPE Receiving Safe (Safe B) `0xb3228B623da92283280C87aB8019A405967A2B8f` — the destination operator's Safe for the `migration-dest-0` receiving infrastructure.
 
 > [!IMPORTANT]
 > This task assumes the `SystemConfig` owner is the OPE Receiving Safe (Safe B). On `migration-src-0` the owner is currently an **EOA** (`0x8f6C6dE7cAfE9b3367f194f2403697bbAa0bA65F`); the EOA → Safe B ownership transfer is performed **outside this repo** (Migration Log step 1). For simulation, [config.toml](./config.toml) overrides `SystemConfig.owner()` to Safe B. Remove that override once the transfer is executed on-chain.
@@ -25,11 +25,11 @@ Writes to `SystemConfigProxy` ([`0xeb776E1d…EE818`](https://sepolia.etherscan.
 
 | Field | Current (on-chain) | New |
 |-------|--------------------|-----|
-| `batcherHash()` | `0x0000000000000000000000009829eb0da5d44de187ddbd8cd6daeb6fc9495931` | `0x0000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce` |
-| `unsafeBlockSigner()` | `0x5887E87eE14012453e5a3C101d8A7f42E0E99853` | `0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90` |
+| `batcherHash()` | `0x0000000000000000000000009829eb0da5d44de187ddbd8cd6daeb6fc9495931` | `0x00000000000000000000000004bf2305dc047e9a00ad71c08c9e8dec502091a2` |
+| `unsafeBlockSigner()` | `0x5887E87eE14012453e5a3C101d8A7f42E0E99853` | `0x5D2680A041a63376071512eBF6f7fB3380Edad02` |
 
 - **Current values**: read on-chain on Sepolia from the SystemConfig (link above). Verified with `cast call 0xeb776E1d… "batcherHash()(bytes32)"` and `"unsafeBlockSigner()(address)"`.
-- **New values**: `migrated-sop-1` receiving infrastructure, read on-chain from `migrated-sop-1`'s SystemConfig (`cast call 0xc771958a… "batcherHash()(bytes32)" / "unsafeBlockSigner()(address)"`).
+- **New values**: `migration-dest-0` receiving infrastructure (batcher + sequencer), per [devnets-private `dev/migration-dest-0`](https://github.com/ethereum-optimism/devnets-private/tree/main/dev/migration-dest-0/migration-dest-0).
 
 ## Simulation & Signing
 

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/README.md
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/README.md
@@ -1,0 +1,50 @@
+# 101-migration-src-0-set-batcher-unsafe-signer
+
+Status: [READY TO SIGN]()
+
+> [!NOTE]
+> Requires the EOA → Safe B `SystemConfig.transferOwnership` (Migration Log step 1) to be executed **outside this repo** before on-chain execution. The hashes in [VALIDATION.md](./VALIDATION.md) were generated with a `SystemConfig.owner → Safe B` simulation override; once the transfer is on-chain the override is a no-op and the hashes hold (re-run `just simulate` to confirm if Safe B's nonce has moved).
+
+## Objective
+
+Registers the batcher and unsafe block signer on the `migration-src-0` (chainId 420120140) `SystemConfig` as part of the **Type A chain-migration exercise** that moves `migration-src-0` onto the `migrated-sop-1` operator infrastructure. This batches Migration Log steps **3** (`setBatcherHash`) and **4** (`setUnsafeBlockSigner`) into a single Multicall3 transaction.
+
+The receiving infrastructure is `migrated-sop-1` (the FROM side of this exercise); the values below are `migrated-sop-1`'s live batcher / unsafe block signer, read on-chain from its `SystemConfig` (`0xc771958aF69D4fa44deC2555c41c48800Ca1F9Fc`).
+
+- **Batcher**: `0x9bEE5085CB02BFb26E5838b88F2d3827401865Ce` (migrated-sop-1 infra)
+- **UnsafeBlockSigner**: `0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90` (migrated-sop-1 infra)
+- **Target**: `SystemConfigProxy` `0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818`
+- **Signer**: OPE Receiving Safe (Safe B) `0xb3228B623da92283280C87aB8019A405967A2B8f` — the same Safe that currently owns `migrated-sop-1`'s SystemConfig.
+
+> [!IMPORTANT]
+> This task assumes the `SystemConfig` owner is the OPE Receiving Safe (Safe B). On `migration-src-0` the owner is currently an **EOA** (`0x8f6C6dE7cAfE9b3367f194f2403697bbAa0bA65F`); the EOA → Safe B ownership transfer is performed **outside this repo** (Migration Log step 1). For simulation, [config.toml](./config.toml) overrides `SystemConfig.owner()` to Safe B. Remove that override once the transfer is executed on-chain.
+
+## State Changes
+
+Writes to `SystemConfigProxy` ([`0xeb776E1d…EE818`](https://sepolia.etherscan.io/address/0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818#readProxyContract)):
+
+| Field | Current (on-chain) | New |
+|-------|--------------------|-----|
+| `batcherHash()` | `0x0000000000000000000000009829eb0da5d44de187ddbd8cd6daeb6fc9495931` | `0x0000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce` |
+| `unsafeBlockSigner()` | `0x5887E87eE14012453e5a3C101d8A7f42E0E99853` | `0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90` |
+
+- **Current values**: read on-chain on Sepolia from the SystemConfig (link above). Verified with `cast call 0xeb776E1d… "batcherHash()(bytes32)"` and `"unsafeBlockSigner()(address)"`.
+- **New values**: `migrated-sop-1` receiving infrastructure, read on-chain from `migrated-sop-1`'s SystemConfig (`cast call 0xc771958a… "batcherHash()(bytes32)" / "unsafeBlockSigner()(address)"`).
+
+## Simulation & Signing
+
+Simulation commands:
+```bash
+cd src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer
+SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../justfile simulate
+```
+
+Signing commands:
+```bash
+cd src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer
+just --dotenv-path $(pwd)/.env --justfile ../../../justfile sign
+```
+
+## Validation
+
+See [VALIDATION.md](./VALIDATION.md) for the expected domain/message hashes and the calldata fingerprints.

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/VALIDATION.md
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/VALIDATION.md
@@ -19,8 +19,8 @@ First, validate the domain and message hashes. These values should match both th
 > ### OPE Receiving Safe / Safe B (`0xb3228B623da92283280C87aB8019A405967A2B8f`)
 >
 > - Domain Hash:  `0x3e8aab7bcaa16ba1ae02e15a7c0fcc9d46b96cb5afed054d4e620ccfc5f62f35`
-> - Message Hash: `0x9680c05902f48995efc6d8364f72249fc9fd0eed9c55336765a37b4a68234b5a`
-> - Safe Hash:    `0x6312d9238e08a1d15772cfcbe5eefa8e047ef02cd5def2076307469954883a8a`
+> - Message Hash: `0xfbbcfe3ee83f92e962fef55be6e4f34a11f6a0393f65e20215f278ea35174811`
+> - Safe Hash:    `0xfd32e22eae1927d52e161484f4798446fd5e606456247a17136e5105e0dda871`
 >
 > _Hashes generated via `just simulate` at the latest block with the state overrides in [config.toml](./config.toml) (Safe B nonce = 1; SystemConfig.owner → Safe B). The Domain Hash was also computed independently (`keccak256(abi.encode(0x47e7…9218, 11155111, 0xb3228B…)))`). If those overrides change (e.g. Safe B transacts before this task, or the on-chain owner transfer is already executed), re-run `just simulate` and replace the Message/Safe hashes before signing._
 
@@ -32,12 +32,12 @@ Verify the two inner calldata fingerprints:
 
 ```bash
 # setBatcherHash(bytes32) — batcher address left-padded to 32 bytes
-cast calldata "setBatcherHash(bytes32)" 0x0000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce
-# Expected: 0xc9b26f610000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce
+cast calldata "setBatcherHash(bytes32)" 0x00000000000000000000000004bf2305dc047e9a00ad71c08c9e8dec502091a2
+# Expected: 0xc9b26f6100000000000000000000000004bf2305dc047e9a00ad71c08c9e8dec502091a2
 
 # setUnsafeBlockSigner(address)
-cast calldata "setUnsafeBlockSigner(address)" 0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90
-# Expected: 0x18d13918000000000000000000000000224c4e0a1d99ce75671c2c3f2a54ab775b999f90
+cast calldata "setUnsafeBlockSigner(address)" 0x5D2680A041a63376071512eBF6f7fB3380Edad02
+# Expected: 0x18d139180000000000000000000000005d2680a041a63376071512ebf6f7fb3380edad02
 ```
 
 The outer Multicall3 `aggregate3` blob is assembled by the framework and printed during simulation; confirm it contains both inner calls above and no others.
@@ -46,8 +46,8 @@ The outer Multicall3 `aggregate3` blob is assembled by the framework and printed
 
 ### `0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818` (SystemConfigProxy) — Chain ID 420120140
 
-- `batcherHash()` updates from `0x000…9829eb0da5d44de187ddbd8cd6daeb6fc9495931` to `0x000…9bee5085cb02bfb26e5838b88f2d3827401865ce` (migrated-sop-1 batcher).
-- `unsafeBlockSigner()` updates from `0x5887E87eE14012453e5a3C101d8A7f42E0E99853` to `0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90` (migrated-sop-1 unsafe block signer).
+- `batcherHash()` updates from `0x000…9829eb0da5d44de187ddbd8cd6daeb6fc9495931` to `0x000…04bf2305dc047e9a00ad71c08c9e8dec502091a2` (migration-dest-0 batcher).
+- `unsafeBlockSigner()` updates from `0x5887E87eE14012453e5a3C101d8A7f42E0E99853` to `0x5D2680A041a63376071512eBF6f7fB3380Edad02` (migration-dest-0 sequencer).
 
 ### `0xb3228B623da92283280C87aB8019A405967A2B8f` (OPE Receiving Safe / Safe B)
 
@@ -60,9 +60,9 @@ Nonce increments by 1.
 
 ```bash
 cast call 0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818 "batcherHash()(bytes32)" --rpc-url <SEPOLIA_RPC>
-# Expected: 0x0000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce
+# Expected: 0x00000000000000000000000004bf2305dc047e9a00ad71c08c9e8dec502091a2
 cast call 0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818 "unsafeBlockSigner()(address)" --rpc-url <SEPOLIA_RPC>
-# Expected: 0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90
+# Expected: 0x5D2680A041a63376071512eBF6f7fB3380Edad02
 ```
 
 Record the executed tx hash in the [Chain Migration Log](https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e) under the setBatcherHash / setUnsafeBlockSigner step.

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/VALIDATION.md
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/VALIDATION.md
@@ -1,0 +1,68 @@
+# Validation
+
+This document can be used to validate the inputs and result of the execution of the transaction which you are signing.
+
+The steps are:
+
+1. [Validate the Domain and Message Hashes](#expected-domain-and-message-hashes)
+2. [Transaction Inputs](config.toml): inputs can be verified in the config.toml file.
+3. State Changes: the template's `_validate` block asserts `SystemConfig.batcherHash()` and `SystemConfig.unsafeBlockSigner()` equal the configured values. State changes can also be reviewed in Tenderly via the link printed during simulation.
+
+## Expected Domain and Message Hashes
+
+First, validate the domain and message hashes. These values should match both the values on your ledger and the values printed to the terminal when you run the task.
+
+> [!CAUTION]
+>
+> Before signing, ensure the below hashes match what is on your ledger.
+>
+> ### OPE Receiving Safe / Safe B (`0xb3228B623da92283280C87aB8019A405967A2B8f`)
+>
+> - Domain Hash:  `0x3e8aab7bcaa16ba1ae02e15a7c0fcc9d46b96cb5afed054d4e620ccfc5f62f35`
+> - Message Hash: `0x9680c05902f48995efc6d8364f72249fc9fd0eed9c55336765a37b4a68234b5a`
+> - Safe Hash:    `0x6312d9238e08a1d15772cfcbe5eefa8e047ef02cd5def2076307469954883a8a`
+>
+> _Hashes generated via `just simulate` at the latest block with the state overrides in [config.toml](./config.toml) (Safe B nonce = 1; SystemConfig.owner → Safe B). The Domain Hash was also computed independently (`keccak256(abi.encode(0x47e7…9218, 11155111, 0xb3228B…)))`). If those overrides change (e.g. Safe B transacts before this task, or the on-chain owner transfer is already executed), re-run `just simulate` and replace the Message/Safe hashes before signing._
+
+## Understanding Task Calldata
+
+The task batches two `SystemConfig` setters through Multicall3, targeting the `migration-src-0` `SystemConfigProxy` (`0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818`).
+
+Verify the two inner calldata fingerprints:
+
+```bash
+# setBatcherHash(bytes32) — batcher address left-padded to 32 bytes
+cast calldata "setBatcherHash(bytes32)" 0x0000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce
+# Expected: 0xc9b26f610000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce
+
+# setUnsafeBlockSigner(address)
+cast calldata "setUnsafeBlockSigner(address)" 0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90
+# Expected: 0x18d13918000000000000000000000000224c4e0a1d99ce75671c2c3f2a54ab775b999f90
+```
+
+The outer Multicall3 `aggregate3` blob is assembled by the framework and printed during simulation; confirm it contains both inner calls above and no others.
+
+## Task State Changes
+
+### `0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818` (SystemConfigProxy) — Chain ID 420120140
+
+- `batcherHash()` updates from `0x000…9829eb0da5d44de187ddbd8cd6daeb6fc9495931` to `0x000…9bee5085cb02bfb26e5838b88f2d3827401865ce` (migrated-sop-1 batcher).
+- `unsafeBlockSigner()` updates from `0x5887E87eE14012453e5a3C101d8A7f42E0E99853` to `0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90` (migrated-sop-1 unsafe block signer).
+
+### `0xb3228B623da92283280C87aB8019A405967A2B8f` (OPE Receiving Safe / Safe B)
+
+Nonce increments by 1.
+
+> [!NOTE]
+> The `SystemConfig.owner()` change from EOA → Safe B is **not** part of this task; it is performed outside the ops repo. The owner override in [config.toml](./config.toml) exists only so the setters authorize during simulation.
+
+## Post-execution verification
+
+```bash
+cast call 0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818 "batcherHash()(bytes32)" --rpc-url <SEPOLIA_RPC>
+# Expected: 0x0000000000000000000000009bee5085cb02bfb26e5838b88f2d3827401865ce
+cast call 0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818 "unsafeBlockSigner()(address)" --rpc-url <SEPOLIA_RPC>
+# Expected: 0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90
+```
+
+Record the executed tx hash in the [Chain Migration Log](https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e) under the setBatcherHash / setUnsafeBlockSigner step.

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/addresses.json
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/addresses.json
@@ -1,0 +1,9 @@
+{
+  "420120140": {
+    "SystemConfigOwner": "0xb3228B623da92283280C87aB8019A405967A2B8f",
+    "SystemConfigProxy": "0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818",
+    "ProxyAdminOwner": "0xe934Dc97E347C6aCef74364B50125bb8689c40ff",
+    "L1StandardBridgeProxy": "0xF6e21D927C2F112F759B658af94B2c8E1fD3D9B9",
+    "OptimismPortalProxy": "0x7b123dD7466dAB1fe60703Cd11fCE9c77d413a05"
+  }
+}

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/config.toml
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/config.toml
@@ -1,22 +1,22 @@
 templateName = "SetBatcherAndOrSigner"
 fallbackAddressesJsonPath = "src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/addresses.json"
 
-# Signed by the new SystemConfig owner (OPE Receiving Safe / Safe B), i.e. the same
-# Safe that currently owns migrated-sop-1's SystemConfig. The EOA -> Safe B ownership
-# transfer is performed OUTSIDE the ops repo (Migration Log step 1); this task assumes
-# Safe B is the owner (see the SystemConfig.owner state override below for simulation).
+# Signed by the new SystemConfig owner (OPE Receiving Safe / Safe B) for the
+# migration-dest-0 receiving infrastructure. The EOA -> Safe B ownership transfer is
+# performed OUTSIDE the ops repo (Migration Log step 1); this task assumes Safe B is the
+# owner (see the SystemConfig.owner state override below for simulation).
 safeAddressString = "SystemConfigOwner"
 
 l2chains = [
     {name = "migration-src-0", chainId = 420120140}
 ]
 
-# Receiving infrastructure = migrated-sop-1 (the FROM side of this exercise). These are
-# migrated-sop-1's live batcher / unsafe block signer, read on-chain from its SystemConfig
-# (0xc771958aF69D4fa44deC2555c41c48800Ca1F9Fc).
+# Receiving infrastructure = migration-dest-0 (the destination operator for this exercise),
+# per devnets-private dev/migration-dest-0. These are migration-dest-0's batcher and
+# sequencer (unsafe block signer).
 [sequencerConfig]
-batcherAddress = "0x9bEE5085CB02BFb26E5838b88F2d3827401865Ce"
-unsafeBlockSigner = "0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90"
+batcherAddress = "0x04bf2305DC047e9A00AD71c08c9e8DEC502091A2"
+unsafeBlockSigner = "0x5D2680A041a63376071512eBF6f7fB3380Edad02"
 
 [stateOverrides]
 # OPE Receiving Safe (Safe B) nonce — current on-chain = 1.

--- a/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/config.toml
+++ b/src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/config.toml
@@ -1,0 +1,32 @@
+templateName = "SetBatcherAndOrSigner"
+fallbackAddressesJsonPath = "src/tasks/sep/101-migration-src-0-set-batcher-unsafe-signer/addresses.json"
+
+# Signed by the new SystemConfig owner (OPE Receiving Safe / Safe B), i.e. the same
+# Safe that currently owns migrated-sop-1's SystemConfig. The EOA -> Safe B ownership
+# transfer is performed OUTSIDE the ops repo (Migration Log step 1); this task assumes
+# Safe B is the owner (see the SystemConfig.owner state override below for simulation).
+safeAddressString = "SystemConfigOwner"
+
+l2chains = [
+    {name = "migration-src-0", chainId = 420120140}
+]
+
+# Receiving infrastructure = migrated-sop-1 (the FROM side of this exercise). These are
+# migrated-sop-1's live batcher / unsafe block signer, read on-chain from its SystemConfig
+# (0xc771958aF69D4fa44deC2555c41c48800Ca1F9Fc).
+[sequencerConfig]
+batcherAddress = "0x9bEE5085CB02BFb26E5838b88F2d3827401865Ce"
+unsafeBlockSigner = "0x224C4E0a1d99CE75671C2C3f2a54ab775b999f90"
+
+[stateOverrides]
+# OPE Receiving Safe (Safe B) nonce — current on-chain = 1.
+0xb3228B623da92283280C87aB8019A405967A2B8f = [
+    {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = 1}
+]
+# Pretend the out-of-ops EOA -> Safe B ownership transfer has executed: override
+# SystemConfig.owner() (slot 0x33) from the current EOA (0x8f6C6dE7…) to Safe B so
+# setBatcherHash / setUnsafeBlockSigner authorize. Remove this override once the
+# ownership transfer is executed on-chain.
+0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818 = [
+    {key = "0x0000000000000000000000000000000000000000000000000000000000000033", value = "0x000000000000000000000000b3228B623da92283280C87aB8019A405967A2B8f"}
+]

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/README.md
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/README.md
@@ -1,6 +1,6 @@
 # 102-migration-src-0-proposer-rotation
 
-Status: [READY TO SIGN]()
+Status: DRAFT, NOT READY TO SIGN
 
 ## Objective
 

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/README.md
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/README.md
@@ -1,0 +1,56 @@
+# 102-migration-src-0-proposer-rotation
+
+Status: [READY TO SIGN]()
+
+## Objective
+
+For the `migration-src-0` (chainId 420120140) DisputeGameFactory on Sepolia, rotate the **PermissionedDisputeGame** (PDG, game type 1) proposer and challenger to the `migrated-sop-1` receiving infrastructure (the FROM side of this Type A migration exercise).
+
+The PDG implementation address is unchanged (`0x58bf355C5d4EdFc723eF89d99582ECCfd143266A`); only the `gameArgs` blob changes, so the template emits a single `setImplementation` call for game type 1.
+
+> [!NOTE]
+> **Fault proofs are out of scope for this exercise.** The absolute prestate is **left unchanged** (`0x038512e0…d54c`, the netchef-default permissioned prestate). The FaultDisputeGame (FDG, game type 0) is **not** registered on `migration-src-0` (`gameImpls(0) == 0x0`) and is not added here — the FDG slot stays zeroed (`fdgImpl = 0x0`, empty `fdgGameArgs`), so no FDG call is emitted.
+
+This is Migration Log step **3a/4** (`DisputeGameFactory.setImplementation`, proposer/challenger rotation).
+
+- **DisputeGameFactoryProxy**: `0xD36035054813F3979f61fE17E870beC0fB8F964D`
+- **Signer**: L1 ProxyAdminOwner Safe `0xe934Dc97E347C6aCef74364B50125bb8689c40ff`
+
+## State Changes
+
+Writes to `DisputeGameFactoryProxy` ([`0xD3603505…964D`](https://sepolia.etherscan.io/address/0xD36035054813F3979f61fE17E870beC0fB8F964D#readContract)) for chainId 420120140.
+
+### Game type 1 (PDG — PERMISSIONED_CANNON)
+
+| `gameArgs(1)` field | Bytes | Current (on-chain) | New |
+|---------------------|-------|--------------------|-----|
+| prestate | 0–32 | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` (unchanged) |
+| vm | 32–52 | `0x6463dee3828677f6270d83d45408044fc5edb908` | `0x6463dee3828677f6270d83d45408044fc5edb908` (unchanged) |
+| anchorStateRegistry | 52–72 | `0x25189fec7e5794e6cbb53afcfe624c517537a216` | `0x25189fec7e5794e6cbb53afcfe624c517537a216` (unchanged) |
+| delayedWETH | 72–92 | `0x3895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e` | `0x3895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e` (unchanged) |
+| l2ChainId | 92–124 | `420120140` | `420120140` (unchanged) |
+| proposer | 124–144 | `0x0fd61abe8d576f2c77ea05af2d37eef98164c9fc` | `0x5e9eE0Aa455425AaD2B55742077F95113FbaeB71` |
+| challenger | 144–164 | `0x5d5f9c4bd7946bf3f1f2ecf2cc9896fcb6a1546e` | `0x9805e7976880e6e48Ce765118846078B877d80D0` |
+
+`gameImpls(1)` is unchanged at `0x58bf355C5d4EdFc723eF89d99582ECCfd143266A`. Game type 0 (FDG) remains unset (`gameImpls(0) == 0x0`).
+
+- **Current values**: full `gameArgs(1)` blob read on-chain on Sepolia via `cast call 0xD3603505… "gameArgs(uint32)(bytes)" 1`. Decomposed per the permissioned 164-byte layout (prestate|vm|ASR|weth|chainId|proposer|challenger).
+- **New proposer / challenger**: `migrated-sop-1` receiving infrastructure, read on-chain from `migrated-sop-1`'s DisputeGameFactory (`cast call 0xD22e520F… "gameArgs(uint32)(bytes)" 1`).
+
+## Simulation & Signing
+
+Simulation commands:
+```bash
+cd src/tasks/sep/102-migration-src-0-proposer-rotation
+SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env --justfile ../../../justfile simulate
+```
+
+Signing commands:
+```bash
+cd src/tasks/sep/102-migration-src-0-proposer-rotation
+just --dotenv-path $(pwd)/.env --justfile ../../../justfile sign
+```
+
+## Validation
+
+See [VALIDATION.md](./VALIDATION.md) for the expected domain/message hashes and the calldata fingerprint.

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/README.md
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/README.md
@@ -4,12 +4,12 @@ Status: DRAFT, NOT READY TO SIGN
 
 ## Objective
 
-For the `migration-src-0` (chainId 420120140) DisputeGameFactory on Sepolia, rotate the **PermissionedDisputeGame** (PDG, game type 1) proposer and challenger to the `migrated-sop-1` receiving infrastructure (the FROM side of this Type A migration exercise).
+For the `migration-src-0` (chainId 420120140) DisputeGameFactory on Sepolia, rotate the **PermissionedDisputeGame** (PDG, game type 1) proposer and challenger to the `migration-dest-0` receiving infrastructure (the destination operator for this Type A migration exercise).
 
 The PDG implementation address is unchanged (`0x58bf355C5d4EdFc723eF89d99582ECCfd143266A`); only the `gameArgs` blob changes, so the template emits a single `setImplementation` call for game type 1.
 
 > [!NOTE]
-> **Fault proofs are out of scope for this exercise.** The absolute prestate is **left unchanged** (`0x038512e0…d54c`, the netchef-default permissioned prestate). The FaultDisputeGame (FDG, game type 0) is **not** registered on `migration-src-0` (`gameImpls(0) == 0x0`) and is not added here — the FDG slot stays zeroed (`fdgImpl = 0x0`, empty `fdgGameArgs`), so no FDG call is emitted.
+> **Fault proofs are out of scope for this exercise.** The PDG absolute prestate is set to the **`0xdead…` placeholder** (was `0x038512e0…d54c`, the netchef-default permissioned prestate). The chain is kept **permissioned** — the FaultDisputeGame (FDG, game type 0) is **not** registered on `migration-src-0` (`gameImpls(0) == 0x0`) and is not added here — the FDG slot stays zeroed (`fdgImpl = 0x0`, empty `fdgGameArgs`), so no FDG call is emitted.
 
 This is Migration Log step **3a/4** (`DisputeGameFactory.setImplementation`, proposer/challenger rotation).
 
@@ -24,18 +24,18 @@ Writes to `DisputeGameFactoryProxy` ([`0xD3603505…964D`](https://sepolia.ether
 
 | `gameArgs(1)` field | Bytes | Current (on-chain) | New |
 |---------------------|-------|--------------------|-----|
-| prestate | 0–32 | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` (unchanged) |
+| prestate | 0–32 | `0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c` | `0xdead000000000000000000000000000000000000000000000000000000000000` |
 | vm | 32–52 | `0x6463dee3828677f6270d83d45408044fc5edb908` | `0x6463dee3828677f6270d83d45408044fc5edb908` (unchanged) |
 | anchorStateRegistry | 52–72 | `0x25189fec7e5794e6cbb53afcfe624c517537a216` | `0x25189fec7e5794e6cbb53afcfe624c517537a216` (unchanged) |
 | delayedWETH | 72–92 | `0x3895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e` | `0x3895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e` (unchanged) |
 | l2ChainId | 92–124 | `420120140` | `420120140` (unchanged) |
-| proposer | 124–144 | `0x0fd61abe8d576f2c77ea05af2d37eef98164c9fc` | `0x5e9eE0Aa455425AaD2B55742077F95113FbaeB71` |
-| challenger | 144–164 | `0x5d5f9c4bd7946bf3f1f2ecf2cc9896fcb6a1546e` | `0x9805e7976880e6e48Ce765118846078B877d80D0` |
+| proposer | 124–144 | `0x0fd61abe8d576f2c77ea05af2d37eef98164c9fc` | `0xD3E481Acf11fB35c1b274342ea3137c7ec29442b` |
+| challenger | 144–164 | `0x5d5f9c4bd7946bf3f1f2ecf2cc9896fcb6a1546e` | `0x4DFb8C08220d7aE47ACd6AEed15A06eCc2f61594` |
 
 `gameImpls(1)` is unchanged at `0x58bf355C5d4EdFc723eF89d99582ECCfd143266A`. Game type 0 (FDG) remains unset (`gameImpls(0) == 0x0`).
 
 - **Current values**: full `gameArgs(1)` blob read on-chain on Sepolia via `cast call 0xD3603505… "gameArgs(uint32)(bytes)" 1`. Decomposed per the permissioned 164-byte layout (prestate|vm|ASR|weth|chainId|proposer|challenger).
-- **New proposer / challenger**: `migrated-sop-1` receiving infrastructure, read on-chain from `migrated-sop-1`'s DisputeGameFactory (`cast call 0xD22e520F… "gameArgs(uint32)(bytes)" 1`).
+- **New proposer / challenger**: `migration-dest-0` receiving infrastructure, per [devnets-private `dev/migration-dest-0`](https://github.com/ethereum-optimism/devnets-private/tree/main/dev/migration-dest-0/migration-dest-0).
 
 ## Simulation & Signing
 

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/VALIDATION.md
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/VALIDATION.md
@@ -1,0 +1,69 @@
+# Validation
+
+This document can be used to validate the inputs and result of the execution of the transaction which you are signing.
+
+The steps are:
+
+1. [Validate the Domain and Message Hashes](#expected-domain-and-message-hashes)
+2. [Transaction Inputs](config.toml): inputs can be verified in the config.toml file.
+3. State Changes: the template's `_validate` block asserts the new `gameArgs(1)` and unchanged `gameImpls(1)`. State changes can also be reviewed in Tenderly via the link printed during simulation.
+
+## Expected Domain and Message Hashes
+
+First, validate the domain and message hashes. These values should match both the values on your ledger and the values printed to the terminal when you run the task.
+
+> [!CAUTION]
+>
+> Before signing, ensure the below hashes match what is on your ledger.
+>
+> ### ProxyAdminOwner Safe (`0xe934Dc97E347C6aCef74364B50125bb8689c40ff`)
+>
+> - Domain Hash:  `0x07e03428d7125835eca12b6dd1a02903029b456da3a091ecd66fda859fbce61e`
+> - Message Hash: `0x8fe01dc79cfe2c0375e3598c95e7ef90036a55feb7fd271446545f9ac96b9205`
+> - Safe Hash:    `0x5e633cffbb0c2facfb32afd9c7337f1145d34f198464ede415a8b3e916b76d05`
+>
+> _Hashes generated via `just simulate` at the latest block with the PAO nonce override in [config.toml](./config.toml) (= 111, the live on-chain nonce; 102 is the first PAO-signed task in this exercise). If the override changes (e.g. another PAO task executes first), re-run `just simulate` and replace the Message/Safe hashes before signing._
+
+## Understanding Task Calldata
+
+The task calls `setImplementation` **once** on the `migration-src-0` DisputeGameFactory (`0xD36035054813F3979f61fE17E870beC0fB8F964D`), for PDG (game type 1). The implementation address does not change; only the `gameArgs` blob changes.
+
+> **Note:** The effective change vs current on-chain state is:
+> - **PDG (game type 1)** proposer: `0x0fd61abe…c9fc` → `0x5e9eE0Aa…eB71` (`migrated-sop-1` receiving infra)
+> - **PDG (game type 1)** challenger: `0x5d5f9c4b…1546e` → `0x9805e797…80D0` (`migrated-sop-1` receiving infra)
+> - prestate is **unchanged** at `0x038512e0…d54c`
+
+Verify the inner calldata fingerprint:
+
+```bash
+cast calldata "setImplementation(uint32,address,bytes)" 1 \
+  0x58bf355C5d4EdFc723eF89d99582ECCfd143266A \
+  0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c6463dee3828677f6270d83d45408044fc5edb90825189fec7e5794e6cbb53afcfe624c517537a2163895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e00000000000000000000000000000000000000000000000000000000190a864c5e9ee0aa455425aad2b55742077f95113fbaeb719805e7976880e6e48ce765118846078b877d80d0
+# Selector + head: 0xb1070957…0000000000000000000000000000000000000000000000000000000000000001
+#                          (gameType = 1, impl = 0x58bf355C…266A, gameArgs = the 164-byte blob above)
+```
+
+The new 164-byte `gameArgs` blob must contain, in order: prestate `0x038512e0…d54c`, vm `0x6463dee3…b908`, ASR `0x25189fec…a216`, delayedWETH `0x3895dcd2…ea8e`, chainId `190a864c` (420120140), proposer `5e9ee0aa…eb71`, challenger `9805e797…80d0`.
+
+The outer Multicall3 blob is assembled by the framework and printed during simulation; confirm it contains only the single `setImplementation` call above.
+
+## Task State Changes
+
+### `0xD36035054813F3979f61fE17E870beC0fB8F964D` (DisputeGameFactoryProxy) — Chain ID 420120140
+
+- `gameArgs` for **game type 1 (PERMISSIONED_CANNON)** updated to embed the new `migrated-sop-1` proposer (`0x5e9eE0Aa455425AaD2B55742077F95113FbaeB71`) and challenger (`0x9805e7976880e6e48Ce765118846078B877d80D0`). Prestate and implementation address (`0x58bf355C…266A`) are unchanged.
+- Game type 0 (CANNON / FDG) is untouched and remains unset.
+
+### `0xe934Dc97E347C6aCef74364B50125bb8689c40ff` (ProxyAdminOwner)
+
+Nonce increments by 1.
+
+## Post-execution verification
+
+```bash
+cast call 0xD36035054813F3979f61fE17E870beC0fB8F964D "gameArgs(uint32)(bytes)" 1 --rpc-url <SEPOLIA_RPC>
+# Bytes 124..144 (proposer)  must equal 5e9ee0aa455425aad2b55742077f95113fbaeb71
+# Bytes 144..164 (challenger) must equal 9805e7976880e6e48ce765118846078b877d80d0
+```
+
+Record the executed tx hash in the [Chain Migration Log](https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e) under the DisputeGameFactory proposer/challenger rotation step.

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/VALIDATION.md
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/VALIDATION.md
@@ -19,8 +19,8 @@ First, validate the domain and message hashes. These values should match both th
 > ### ProxyAdminOwner Safe (`0xe934Dc97E347C6aCef74364B50125bb8689c40ff`)
 >
 > - Domain Hash:  `0x07e03428d7125835eca12b6dd1a02903029b456da3a091ecd66fda859fbce61e`
-> - Message Hash: `0x8fe01dc79cfe2c0375e3598c95e7ef90036a55feb7fd271446545f9ac96b9205`
-> - Safe Hash:    `0x5e633cffbb0c2facfb32afd9c7337f1145d34f198464ede415a8b3e916b76d05`
+> - Message Hash: `0xfa328de0d675dc73744a57cc2dee420747640bc257882c27887e6d41e8a22b11`
+> - Safe Hash:    `0x903c07f6e413342527ee5dda00d8b64af80477cab0ea64abe1bb7a7ac80fb598`
 >
 > _Hashes generated via `just simulate` at the latest block with the PAO nonce override in [config.toml](./config.toml) (= 111, the live on-chain nonce; 102 is the first PAO-signed task in this exercise). If the override changes (e.g. another PAO task executes first), re-run `just simulate` and replace the Message/Safe hashes before signing._
 
@@ -29,21 +29,21 @@ First, validate the domain and message hashes. These values should match both th
 The task calls `setImplementation` **once** on the `migration-src-0` DisputeGameFactory (`0xD36035054813F3979f61fE17E870beC0fB8F964D`), for PDG (game type 1). The implementation address does not change; only the `gameArgs` blob changes.
 
 > **Note:** The effective change vs current on-chain state is:
-> - **PDG (game type 1)** proposer: `0x0fd61abe…c9fc` → `0x5e9eE0Aa…eB71` (`migrated-sop-1` receiving infra)
-> - **PDG (game type 1)** challenger: `0x5d5f9c4b…1546e` → `0x9805e797…80D0` (`migrated-sop-1` receiving infra)
-> - prestate is **unchanged** at `0x038512e0…d54c`
+> - **PDG (game type 1)** proposer: `0x0fd61abe…c9fc` → `0xD3E481Ac…442b` (`migration-dest-0` receiving infra)
+> - **PDG (game type 1)** challenger: `0x5d5f9c4b…1546e` → `0x4DFb8C08…1594` (`migration-dest-0` receiving infra)
+> - **PDG (game type 1)** prestate: `0x038512e0…d54c` → `0xdead…` (`0xdead` placeholder)
 
 Verify the inner calldata fingerprint:
 
 ```bash
 cast calldata "setImplementation(uint32,address,bytes)" 1 \
   0x58bf355C5d4EdFc723eF89d99582ECCfd143266A \
-  0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c6463dee3828677f6270d83d45408044fc5edb90825189fec7e5794e6cbb53afcfe624c517537a2163895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e00000000000000000000000000000000000000000000000000000000190a864c5e9ee0aa455425aad2b55742077f95113fbaeb719805e7976880e6e48ce765118846078b877d80d0
+  0xdead0000000000000000000000000000000000000000000000000000000000006463dee3828677f6270d83d45408044fc5edb90825189fec7e5794e6cbb53afcfe624c517537a2163895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e00000000000000000000000000000000000000000000000000000000190a864cd3e481acf11fb35c1b274342ea3137c7ec29442b4dfb8c08220d7ae47acd6aeed15a06ecc2f61594
 # Selector + head: 0xb1070957…0000000000000000000000000000000000000000000000000000000000000001
 #                          (gameType = 1, impl = 0x58bf355C…266A, gameArgs = the 164-byte blob above)
 ```
 
-The new 164-byte `gameArgs` blob must contain, in order: prestate `0x038512e0…d54c`, vm `0x6463dee3…b908`, ASR `0x25189fec…a216`, delayedWETH `0x3895dcd2…ea8e`, chainId `190a864c` (420120140), proposer `5e9ee0aa…eb71`, challenger `9805e797…80d0`.
+The new 164-byte `gameArgs` blob must contain, in order: prestate `0xdead…` (`0xdead` placeholder), vm `0x6463dee3…b908`, ASR `0x25189fec…a216`, delayedWETH `0x3895dcd2…ea8e`, chainId `190a864c` (420120140), proposer `d3e481ac…442b`, challenger `4dfb8c08…1594`.
 
 The outer Multicall3 blob is assembled by the framework and printed during simulation; confirm it contains only the single `setImplementation` call above.
 
@@ -51,7 +51,7 @@ The outer Multicall3 blob is assembled by the framework and printed during simul
 
 ### `0xD36035054813F3979f61fE17E870beC0fB8F964D` (DisputeGameFactoryProxy) — Chain ID 420120140
 
-- `gameArgs` for **game type 1 (PERMISSIONED_CANNON)** updated to embed the new `migrated-sop-1` proposer (`0x5e9eE0Aa455425AaD2B55742077F95113FbaeB71`) and challenger (`0x9805e7976880e6e48Ce765118846078B877d80D0`). Prestate and implementation address (`0x58bf355C…266A`) are unchanged.
+- `gameArgs` for **game type 1 (PERMISSIONED_CANNON)** updated to embed the new `migration-dest-0` proposer (`0xD3E481Acf11fB35c1b274342ea3137c7ec29442b`) and challenger (`0x4DFb8C08220d7aE47ACd6AEed15A06eCc2f61594`), and to set the prestate to the `0xdead…` placeholder. The implementation address (`0x58bf355C…266A`) is unchanged.
 - Game type 0 (CANNON / FDG) is untouched and remains unset.
 
 ### `0xe934Dc97E347C6aCef74364B50125bb8689c40ff` (ProxyAdminOwner)
@@ -62,8 +62,9 @@ Nonce increments by 1.
 
 ```bash
 cast call 0xD36035054813F3979f61fE17E870beC0fB8F964D "gameArgs(uint32)(bytes)" 1 --rpc-url <SEPOLIA_RPC>
-# Bytes 124..144 (proposer)  must equal 5e9ee0aa455425aad2b55742077f95113fbaeb71
-# Bytes 144..164 (challenger) must equal 9805e7976880e6e48ce765118846078b877d80d0
+# Bytes 0..32    (prestate)   must equal dead000000000000000000000000000000000000000000000000000000000000
+# Bytes 124..144 (proposer)  must equal d3e481acf11fb35c1b274342ea3137c7ec29442b
+# Bytes 144..164 (challenger) must equal 4dfb8c08220d7ae47acd6aeed15a06ecc2f61594
 ```
 
 Record the executed tx hash in the [Chain Migration Log](https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e) under the DisputeGameFactory proposer/challenger rotation step.

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/addresses.json
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/addresses.json
@@ -1,0 +1,13 @@
+{
+  "420120140": {
+    "ProxyAdmin": "0x6D2E0B44e31a6Fa514135AB560148e944e400b4e",
+    "ProxyAdminOwner": "0xe934Dc97E347C6aCef74364B50125bb8689c40ff",
+    "SystemConfigProxy": "0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818",
+    "L1StandardBridgeProxy": "0xF6e21D927C2F112F759B658af94B2c8E1fD3D9B9",
+    "OptimismPortalProxy": "0x7b123dD7466dAB1fe60703Cd11fCE9c77d413a05",
+    "DisputeGameFactoryProxy": "0xD36035054813F3979f61fE17E870beC0fB8F964D",
+    "DelayedWETHProxy": "0x3895DCD2f5DDd092C31Aa8744Ceb4c6006b7Ea8E",
+    "PermissionedDelayedWETHProxy": "0x3895DCD2f5DDd092C31Aa8744Ceb4c6006b7Ea8E",
+    "AnchorStateRegistryProxy": "0x25189FeC7e5794e6cBB53aFCFe624C517537A216"
+  }
+}

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/config.toml
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/config.toml
@@ -1,0 +1,46 @@
+l2chains = [
+    {name = "migration-src-0", chainId = 420120140}
+]
+
+templateName = "SetDisputeGameImpl"
+fallbackAddressesJsonPath = "src/tasks/sep/102-migration-src-0-proposer-rotation/addresses.json"
+
+[[gameImplConfig]]
+# Rotate the PermissionedDisputeGame (PDG, game type 1) proposer and challenger to the
+# migrated-sop-1 receiving infrastructure (the FROM side of this exercise). The absolute
+# prestate is intentionally LEFT UNCHANGED (fault proofs are out of scope for this
+# exercise) — only the proposer (bytes 124..144) and challenger (bytes 144..164) change.
+#
+# FaultDisputeGame (FDG, game type 0) is NOT registered on migration-src-0
+# (gameImpls(0) == 0x0) and is out of scope here, so the FDG slot is zeroed: with
+# fdgImpl = 0x0 and empty fdgGameArgs matching the empty on-chain gameArgs(0), the
+# template's skip-if-unchanged guard (SetDisputeGameImpl._setFDGImplementation) emits
+# no FDG call. Only the PDG setImplementation call is emitted.
+chainId = 420120140
+fdgBond = 0
+pdgBond = 0
+fdgImpl = "0x0000000000000000000000000000000000000000"
+fdgGameArgs = "0x"
+pdgImpl = "0x58bf355C5d4EdFc723eF89d99582ECCfd143266A" # PermissionedDisputeGameImpl (unchanged)
+prevFdgImpl = "0x0000000000000000000000000000000000000000"
+prevPdgImpl = "0x58bf355C5d4EdFc723eF89d99582ECCfd143266A" # Same impl — only gameArgs change (new proposer/challenger)
+# 164-byte encoded constructor args for PermissionedDisputeGame.
+# Layout (per SetDisputeGameImpl._validateGameArgsFormat, permissioned = 164 bytes):
+#   prestate(32) | vm(20) | anchorStateRegistry(20) | delayedWETH(20) | chainId(32) | proposer(20) | challenger(20)
+# Values:
+#   prestate            = 0x038512e0…d54c  (UNCHANGED — netchef-default permissioned prestate; fault proofs out of scope)
+#   vm                  = 0x6463dee3…b908  (MIPS 1.9.0)
+#   anchorStateRegistry = 0x25189fec…a216  (migration-src-0 ASR)
+#   delayedWETH         = 0x3895dcd2…ea8e  (DelayedWethPermissionedGameProxy)
+#   chainId             = 420120140 (= 0x190a864c), 32-byte left-padded
+#   proposer            = 0x5e9eE0Aa…eB71  (migrated-sop-1 receiving infra — UPDATED from on-chain 0x0fd61abe…c9fc)
+#   challenger          = 0x9805e797…80D0  (migrated-sop-1 receiving infra — UPDATED from on-chain 0x5d5f9c4b…1546e)
+pdgGameArgs = "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c6463dee3828677f6270d83d45408044fc5edb90825189fec7e5794e6cbb53afcfe624c517537a2163895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e00000000000000000000000000000000000000000000000000000000190a864c5e9ee0aa455425aad2b55742077f95113fbaeb719805e7976880e6e48ce765118846078b877d80d0"
+
+[stateOverrides]
+# PAO Safe nonce override = current on-chain (111). This is the first PAO-signed task in
+# this exercise (101 is signed by Safe B; the SystemConfig transfer is out-of-ops), so 102
+# signs at the live PAO nonce. If 103 (fee-vault) is executed before this task, bump accordingly.
+0xe934Dc97E347C6aCef74364B50125bb8689c40ff = [
+    {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = 111}
+]

--- a/src/tasks/sep/102-migration-src-0-proposer-rotation/config.toml
+++ b/src/tasks/sep/102-migration-src-0-proposer-rotation/config.toml
@@ -7,9 +7,10 @@ fallbackAddressesJsonPath = "src/tasks/sep/102-migration-src-0-proposer-rotation
 
 [[gameImplConfig]]
 # Rotate the PermissionedDisputeGame (PDG, game type 1) proposer and challenger to the
-# migrated-sop-1 receiving infrastructure (the FROM side of this exercise). The absolute
-# prestate is intentionally LEFT UNCHANGED (fault proofs are out of scope for this
-# exercise) — only the proposer (bytes 124..144) and challenger (bytes 144..164) change.
+# migration-dest-0 receiving infrastructure (the destination operator for this exercise),
+# and set the PDG absolute prestate to the 0xdead placeholder (fault proofs are out of
+# scope for this exercise). The chain is kept PERMISSIONED (no FDG added); the proposer
+# (bytes 124..144), challenger (bytes 144..164) and prestate (bytes 0..32) all change.
 #
 # FaultDisputeGame (FDG, game type 0) is NOT registered on migration-src-0
 # (gameImpls(0) == 0x0) and is out of scope here, so the FDG slot is zeroed: with
@@ -23,19 +24,19 @@ fdgImpl = "0x0000000000000000000000000000000000000000"
 fdgGameArgs = "0x"
 pdgImpl = "0x58bf355C5d4EdFc723eF89d99582ECCfd143266A" # PermissionedDisputeGameImpl (unchanged)
 prevFdgImpl = "0x0000000000000000000000000000000000000000"
-prevPdgImpl = "0x58bf355C5d4EdFc723eF89d99582ECCfd143266A" # Same impl — only gameArgs change (new proposer/challenger)
+prevPdgImpl = "0x58bf355C5d4EdFc723eF89d99582ECCfd143266A" # Same impl — only gameArgs change (new prestate, proposer, challenger)
 # 164-byte encoded constructor args for PermissionedDisputeGame.
 # Layout (per SetDisputeGameImpl._validateGameArgsFormat, permissioned = 164 bytes):
 #   prestate(32) | vm(20) | anchorStateRegistry(20) | delayedWETH(20) | chainId(32) | proposer(20) | challenger(20)
 # Values:
-#   prestate            = 0x038512e0…d54c  (UNCHANGED — netchef-default permissioned prestate; fault proofs out of scope)
+#   prestate            = 0xdead0000…0000  (0xdead placeholder — fault proofs out of scope; was on-chain 0x038512e0…d54c)
 #   vm                  = 0x6463dee3…b908  (MIPS 1.9.0)
 #   anchorStateRegistry = 0x25189fec…a216  (migration-src-0 ASR)
 #   delayedWETH         = 0x3895dcd2…ea8e  (DelayedWethPermissionedGameProxy)
 #   chainId             = 420120140 (= 0x190a864c), 32-byte left-padded
-#   proposer            = 0x5e9eE0Aa…eB71  (migrated-sop-1 receiving infra — UPDATED from on-chain 0x0fd61abe…c9fc)
-#   challenger          = 0x9805e797…80D0  (migrated-sop-1 receiving infra — UPDATED from on-chain 0x5d5f9c4b…1546e)
-pdgGameArgs = "0x038512e02c4c3f7bdaec27d00edf55b7155e0905301e1a88083e4e0a6764d54c6463dee3828677f6270d83d45408044fc5edb90825189fec7e5794e6cbb53afcfe624c517537a2163895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e00000000000000000000000000000000000000000000000000000000190a864c5e9ee0aa455425aad2b55742077f95113fbaeb719805e7976880e6e48ce765118846078b877d80d0"
+#   proposer            = 0xD3E481Ac…442b  (migration-dest-0 receiving infra — UPDATED from on-chain 0x0fd61abe…c9fc)
+#   challenger          = 0x4DFb8C08…1594  (migration-dest-0 receiving infra — UPDATED from on-chain 0x5d5f9c4b…1546e)
+pdgGameArgs = "0xdead0000000000000000000000000000000000000000000000000000000000006463dee3828677f6270d83d45408044fc5edb90825189fec7e5794e6cbb53afcfe624c517537a2163895dcd2f5ddd092c31aa8744ceb4c6006b7ea8e00000000000000000000000000000000000000000000000000000000190a864cd3e481acf11fb35c1b274342ea3137c7ec29442b4dfb8c08220d7ae47acd6aeed15a06ecc2f61594"
 
 [stateOverrides]
 # PAO Safe nonce override = current on-chain (111). This is the first PAO-signed task in

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/README.md
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/README.md
@@ -1,6 +1,6 @@
 # 103-migration-src-0-fee-vault-update
 
-Status: BLOCKED — see prerequisite below. (Do not sign yet.)
+Status: DRAFT, NOT READY TO SIGN
 
 > [!WARNING]
 > **The L2 ProxyAdmin owner pre-flight check (enabled via `l2RpcUrls`) currently fails.**

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/README.md
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/README.md
@@ -1,6 +1,19 @@
 # 103-migration-src-0-fee-vault-update
 
-Status: [READY TO SIGN]()
+Status: BLOCKED — see prerequisite below. (Do not sign yet.)
+
+> [!WARNING]
+> **The L2 ProxyAdmin owner pre-flight check (enabled via `l2RpcUrls`) currently fails.**
+> migration-src-0's L2 ProxyAdmin (`0x4200000000000000000000000000000000000018`) is owned by
+> `0x1c784CC0B5DFb4f6ad3FD9E430069bcBD2bC8D5c` (the netchef deployer admin, the L1->L2 alias of
+> L1 EOA `0x0b674cc0…7c4b`), **not** the aliased L1 ProxyAdminOwner (`0xfA45dc97E347C6acEF74364B50125BB8689c5210`).
+> The `ProxyAdmin.upgradeAndCall` portal deposits in this task would **revert on L2**.
+>
+> **Prerequisite (out-of-ops, like the SystemConfig owner transfer):** transfer the L2 ProxyAdmin
+> ownership to the aliased L1 PAO `0xfA45dc97…5210`. This must be driven by the current controller
+> (L1 EOA `0x0b674cc0…7c4b` via netchef/op-deployer), since the L1 PAO's alias is not yet the owner —
+> so it cannot be done by a PAO-signed ops task here. Once transferred, re-run `just simulate` to
+> confirm the pre-flight passes and regenerate the hashes in [VALIDATION.md](./VALIDATION.md) before signing.
 
 ## Objective
 

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/README.md
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/README.md
@@ -1,0 +1,59 @@
+# 103-migration-src-0-fee-vault-update
+
+Status: [READY TO SIGN]()
+
+## Objective
+
+Deploys new v1.6.0 fee-vault implementations on `migration-src-0` (chainId 420120140, Sepolia) and upgrades the four predeploy proxies — `SequencerFeeVault`, `BaseFeeVault`, `L1FeeVault`, `OperatorFeeVault` — to them, each initialized with its own recipient. This is Migration Log step **15** (post-cutover) of the Type A migration exercise.
+
+Each upgrade is performed via `OptimismPortal2.depositTransaction` calls batched through `Multicall3.aggregate3Value`, sending L1→L2 messages to:
+
+1. **CREATE2-deploy** the new impl bytecode on L2 (one for `SequencerFeeVault`, one shared between `BaseFeeVault` & `L1FeeVault`, one for `OperatorFeeVault`).
+2. **`ProxyAdmin.upgradeAndCall`** each proxy to the deployed impl, calling `initialize(recipient, 0, WithdrawalNetwork.L1)`.
+
+Total: **7 portal deposits** in one Safe transaction (3 deploys + 4 upgrades). All signed by the L1 ProxyAdminOwner Safe (`0xe934Dc97E347C6aCef74364B50125bb8689c40ff`).
+
+## State Changes
+
+State changes land on the **migration-src-0 L2** (chainId 420120140) once the portal deposits are relayed.
+
+| L2 Vault | L2 Predeploy | New recipient (this task) |
+|----------|--------------|---------------------------|
+| SequencerFeeVault | `0x4200000000000000000000000000000000000011` | `0xdead000000000000000000000000000000000011` |
+| BaseFeeVault | `0x4200000000000000000000000000000000000019` | `0xdead000000000000000000000000000000000019` |
+| L1FeeVault | `0x420000000000000000000000000000000000001a` | `0xdead00000000000000000000000000000000001a` |
+| OperatorFeeVault | `0x420000000000000000000000000000000000001b` | `0xdead00000000000000000000000000000000001b` |
+
+Each vault is also re-initialized with `MIN_WITHDRAWAL_AMOUNT() = 0` and `WITHDRAWAL_NETWORK() = 0` (L1), and its proxy impl slot is set to the newly CREATE2-deployed v1.6.0 implementation (deterministic addresses).
+
+> [!IMPORTANT]
+> The recipients above are **`0xdead…` test placeholders** for the migration exercise (low nibble matches the predeploy slot for a visually obvious state diff). Replace with the real OP-controlled recipients from the [Chain Migration Log](https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e) before any production signing.
+
+> [!IMPORTANT]
+> The new impls are deployed and initialized atomically in this single transaction (no pre-deployment required). The recipient is stored in v1.6.0 contract storage (settable post-init), so a single shared default-impl bytecode serves both `BaseFeeVault` and `L1FeeVault` despite different recipients.
+
+## Execution order
+
+This task is **Migration Log step 15**. Run **after** the chain-cutover sequence for this exercise:
+1. (out-of-ops) EOA → Safe B `SystemConfig.transferOwnership`
+2. `101-migration-src-0-set-batcher-unsafe-signer`
+3. `102-migration-src-0-proposer-rotation`
+4. **`103-migration-src-0-fee-vault-update`** ← this task
+
+## Simulation & Signing
+
+Simulation commands:
+```bash
+cd src/tasks/sep/103-migration-src-0-fee-vault-update
+SIMULATE_WITHOUT_LEDGER=1 just --dotenv-path $(pwd)/.env simulate
+```
+
+Signing commands:
+```bash
+cd src/tasks/sep/103-migration-src-0-fee-vault-update
+just --dotenv-path $(pwd)/.env sign
+```
+
+## Validation
+
+See [VALIDATION.md](./VALIDATION.md) for the expected domain/message hashes and the state changes.

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/VALIDATION.md
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/VALIDATION.md
@@ -12,6 +12,13 @@ The steps are:
 
 First, validate the domain and message hashes. These values should match both the values on your ledger and the values printed to the terminal when you run the task.
 
+> [!WARNING]
+> **This task is currently BLOCKED and must not be signed.** The `l2RpcUrls` pre-flight check reverts:
+> the L2 ProxyAdmin is owned by `0x1c784CC0…` (netchef deployer, aliased), not the aliased L1 PAO
+> `0xfA45dc97…5210`, so the `upgradeAndCall` deposits would revert on L2. The L2 ProxyAdmin ownership
+> must first be transferred to the aliased L1 PAO (out-of-ops; see [README.md](./README.md)). After that,
+> re-run `just simulate` and replace the hashes below.
+
 > [!CAUTION]
 >
 > Before signing, ensure the below hashes match what is on your ledger.
@@ -19,10 +26,10 @@ First, validate the domain and message hashes. These values should match both th
 > ### ProxyAdminOwner Safe (`0xe934Dc97E347C6aCef74364B50125bb8689c40ff`)
 >
 > - Domain Hash:  `0x07e03428d7125835eca12b6dd1a02903029b456da3a091ecd66fda859fbce61e`
-> - Message Hash: `0x5a442cc9643cbebe6262307d5b4636da5e06b4de42010e1a75880760bd3f9389`
-> - Safe Hash:    `0x0bd45f677139f6c89c4ee904c5f9c4c852d970affc7f81b3d7f7b0c5da70ec62`
+> - Message Hash: `0x5a442cc9643cbebe6262307d5b4636da5e06b4de42010e1a75880760bd3f9389` _(provisional — captured before enabling the pre-flight; regenerate after the L2 PAO transfer)_
+> - Safe Hash:    `0x0bd45f677139f6c89c4ee904c5f9c4c852d970affc7f81b3d7f7b0c5da70ec62` _(provisional)_
 >
-> _Hashes generated via `just simulate` at the latest block with the PAO nonce override in [config.toml](./config.toml) (= 112, i.e. live nonce 111 + 1 for task 102 executing first). If that ordering/override changes, or the recipients change, re-run `just simulate` and replace the Message/Safe hashes before signing._
+> _The Domain Hash is deterministic for the PAO Safe on Sepolia. The provisional Message/Safe hashes were generated via `just simulate` with the PAO nonce override in [config.toml](./config.toml) (= 112, i.e. live nonce 111 + 1 for task 102 executing first) BEFORE the `l2RpcUrls` pre-flight was enabled — enabling `l2RpcUrls` does not change the Safe calldata, only adds the L2 ownership check. They remain unverifiable end-to-end until the L2 ProxyAdmin transfer unblocks the simulation; regenerate then._
 
 ## Understanding Task Calldata
 

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/VALIDATION.md
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/VALIDATION.md
@@ -1,0 +1,61 @@
+# Validation
+
+This document can be used to validate the inputs and result of the execution of the transaction which you are signing.
+
+The steps are:
+
+1. [Validate the Domain and Message Hashes](#expected-domain-and-message-hashes)
+2. [Transaction Inputs](config.toml): inputs can be verified in the config.toml file.
+3. State Changes: reviewed in Tenderly via the link printed during simulation (L1 deposits) and on the L2 once relayed.
+
+## Expected Domain and Message Hashes
+
+First, validate the domain and message hashes. These values should match both the values on your ledger and the values printed to the terminal when you run the task.
+
+> [!CAUTION]
+>
+> Before signing, ensure the below hashes match what is on your ledger.
+>
+> ### ProxyAdminOwner Safe (`0xe934Dc97E347C6aCef74364B50125bb8689c40ff`)
+>
+> - Domain Hash:  `0x07e03428d7125835eca12b6dd1a02903029b456da3a091ecd66fda859fbce61e`
+> - Message Hash: `0x5a442cc9643cbebe6262307d5b4636da5e06b4de42010e1a75880760bd3f9389`
+> - Safe Hash:    `0x0bd45f677139f6c89c4ee904c5f9c4c852d970affc7f81b3d7f7b0c5da70ec62`
+>
+> _Hashes generated via `just simulate` at the latest block with the PAO nonce override in [config.toml](./config.toml) (= 112, i.e. live nonce 111 + 1 for task 102 executing first). If that ordering/override changes, or the recipients change, re-run `just simulate` and replace the Message/Safe hashes before signing._
+
+## Understanding Task Calldata
+
+The task assembles **7 `OptimismPortal2.depositTransaction` calls** through `Multicall3.aggregate3Value`, targeting the `migration-src-0` `OptimismPortalProxy` (`0x7b123dD7466dAB1fe60703Cd11fCE9c77d413a05`):
+
+1. 3 × CREATE2 deploy of the v1.6.0 fee-vault impl bytecode on L2 (SequencerFeeVault; a shared BaseFeeVault/L1FeeVault impl; OperatorFeeVault).
+2. 4 × `ProxyAdmin.upgradeAndCall(proxy, impl, initialize(recipient, 0, WithdrawalNetwork.L1))` — one per vault.
+
+The exact deposit calldata (deterministic CREATE2 addresses + per-vault `initialize` args) is assembled by the template and printed during simulation. Confirm the 4 upgrade calls target the 4 predeploys with the 4 recipients listed below, and that each `initialize` passes `minWithdrawalAmount = 0` and `withdrawalNetwork = 0` (L1).
+
+## Task State Changes
+
+### migration-src-0 L2 (chainId 420120140) — applied once portal deposits are relayed
+
+| L2 Predeploy | RECIPIENT() (new) | MIN_WITHDRAWAL_AMOUNT() | WITHDRAWAL_NETWORK() |
+|--------------|-------------------|-------------------------|----------------------|
+| `0x4200…0011` SequencerFeeVault | `0xdead000000000000000000000000000000000011` | `0` | `0` (L1) |
+| `0x4200…0019` BaseFeeVault | `0xdead000000000000000000000000000000000019` | `0` | `0` (L1) |
+| `0x4200…001a` L1FeeVault | `0xdead00000000000000000000000000000000001a` | `0` | `0` (L1) |
+| `0x4200…001b` OperatorFeeVault | `0xdead00000000000000000000000000000000001b` | `0` | `0` (L1) |
+
+Each proxy's implementation slot is set to the corresponding CREATE2-deployed v1.6.0 implementation.
+
+### `0xe934Dc97E347C6aCef74364B50125bb8689c40ff` (ProxyAdminOwner) — L1
+
+Nonce increments by 1. (Plus the L1 portal `depositTransaction` events for the 7 deposits.)
+
+## Post-execution verification
+
+```bash
+cast call 0x4200000000000000000000000000000000000011 "RECIPIENT()(address)" --rpc-url https://migration-src-0.optimism.io
+# Expected: 0xdEAD000000000000000000000000000000000011
+# ...repeat for 0x…0019, 0x…001a, 0x…001b
+```
+
+Record the executed tx hash in the [Chain Migration Log](https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e) under the FeeVault recipient update step.

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/addresses.json
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/addresses.json
@@ -1,0 +1,8 @@
+{
+  "420120140": {
+    "ProxyAdminOwner": "0xe934Dc97E347C6aCef74364B50125bb8689c40ff",
+    "SystemConfigProxy": "0xeb776E1d4cda95D4155e73c5ceE34b9f7C2EE818",
+    "L1StandardBridgeProxy": "0xF6e21D927C2F112F759B658af94B2c8E1fD3D9B9",
+    "OptimismPortalProxy": "0x7b123dD7466dAB1fe60703Cd11fCE9c77d413a05"
+  }
+}

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/config.toml
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/config.toml
@@ -1,0 +1,53 @@
+# Fee Vault Upgrade — migration-src-0 (chainId 420120140, Sepolia)
+#
+# Deploys new v1.6.0 fee-vault implementations on the migration-src-0 L2 and upgrades
+# the four predeploys to them in a single L1 Safe transaction, each initialized with its
+# own recipient. This is Migration Log step 15 (post-cutover) of the Type A migration
+# exercise.
+#
+# The v1.6.0 impls store the recipient in storage (settable post-init), so a single shared
+# impl can serve all vaults and per-vault recipients are passed via initialize(...).
+#
+# Migration Log: https://www.notion.so/oplabs/Chain-Migration-Log-367f153ee16280be835deeb764aca44e
+
+templateName = "FeeVaultUpgradeTemplate"
+fallbackAddressesJsonPath = "src/tasks/sep/103-migration-src-0-fee-vault-update/addresses.json"
+
+l2chains = [
+    {name = "migration-src-0", chainId = 420120140}
+]
+
+# Which fee-vault predeploys to upgrade (same addresses on every OP Stack chain).
+vaultProxies = [
+    "0x4200000000000000000000000000000000000011",  # SequencerFeeVault
+    "0x4200000000000000000000000000000000000019",  # BaseFeeVault
+    "0x420000000000000000000000000000000000001a",  # L1FeeVault
+    "0x420000000000000000000000000000000000001b",  # OperatorFeeVault (U18+)
+]
+
+# Recipients per (chain, vault), flat row-major (chain-major) layout.
+# Length must equal l2chains.length * vaultProxies.length = 1 * 4 = 4.
+# Order MUST match the vaultProxies order above.
+#
+# Test placeholders for the migration exercise: the low nibble matches the corresponding
+# predeploy address so the state diff is visually obvious (0xdead…0011 → SequencerFeeVault,
+# 0xdead…0019 → BaseFeeVault, etc.). Replace with the real OP-controlled recipients from the
+# Chain Migration Log before any production signing.
+recipients = [
+    "0xdead000000000000000000000000000000000011",  # SequencerFeeVault test placeholder
+    "0xdead000000000000000000000000000000000019",  # BaseFeeVault test placeholder
+    "0xdead00000000000000000000000000000000001a",  # L1FeeVault test placeholder
+    "0xdead00000000000000000000000000000000001b",  # OperatorFeeVault test placeholder
+]
+
+# Per-chain settings (one entry per l2chains entry).
+networks             = [0]   # 0 = WithdrawalNetwork.L1 — fees are withdrawn to L1
+minWithdrawalAmounts = [0]   # no minimum threshold
+
+# PAO Safe nonce override. Current on-chain value is 111. In this exercise stack, 101 is
+# signed by Safe B and 102 (proposer-rotation) is the first PAO-signed task, so when 103
+# runs after 102 the PAO nonce is 111 + 1 = 112. If executed before 102, set this to 111.
+[stateOverrides]
+0xe934Dc97E347C6aCef74364B50125bb8689c40ff = [
+    {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = 112}
+]

--- a/src/tasks/sep/103-migration-src-0-fee-vault-update/config.toml
+++ b/src/tasks/sep/103-migration-src-0-fee-vault-update/config.toml
@@ -44,6 +44,12 @@ recipients = [
 networks             = [0]   # 0 = WithdrawalNetwork.L1 — fees are withdrawn to L1
 minWithdrawalAmounts = [0]   # no minimum threshold
 
+# L2 RPC per chain — enables the pre-flight check that the L2 ProxyAdmin
+# (0x4200…0018) is owned by the aliased L1 rootSafe (aliased ProxyAdminOwner)
+# before signing. The upgradeAndCall portal deposits only succeed on L2 if the
+# depositing aliased L1 PAO is the L2 ProxyAdmin owner.
+l2RpcUrls = ["https://migration-src-0.optimism.io"]
+
 # PAO Safe nonce override. Current on-chain value is 111. In this exercise stack, 101 is
 # signed by Safe B and 102 (proposer-rotation) is the first PAO-signed task, so when 103
 # runs after 102 the PAO nonce is 111 + 1 = 112. If executed before 102, set this to 111.


### PR DESCRIPTION
## Summary

Replicates the **Type A chain-migration exercise** (cf. `migrations-sop-1`, tasks [080–085](https://github.com/ethereum-optimism/superchain-ops/tree/main/src/tasks/sep)) for **`migration-src-0`** (chainId `420120140`) on Sepolia, migrating it onto the **`migration-dest-0`** operator infrastructure (per [devnets-private `dev/migration-dest-0`](https://github.com/ethereum-optimism/devnets-private/tree/main/dev/migration-dest-0/migration-dest-0)).

> [!IMPORTANT]
> All three tasks are **`DRAFT, NOT READY TO SIGN`**. They are pending review, the out-of-ops ownership transfers, recipient finalization, and re-simulation.

Three tasks, in execution order:

| # | Task | Template | Signer | Status |
|---|------|----------|--------|--------|
| 101 | `set-batcher-unsafe-signer` | `SetBatcherAndOrSigner` | OPE Receiving Safe (`0xb3228B…2B8f`) | DRAFT, NOT READY TO SIGN |
| 102 | `proposer-rotation` | `SetDisputeGameImpl` | ProxyAdminOwner (`0xe934Dc97…40ff`) | DRAFT, NOT READY TO SIGN |
| 103 | `fee-vault-update` | `FeeVaultUpgradeTemplate` | ProxyAdminOwner (`0xe934Dc97…40ff`) | DRAFT, NOT READY TO SIGN |

### What each task does
- **101** — sets `batcherHash` → `0x04bf2305…91A2` and `unsafeBlockSigner` → `0x5D2680A0…ad02` on `migration-src-0`'s SystemConfig (the `migration-dest-0` receiving batcher / sequencer). Current on-chain FROM values: batcher `0x9829eb0d…5931`, signer `0x5887E87e…9853`. Simulates cleanly.
- **102** — rotates the **PermissionedDisputeGame (game type 1)** proposer → `0xD3E481Ac…442b` and challenger → `0x4DFb8C08…1594` (the `migration-dest-0` receiving infra), and sets the absolute **prestate → `0xdead…` placeholder**. Chain is kept **permissioned**; FDG (game type 0) untouched (not registered on this chain). Current on-chain FROM values: proposer `0x0fd61abe…c9fc`, challenger `0x5d5f9c4b…1546e`, prestate `0x038512e0…d54c`. Simulates cleanly.
- **103** — upgrades the 4 fee-vault predeploys to v1.6.0 via 7 portal deposits, with `0xdead…` **placeholder recipients** (replace with real OP-controlled recipients before production signing). Blocked on L2 ProxyAdmin ownership (below).

### Task 103 — L2 ProxyAdmin blocker (surfaced by the `l2RpcUrls` pre-flight)
migration-src-0's **L2 ProxyAdmin** (`0x4200…0018`) is owned by `0x1c784CC0…` (the netchef deployer admin — alias of L1 EOA `0x0b674cc0…`), **not** the aliased L1 PAO (`0xfA45dc97…5210`). The `upgradeAndCall` portal deposits would **revert on L2**. The pre-flight check (`l2RpcUrls`) now enforces this.

**Prerequisite (out-of-ops, like the SystemConfig owner transfer):** transfer L2 ProxyAdmin ownership to the aliased L1 PAO, driven by the current controller (not a PAO-signed ops task). Then re-run `just simulate` and regenerate 103's hashes. Tasks 101/102 are pure-L1 and unaffected.

### Scope decisions
- **Fault proofs out of scope** — no `add-game-type`, no `set-respected-game-type`, no prestate build. 102 keeps the chain **permissioned** (PDG only, no FDG) and sets the PDG prestate to the `0xdead…` placeholder (matches the repo's 079/086/091 dead-prestate convention).
- **SystemConfig ownership transfer out of scope here** — current owner is an EOA (`0x8f6C6dE7…`); the EOA → Safe B (`0xb3228B…2B8f`) transfer is performed **outside this repo**. Task 101 uses a `SystemConfig.owner → Safe B` simulation override.

### Validation (provisional — tasks remain DRAFT)
- **101**: simulates cleanly. Domain `0x3e8aab7b…`, Message `0xfbbcfe3e…`, Safe `0xfd32e22e…`. State diff verified (batcher + signer; Safe B nonce +1).
- **102**: simulates cleanly. Domain `0x07e03428…`, Message `0xfa328de0…`, Safe `0x903c07f6…`. State diff verified (PDG proposer/challenger + prestate → `0xdead`; PAO nonce +1).
- **103**: pre-flight reverts (blocker above). Provisional hashes captured before enabling the check are noted in its VALIDATION.md; regenerate after remediation.

> [!NOTE]
> Nonce overrides assume order 101 (Safe B) → 102 (PAO @ 111) → 103 (PAO @ 112), confirmed against on-chain nonces (Safe B = 1, PAO = 111). Re-run `just simulate` to regenerate hashes if on-chain nonces have moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)