### PR TITLE
docs: complete signing/execution commands in task READMEs + scaffold

### DIFF
--- a/src/tasks/eth/053-U19-op-ink-mmz-soneium/README.md
+++ b/src/tasks/eth/053-U19-op-ink-mmz-soneium/README.md
@@ -32,14 +32,45 @@ proceeding.
 
 ## Simulation & Signing
 
+This task is signed by the Mainnet ProxyAdminOwner, a nested 2-of-2 of the
+Security Council and the Foundation Upgrade Safe. Run the commands once for the
+safe you sign for, replacing `<council|foundation>` with `council` or
+`foundation`.
+
+`SKIP_DECODE_AND_PRINT=1` skips the slow human-readable state-diff printout
+without changing the domain/message hashes you verify or the Tenderly link. It
+is set on the sign command below; you can also prefix `simulate-stack` with it
+for a faster run (review state changes via the Tenderly link instead).
+
+### For Signers
+
 ```bash
+# Change directory to the task
+cd src/tasks/eth/053-U19-op-ink-mmz-soneium
+
 # Simulate
-just simulate-stack eth 053-U19-op-ink-mmz-soneium
+just simulate-stack eth 053-U19-op-ink-mmz-soneium <council|foundation>
 
 # Sign
-USE_KEYSTORE=1 just sign-stack eth 053-U19-op-ink-mmz-soneium
+SKIP_DECODE_AND_PRINT=1 just sign-stack eth 053-U19-op-ink-mmz-soneium <council|foundation>
 
-# Execute
+# Add USE_KEYSTORE=1 before the command if you are signing with a local keystore
+# instead of a connected Ledger, e.g.
+#   USE_KEYSTORE=1 SKIP_DECODE_AND_PRINT=1 just sign-stack eth 053-U19-op-ink-mmz-soneium <council|foundation>
+```
+
+### For Facilitators, after signatures have been collected
+
+```bash
+# Change directory to the task
 cd src/tasks/eth/053-U19-op-ink-mmz-soneium
-SIGNATURES=0x just execute
+
+# Approve once per safe, passing that safe's collected signatures
+SIGNATURES=0x... just approve <council|foundation>
+
+# Execute once both safes have approved
+just execute
+
+# Add USE_KEYSTORE=1 before the command if you are using a local keystore
+# instead of a connected Ledger.
 ```

--- a/src/tasks/eth/054-U19-unichain/README.md
+++ b/src/tasks/eth/054-U19-unichain/README.md
@@ -12,7 +12,46 @@ independent of the bundled OP-governed upgrade in `053-U19-op-ink-mmz-soneium`.
 
 ## Simulation & Signing
 
+This task is signed by Unichain's ProxyAdminOwner, a nested 3-of-3 of the
+Foundation Upgrade Safe, the Security Council, and the Unichain Chain Governor
+Safe. Run the commands once for the safe you sign for, replacing
+`<foundation|council|chain-governor>` with `foundation`, `council`, or
+`chain-governor`.
+
+`SKIP_DECODE_AND_PRINT=1` skips the slow human-readable state-diff printout
+without changing the domain/message hashes you verify or the Tenderly link. It
+is set on the sign command below; you can also prefix `simulate-stack` with it
+for a faster run (review state changes via the Tenderly link instead).
+
+### For Signers
+
 ```bash
-just simulate-stack eth 054-U19-unichain
-USE_KEYSTORE=1 just sign-stack eth 054-U19-unichain
+# Change directory to the task
+cd src/tasks/eth/054-U19-unichain
+
+# Simulate
+just simulate-stack eth 054-U19-unichain <foundation|council|chain-governor>
+
+# Sign
+SKIP_DECODE_AND_PRINT=1 just sign-stack eth 054-U19-unichain <foundation|council|chain-governor>
+
+# Add USE_KEYSTORE=1 before the command if you are signing with a local keystore
+# instead of a connected Ledger, e.g.
+#   USE_KEYSTORE=1 SKIP_DECODE_AND_PRINT=1 just sign-stack eth 054-U19-unichain <foundation|council|chain-governor>
+```
+
+### For Facilitators, after signatures have been collected
+
+```bash
+# Change directory to the task
+cd src/tasks/eth/054-U19-unichain
+
+# Approve once per safe, passing that safe's collected signatures
+SIGNATURES=0x... just approve <foundation|council|chain-governor>
+
+# Execute once all three safes have approved
+just execute
+
+# Add USE_KEYSTORE=1 before the command if you are using a local keystore
+# instead of a connected Ledger.
 ```

--- a/src/template/boilerplate/README.template.md
+++ b/src/template/boilerplate/README.template.md
@@ -8,14 +8,45 @@ Todo: Describe the objective of the task
 
 ## Simulation & Signing
 
-Simulation commands for each safe:
+Replace `<network>` (`eth` or `sep`) and `<council|foundation>` (the safe you
+are signing for; `council` or `foundation`, Unichain also has `chain-governor`)
+in the commands below. For a nested task, run each command once per safe. For a
+task signed by a single safe, drop the `<council|foundation>` selector entirely.
+
+`SKIP_DECODE_AND_PRINT=1` skips the slow human-readable state-diff printout
+without changing the domain/message hashes you verify or the Tenderly link. It
+is set on the sign command below; you can also prefix `simulate-stack` with it
+for a faster run (review state changes via the Tenderly link instead).
+
+### For Signers
+
 ```bash
+# Change directory to the task
 <navigate-to-simulation-command>
-<TODO-add-simulation-commands-for-each-safe>
+
+# Simulate
+just simulate-stack <network> <task-name> <council|foundation>
+
+# Sign
+SKIP_DECODE_AND_PRINT=1 just sign-stack <network> <task-name> <council|foundation>
+
+# Add USE_KEYSTORE=1 before the command if you are signing with a local keystore
+# instead of a connected Ledger, e.g.
+#   USE_KEYSTORE=1 SKIP_DECODE_AND_PRINT=1 just sign-stack <network> <task-name> <council|foundation>
 ```
 
-Signing commands for each safe:
+### For Facilitators, after signatures have been collected
+
 ```bash
+# Change directory to the task
 <navigate-to-signing-command>
-<TODO-add-signing-commands-for-each-safe>
+
+# Approve once per safe, passing that safe's collected signatures
+SIGNATURES=0x... just approve <council|foundation>
+
+# Execute once all required safes have approved
+just execute
+
+# Add USE_KEYSTORE=1 before the command if you are using a local keystore
+# instead of a connected Ledger.
 ```


### PR DESCRIPTION
## What

Task READMEs `053`/`054` (and the `README.template.md` scaffold) had incomplete signing/execution commands. Restored the full copy-paste flow used by the executed `040`/`041`/`042` tasks — **cd → simulate → sign → approve → execute**, split into *For Signers* / *For Facilitators*.

- Add the `<council|foundation>` safe selector (`053` = 2-of-2, `054` = 3-of-3 incl. `chain-governor`).
- `USE_KEYSTORE=1` is now an optional comment, not hard-coded.
- Add `SKIP_DECODE_AND_PRINT=1` to the sign command — pure speed-up; it only skips the decoded state-diff print, the verified hashes + Tenderly link are unchanged.

Scaffold updated so new tasks are copy-paste-ready out of the box. Executed/cancelled READMEs left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)