### PR TITLE
template: tolerate SystemConfig 4.0.0 batchInbox removal in OPCMUpgradeV800

### DIFF
--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -154,9 +154,12 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
                 ISystemConfigV800(superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId));
             // SystemConfig 4.0.0 (op-contracts/v8.0.0) removes the batchInbox() getter and clears
             // the legacy batch inbox slot during reinitialization, so read it with a staticcall
-            // that tolerates both pre- and post-removal SystemConfig versions.
+            // that tolerates both pre- and post-removal SystemConfig versions. A missing selector
+            // reverts with empty return data; any other failure (a revert with data) is unexpected
+            // and must surface loudly rather than being mistaken for the post-removal case.
             // See https://github.com/ethereum-optimism/optimism/issues/21614.
             (bool ok, bytes memory data) = address(sysCfg).staticcall(abi.encodeWithSignature("batchInbox()"));
+            require(ok || data.length == 0, "OPCMUpgradeV800: unexpected batchInbox() failure");
             address batchInbox = (ok && data.length == 32) ? abi.decode(data, (address)) : address(0);
             address[4] memory candidates = [
                 sysCfg.owner(), // slot 0x33 — Safe in prod, EOA in dev

--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -152,10 +152,16 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         for (uint256 i = 0; i < chains.length; i++) {
             ISystemConfigV800 sysCfg =
                 ISystemConfigV800(superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId));
+            // SystemConfig 4.0.0 (op-contracts/v8.0.0) removes the batchInbox() getter and clears
+            // the legacy batch inbox slot during reinitialization, so read it with a staticcall
+            // that tolerates both pre- and post-removal SystemConfig versions.
+            // See https://github.com/ethereum-optimism/optimism/issues/21614.
+            (bool ok, bytes memory data) = address(sysCfg).staticcall(abi.encodeWithSignature("batchInbox()"));
+            address batchInbox = (ok && data.length == 32) ? abi.decode(data, (address)) : address(0);
             address[4] memory candidates = [
                 sysCfg.owner(), // slot 0x33 — Safe in prod, EOA in dev
                 sysCfg.unsafeBlockSigner(), // hashed slot — always EOA
-                sysCfg.batchInbox(), // hashed slot — always EOA
+                batchInbox, // hashed slot — EOA before SystemConfig 4.0.0, zero after
                 address(uint160(uint256(sysCfg.batcherHash()))) // slot 0x67 — always EOA (sequencer batcher)
             ];
             for (uint256 j = 0; j < candidates.length; j++) {
@@ -470,6 +476,5 @@ interface ISystemConfig {
 interface ISystemConfigV800 {
     function owner() external view returns (address);
     function unsafeBlockSigner() external view returns (address);
-    function batchInbox() external view returns (address);
     function batcherHash() external view returns (bytes32);
 }

--- a/test/integration/SuperRootMigrate.t.sol
+++ b/test/integration/SuperRootMigrate.t.sol
@@ -257,10 +257,15 @@ contract SuperRootMigrateIntegrationTest is Test, OPCMMigrateV800 {
         for (uint256 i = 0; i < chains.length; i++) {
             ISystemConfigV800 sysCfg =
                 ISystemConfigV800(superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId));
+            // Mirrors the tolerant batchInbox() read in OPCMUpgradeV800: the getter is removed as
+            // of SystemConfig 4.0.0, so resolve it to address(0) when the selector is missing.
+            (bool ok, bytes memory data) = address(sysCfg).staticcall(abi.encodeWithSignature("batchInbox()"));
+            require(ok || data.length == 0, "SuperRootMigrate: unexpected batchInbox() failure");
+            address batchInbox = (ok && data.length == 32) ? abi.decode(data, (address)) : address(0);
             address[4] memory candidates = [
                 sysCfg.owner(),
                 sysCfg.unsafeBlockSigner(),
-                sysCfg.batchInbox(),
+                batchInbox,
                 address(uint160(uint256(sysCfg.batcherHash())))
             ];
             for (uint256 j = 0; j < candidates.length; j++) {


### PR DESCRIPTION
Prepares `OPCMUpgradeV800` for SystemConfig 4.0.0 (op-contracts v8.0.0), which removes the `batchInbox()` getter and clears the legacy batch inbox slot during reinitialization (https://github.com/ethereum-optimism/optimism/pull/21641).

Changes:

1. The template's dev-HACK block read `sysCfg.batchInbox()` to build the code-exception whitelist. That getter call now goes through a tolerant staticcall: against SystemConfig 3.14.x it behaves as before, against 4.0.0 the missing selector reverts with empty return data and resolves to `address(0)`, which is filtered out (the reinit writes zero to that slot, which needs no code exception). Any other failure — a revert with data — surfaces loudly via `require` instead of being mistaken for the post-removal case.
2. Removed `batchInbox()` from the `ISystemConfigV800` interface, and applied the same tolerant read to the `SuperRootMigrate` integration test, which called the removed member.

Worth noting for U20 validation: `AccountAccessParser` labels SystemConfig slots by their keccak values, so the two slot-clearing writes (`Batch inbox address` → `0x0`, start block → `0x0`) will show up correctly labeled in every chain's state diff. That is the expected diff, per https://github.com/ethereum-optimism/optimism/pull/21641.

`OPCMUpgradeV700` also reads `batchInbox()`, but only ever runs against pre-4.0.0 SystemConfigs, so it is untouched.

Related PRs: https://github.com/ethereum-optimism/optimism/pull/21641 (contracts), https://github.com/ethereum-optimism/specs/pull/922 (spec), the dev-docs edit rides along in the monorepo PR. Context: ethereum-optimism/optimism#21614.
