### PR TITLE
Remove SystemConfig batch inbox getter reads

### DIFF
--- a/src/libraries/AccountAccessParser.sol
+++ b/src/libraries/AccountAccessParser.sol
@@ -644,8 +644,8 @@ library AccountAccessParser {
                 kind: "address",
                 oldValue: toAddress(_oldValue),
                 newValue: toAddress(_newValue),
-                summary: "Batch inbox address",
-                detail: "Unstructured storage slot for the address of the BatchInbox proxy."
+                summary: "Legacy batch inbox address",
+                detail: "Unstructured storage slot for the legacy SystemConfig batch inbox address."
             });
         }
         if (_slot == START_BLOCK_SLOT) {

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -501,7 +501,7 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
 
     /// @notice Code-length exceptions for storage values written by the upgrade.
     /// @dev v7.1.17 reinitialises SystemConfig and rewrites the slots that hold
-    /// `owner`, `unsafeBlockSigner`, `batchInbox`, and the address derived from
+    /// `owner`, `unsafeBlockSigner`, the legacy batch inbox slot, and the address derived from
     /// `batcherHash`. On betanets these are typically EOAs, not contracts, so the
     /// post-execution `Likely address in storage has no code` check would reject the
     /// writes. We skip the check for these specific values per chain.
@@ -515,8 +515,12 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
             // Only include true EOAs (no code). Contract addresses (e.g. multisig owners)
             // must not be in the exceptions list — they are handled by the normal allowed
             // storage accesses check instead.
-            address[4] memory candidates =
-                [sc.owner(), sc.unsafeBlockSigner(), sc.batchInbox(), address(uint160(uint256(sc.batcherHash())))];
+            address[4] memory candidates = [
+                sc.owner(),
+                sc.unsafeBlockSigner(),
+                _deriveBatchInbox(chains[i].chainId),
+                address(uint160(uint256(sc.batcherHash())))
+            ];
             for (uint256 j = 0; j < 4; j++) {
                 if (candidates[j].code.length == 0) exceptions[cursor++] = candidates[j];
             }
@@ -527,13 +531,19 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         }
         return result;
     }
+
+    function _deriveBatchInbox(uint256 chainId) internal pure returns (address) {
+        bytes1 versionByte = 0x00;
+        bytes32 hashedChainId = keccak256(bytes.concat(bytes32(chainId)));
+        bytes19 first19Bytes = bytes19(hashedChainId);
+        return address(uint160(bytes20(bytes.concat(versionByte, first19Bytes))));
+    }
 }
 
 /// @notice Read-only SystemConfig accessors used to populate `_getCodeExceptions`.
 interface ISystemConfigEOAs {
     function owner() external view returns (address);
     function unsafeBlockSigner() external view returns (address);
-    function batchInbox() external view returns (address);
     function batcherHash() external view returns (bytes32);
 }
 

--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -146,8 +146,8 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         // The V800 upgrade reinitializes SystemConfig, re-writing all its storage.
         // Some stored addresses are legitimately EOAs that get re-written during reinitialization.
         // HACK: The current test uses a custom dev OPCM on Sepolia where the owner is also an
-        // EOA (in production it would be a Safe), and the OPCM changes the batchInbox to a new
-        // EOA during upgrade (in production batchInbox would not change).
+        // EOA (in production it would be a Safe), and the legacy batch inbox slot still needs
+        // to be treated as a code-length exception during reinitialization.
         // TODO: Remove this entire block once a production-like OPCM is deployed for testing.
         for (uint256 i = 0; i < chains.length; i++) {
             ISystemConfigV800 sysCfg =
@@ -155,7 +155,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
             address[4] memory candidates = [
                 sysCfg.owner(), // slot 0x33 — Safe in prod, EOA in dev
                 sysCfg.unsafeBlockSigner(), // hashed slot — always EOA
-                sysCfg.batchInbox(), // hashed slot — always EOA
+                _deriveBatchInbox(chains[i].chainId), // legacy batch inbox slot — always EOA
                 address(uint160(uint256(sysCfg.batcherHash()))) // slot 0x67 — always EOA (sequencer batcher)
             ];
             for (uint256 j = 0; j < candidates.length; j++) {
@@ -164,10 +164,6 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
                 }
             }
         }
-        // HACK: The dev OPCM writes a new batchInbox address during upgrade that differs from the
-        // current one. This won't happen with a production OPCM. Etch code at the known output.
-        // TODO: Remove once production OPCM is used.
-        vm.etch(address(0x0002b8639730E2F4dc88Dfd5Bbd0352E5518A758), hex"01");
 
         // OPCM from TOML; must be v7.1.17
         opcm = IOPContractsManagerV800(tomlContent.readAddress(".addresses.OPCM"));
@@ -245,6 +241,13 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
             gameType: gt,
             gameArgs: gameArgs
         });
+    }
+
+    function _deriveBatchInbox(uint256 chainId) internal pure returns (address) {
+        bytes1 versionByte = 0x00;
+        bytes32 hashedChainId = keccak256(bytes.concat(bytes32(chainId)));
+        bytes19 first19Bytes = bytes19(hashedChainId);
+        return address(uint160(bytes20(bytes.concat(versionByte, first19Bytes))));
     }
 
     /// @notice Builds DisputeGameConfig[] for a chain from registry addresses and config prestates.
@@ -470,6 +473,5 @@ interface ISystemConfig {
 interface ISystemConfigV800 {
     function owner() external view returns (address);
     function unsafeBlockSigner() external view returns (address);
-    function batchInbox() external view returns (address);
     function batcherHash() external view returns (bytes32);
 }

--- a/test/integration/SuperRootMigrate.t.sol
+++ b/test/integration/SuperRootMigrate.t.sol
@@ -260,7 +260,7 @@ contract SuperRootMigrateIntegrationTest is Test, OPCMMigrateV800 {
             address[4] memory candidates = [
                 sysCfg.owner(),
                 sysCfg.unsafeBlockSigner(),
-                sysCfg.batchInbox(),
+                _deriveBatchInbox(chains[i].chainId),
                 address(uint160(uint256(sysCfg.batcherHash())))
             ];
             for (uint256 j = 0; j < candidates.length; j++) {
@@ -269,7 +269,6 @@ contract SuperRootMigrateIntegrationTest is Test, OPCMMigrateV800 {
                 }
             }
         }
-        vm.etch(address(0x0002b8639730E2F4dc88Dfd5Bbd0352E5518A758), hex"01");
 
         uint256 numCalls = 1 + chains.length;
         IMulticall3.Call3[] memory calls = new IMulticall3.Call3[](numCalls);
@@ -414,5 +413,12 @@ contract SuperRootMigrateIntegrationTest is Test, OPCMMigrateV800 {
             data: abi.encode(migrateParams.startingRespectedGameType)
         });
         return extras;
+    }
+
+    function _deriveBatchInbox(uint256 chainId) internal pure returns (address) {
+        bytes1 versionByte = 0x00;
+        bytes32 hashedChainId = keccak256(bytes.concat(bytes32(chainId)));
+        bytes19 first19Bytes = bytes19(hashedChainId);
+        return address(uint160(bytes20(bytes.concat(versionByte, first19Bytes))));
     }
 }


### PR DESCRIPTION
Removes direct `SystemConfig.batchInbox()` reads from the OPCM upgrade templates and the V800 migration integration test.

These paths only need the value as a code-length exception for `SystemConfig` reinitialization, so they derive the standard batch inbox address from the L2 chain ID instead of calling the getter removed in ethereum-optimism/optimism#21638.

`AccountAccessParser` still decodes the raw storage slot, but now labels it as the legacy `SystemConfig` batch inbox slot. That keeps historical state-diff output readable without treating the slot as the source of truth.

Companion PRs:
- `optimism`: https://github.com/ethereum-optimism/optimism/pull/21638
- `op-analytics`: https://github.com/ethereum-optimism/op-analytics/pull/1798
