### PR TITLE
Require SIGNATURES for just execute

### DIFF
--- a/src/justfile
+++ b/src/justfile
@@ -400,6 +400,17 @@ execute:
   unset ETHERSCAN_API_KEY # Avoid Etherscan API rate limiting during simulation
   root_dir=$(git rev-parse --show-toplevel)
   root_just_file="${root_dir}/src/justfile"
+  if [ -z "${SIGNATURES+x}" ]; then
+    echo "Error: SIGNATURES is required for just execute."
+    echo "Run SIGNATURES=<hex signatures> just execute for signed execution."
+    echo "Run SIGNATURES=0x just execute only after onchain approvals already exist, e.g. nested-safe execution after just approve."
+    exit 1
+  fi
+  if [ -z "$SIGNATURES" ]; then
+    echo "Error: SIGNATURES is set but empty."
+    echo "Use SIGNATURES=0x only after onchain approvals already exist."
+    exit 1
+  fi
   config_path=${TASK_PATH}/config.toml
   script_name=$(yq '.templateName' $config_path)
 
@@ -411,7 +422,6 @@ execute:
   USE_KEYSTORE=${USE_KEYSTORE:-}
   network=$(just --justfile "$root_just_file" _get-network-from-task-path "$TASK_PATH")
   ETH_RPC_URL=$("$root_dir"/src/script/get-rpc-url.sh "$network")
-  SIGNATURES=${SIGNATURES:-"0x"}
   signer_info=$(just --justfile "$root_just_file" _get-signer-args "$HD_PATH" "$USE_KEYSTORE")
   sender=$(echo "$signer_info" | sed -n '1p')
   signer_args=$(echo "$signer_info" | sed -n '2p')


### PR DESCRIPTION
`just execute` now fails before reading task config when `SIGNATURES` is unset or empty.

This prevents accidental bare execution from silently falling back to `0x`, while preserving the explicit pre-approved path:

- `SIGNATURES=<hex signatures> just execute` for signed execution
- `SIGNATURES=0x just execute` only after onchain approvals already exist, e.g. nested-safe execution after `just approve`

Validation:
- `env -u SIGNATURES just --justfile /private/tmp/superchain-ops-signatures-guard/src/justfile execute` exits with the new required-`SIGNATURES` error
- `SIGNATURES= just --justfile /private/tmp/superchain-ops-signatures-guard/src/justfile execute` exits with the new empty-`SIGNATURES` error
- `just --summary --justfile src/justfile`
- `git diff --check HEAD~1 HEAD`

I did not run an end-to-end broadcast execute; this PR only changes the preflight handling before the existing execute flow starts.