### PR TITLE
Emit compressed op-txverify links and bump registry

### DIFF
--- a/src/libraries/MultisigTaskPrinter.sol
+++ b/src/libraries/MultisigTaskPrinter.sol
@@ -5,6 +5,7 @@ import {console} from "forge-std/console.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {StdStyle} from "forge-std/StdStyle.sol";
 import {Base64} from "solady/utils/Base64.sol";
+import {LibZip} from "solady/utils/LibZip.sol";
 import {Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
 import {Simulation} from "@base-contracts/script/universal/Simulation.sol";
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
@@ -317,10 +318,10 @@ library MultisigTaskPrinter {
             "\n}"
         );
 
-        string memory base64Json = Base64.encode(bytes(json));
+        string memory base64Json = Base64.encode(LibZip.flzCompress(bytes(json)), true, true);
         printTitle("OP-TXVERIFY LINK");
         console.log(
-            "To verify this transaction, run `op-txverify qr` on your machine, then open the following link on your mobile device: https://op-txverify.optimism.io/?tx=%s",
+            "To verify this transaction, run `op-txverify qr` on your machine, then open the following link on your mobile device: https://op-txverify.optimism.io/?txz=%s",
             base64Json
         );
     }


### PR DESCRIPTION
## Summary
- compress op-txverify JSON payloads with Solady `LibZip.flzCompress`
- emit URL-safe Base64 without padding and switch printed links from legacy `tx=` to compressed `txz=`
- bump `lib/superchain-registry` from `8bc6125b` to `3d29f56a` so `check_superchain_registry` matches upstream registry state

Companion decoder PR: https://github.com/ethereum-optimism/op-txverify/pull/54

## Testing
- `forge build`
- `just --justfile ci.just check-superchain-registry-latest` from `src/`
- `SKIP_DECODE_AND_PRINT=1 just simulate-stack eth 053-U19-op-ink-mmz-soneium council`
- verified the generated compressed URL with `env -u GOROOT go run ./cmd/op-txverify qr --url "$url"` from the companion op-txverify branch

For task 53, the generated op-txverify URL dropped from about 39.8k chars to about 3.2k chars while preserving the same Safe tx hash (`0x0A64B387CA4EFA20642657F72FAADAF48142DE609D11C674113AD88EBD4A626E`).

The registry bump also resolves the CI drift where upstream removed Ethernity Sepolia (`233`) and Creator Chain testnet (`66665`) from `addresses.json`.
