### PR TITLE
fix: preserve Safe owners in simulation overrides

### DIFF
--- a/src/tasks/StateOverrideManager.sol
+++ b/src/tasks/StateOverrideManager.sol
@@ -115,9 +115,9 @@ abstract contract StateOverrideManager is CommonBase {
         defaultOverride.contractAddress = rootSafe;
         defaultOverride = Simulation.addThresholdOverride(defaultOverride.contractAddress, defaultOverride);
 
-        // We need to override the owner on the root safe to ensure single safes can execute but only if the owner is not already an owner.
-        if (owner != address(0) && !IGnosisSafe(rootSafe).isOwner(owner)) {
-            defaultOverride = Simulation.addOwnerOverride(rootSafe, defaultOverride, owner);
+        // We need to override the owner on the root safe to ensure single safes can execute.
+        if (owner != address(0)) {
+            defaultOverride = _addOwnerOverride(rootSafe, defaultOverride, owner);
         }
     }
 
@@ -129,7 +129,35 @@ abstract contract StateOverrideManager is CommonBase {
     {
         defaultOverride.contractAddress = childSafe;
         defaultOverride = Simulation.addThresholdOverride(defaultOverride.contractAddress, defaultOverride);
-        defaultOverride = Simulation.addOwnerOverride(childSafe, defaultOverride, MULTICALL3_ADDRESS);
+        defaultOverride = _addOwnerOverride(childSafe, defaultOverride, MULTICALL3_ADDRESS);
+    }
+
+    function _addOwnerOverride(address safe, Simulation.StateOverride memory state, address owner)
+        private
+        view
+        returns (Simulation.StateOverride memory)
+    {
+        address[] memory owners = IGnosisSafe(safe).getOwners();
+        for (uint256 i; i < owners.length; i++) {
+            if (owners[i] == owner) return state;
+        }
+
+        state = Simulation.addOverride(
+            state, Simulation.StorageOverride({key: bytes32(uint256(0x3)), value: bytes32(owners.length + 1)})
+        );
+
+        // Append the simulation owner so existing prevOwner links remain valid for owner rotations.
+        state = Simulation.addOverride(
+            state,
+            Simulation.StorageOverride({
+                key: keccak256(abi.encode(owners[owners.length - 1], uint256(2))),
+                value: bytes32(uint256(uint160(owner)))
+            })
+        );
+        return Simulation.addOverride(
+            state,
+            Simulation.StorageOverride({key: keccak256(abi.encode(owner, uint256(2))), value: bytes32(uint256(0x1))})
+        );
     }
 
     /// @notice Read state overrides from a TOML config file.

--- a/test/tasks/StateOverrideManager.t.sol
+++ b/test/tasks/StateOverrideManager.t.sol
@@ -459,6 +459,30 @@ contract StateOverrideManagerUnitTest is Test {
         assertEq(allOverrides[0].overrides.length, 3, "Expected 3 storage overrides");
     }
 
+    function test_getStateOverrides_appendsSimulationOwnerWithoutReplacingOwnerList() public {
+        MockStateOverrideManager som = new MockStateOverrideManager();
+        address[] memory owners = IGnosisSafe(FOUNDATION_UPGRADE_SAFE).getOwners();
+
+        Simulation.StateOverride[] memory allOverrides =
+            som.wrapperGetStateOverrides(FOUNDATION_UPGRADE_SAFE, new address[](0));
+        Simulation.StorageOverride[] memory overrides = allOverrides[0].overrides;
+
+        assertEq(overrides[1].key, bytes32(uint256(0x3)), "Expected owner count override");
+        assertEq(overrides[1].value, bytes32(owners.length + 1), "Expected incremented owner count");
+        assertEq(
+            overrides[2].key,
+            keccak256(abi.encode(owners[owners.length - 1], uint256(2))),
+            "Expected last owner mapping override"
+        );
+        assertEq(overrides[2].value, bytes32(uint256(uint160(address(this)))), "Expected appended simulation owner");
+        assertEq(
+            overrides[3].key,
+            keccak256(abi.encode(address(this), uint256(2))),
+            "Expected simulation owner mapping override"
+        );
+        assertEq(overrides[3].value, bytes32(uint256(0x1)), "Expected simulation owner to point to sentinel");
+    }
+
     function test_getStateOverrides_oneLevelNesting() public {
         vm.createSelectFork("mainnet");
         MockStateOverrideManager som = new MockStateOverrideManager();
@@ -473,20 +497,7 @@ contract StateOverrideManagerUnitTest is Test {
         assertEq(allOverrides[1].contractAddress, childSafes[0], "Child safe address mismatch");
         assertEq(allOverrides[1].overrides.length, 4, "Expected 4 storage overrides");
         assertEq(allOverrides[1].overrides[0].key, bytes32(uint256(0x4)), "Expected threshold override");
-        assertEq(allOverrides[1].overrides[1].key, bytes32(uint256(0x3)), "Expected owner count override");
-        bytes32 ownerMappingSlot = keccak256(abi.encode(uint256(1), uint256(2)));
-        assertEq(allOverrides[1].overrides[2].key, ownerMappingSlot, "Expected owner mapping override");
-        assertEq(
-            allOverrides[1].overrides[2].value,
-            bytes32(uint256(uint160(MULTICALL3_ADDRESS))),
-            "Expected owner mapping override value"
-        );
-        assertEq(
-            allOverrides[1].overrides[3].key,
-            keccak256(abi.encode(MULTICALL3_ADDRESS, uint256(2))),
-            "Expected owner mapping override"
-        );
-        assertEq(allOverrides[1].overrides[3].value, bytes32(uint256(0x1)), "Expected owner mapping override value");
+        assertOwnerOverrides(allOverrides[1], childSafes[0], MULTICALL3_ADDRESS);
     }
 
     function test_getStateOverrides_twoLevelNesting() public {
@@ -504,38 +515,12 @@ contract StateOverrideManagerUnitTest is Test {
         assertEq(allOverrides[1].contractAddress, childSafes[0], "Child safe address mismatch");
         assertEq(allOverrides[1].overrides.length, 4, "Expected 4 storage overrides");
         assertEq(allOverrides[1].overrides[0].key, bytes32(uint256(0x4)), "Expected threshold override");
-        assertEq(allOverrides[1].overrides[1].key, bytes32(uint256(0x3)), "Expected owner count override");
-        bytes32 ownerMappingSlot = keccak256(abi.encode(uint256(1), uint256(2)));
-        assertEq(allOverrides[1].overrides[2].key, ownerMappingSlot, "Expected owner mapping override");
-        assertEq(
-            allOverrides[1].overrides[2].value,
-            bytes32(uint256(uint160(MULTICALL3_ADDRESS))),
-            "Expected owner mapping override value"
-        );
-        assertEq(
-            allOverrides[1].overrides[3].key,
-            keccak256(abi.encode(MULTICALL3_ADDRESS, uint256(2))),
-            "Expected owner mapping override"
-        );
-        assertEq(allOverrides[1].overrides[3].value, bytes32(uint256(0x1)), "Expected owner mapping override value");
+        assertOwnerOverrides(allOverrides[1], childSafes[0], MULTICALL3_ADDRESS);
 
         assertEq(allOverrides[2].contractAddress, childSafes[1], "Child safe address mismatch");
         assertEq(allOverrides[2].overrides.length, 4, "Expected 4 storage overrides");
         assertEq(allOverrides[2].overrides[0].key, bytes32(uint256(0x4)), "Expected threshold override");
-        assertEq(allOverrides[2].overrides[1].key, bytes32(uint256(0x3)), "Expected owner count override");
-        bytes32 ownerMappingSlot2 = keccak256(abi.encode(uint256(1), uint256(2)));
-        assertEq(allOverrides[2].overrides[2].key, ownerMappingSlot2, "Expected owner mapping override");
-        assertEq(
-            allOverrides[2].overrides[2].value,
-            bytes32(uint256(uint160(MULTICALL3_ADDRESS))),
-            "Expected owner mapping override value"
-        );
-        assertEq(
-            allOverrides[2].overrides[3].key,
-            keccak256(abi.encode(MULTICALL3_ADDRESS, uint256(2))),
-            "Expected owner mapping override"
-        );
-        assertEq(allOverrides[2].overrides[3].value, bytes32(uint256(0x1)), "Expected owner mapping override value");
+        assertOwnerOverrides(allOverrides[2], childSafes[1], MULTICALL3_ADDRESS);
     }
 
     /// @notice Helper function to convert strings to bytes32
@@ -599,7 +584,7 @@ contract StateOverrideManagerUnitTest is Test {
         } else {
             assertTrue(parentLen == 4, string.concat("Parent overrides == 4, found: ", LibString.toString(parentLen)));
             // In single execution, the parent owner override should be address(this).
-            assertOwnerOverrides(parent, address(this));
+            assertOwnerOverrides(parent, rootSafe, address(this));
         }
 
         assertEq(parent.overrides[0].key, bytes32(uint256(0x4)), "Parent: threshold key");
@@ -616,7 +601,7 @@ contract StateOverrideManagerUnitTest is Test {
     /// Specifically, it verifies that the child state overrides contain a threshold, nonce, owner count, and owner mapping overrides.
     function assertDefaultChildStateOverrides(Simulation.StateOverride[] memory allOverrides, address childMultisig)
         internal
-        pure
+        view
     {
         assertTrue(
             allOverrides.length >= 2,
@@ -658,13 +643,15 @@ contract StateOverrideManagerUnitTest is Test {
             "ChildDefaultOverride: Threshold override must be 1"
         );
         // MULTICALL3_ADDRESS should be the owner override for the child multisig in a nested execution.
-        assertOwnerOverrides(childDefaultOverride, MULTICALL3_ADDRESS);
+        assertOwnerOverrides(childDefaultOverride, childMultisig, MULTICALL3_ADDRESS);
     }
 
-    function assertOwnerOverrides(Simulation.StateOverride memory defaultOverride, address expectedOwnerOverride)
-        private
-        pure
-    {
+    function assertOwnerOverrides(
+        Simulation.StateOverride memory defaultOverride,
+        address safe,
+        address expectedOwnerOverride
+    ) private view {
+        address[] memory owners = IGnosisSafe(safe).getOwners();
         assertEq(
             defaultOverride.overrides[1].key,
             bytes32(uint256(0x3)),
@@ -672,14 +659,11 @@ contract StateOverrideManagerUnitTest is Test {
         );
         assertEq(
             defaultOverride.overrides[1].value,
-            bytes32(uint256(0x1)),
-            "ChildDefaultOverride: Owner count override must be 1"
+            bytes32(owners.length + 1),
+            "ChildDefaultOverride: Owner count override must increment"
         );
 
-        // Verify owner mapping overrides
-        // Calculate the storage slot for owner mapping: keccak256(abi.encode(1, 2))
-        // where 1 is the owner index and 2 is the mapping slot in the contract
-        bytes32 ownerMappingSlot = keccak256(abi.encode(uint256(1), uint256(2)));
+        bytes32 ownerMappingSlot = keccak256(abi.encode(owners[owners.length - 1], uint256(2)));
         assertEq(
             defaultOverride.overrides[2].key,
             ownerMappingSlot,


### PR DESCRIPTION
## Summary

Preserve the Safe's real owner links when adding the synthetic simulation owner. The override now appends that owner and increments `ownerCount` instead of replacing the real owner list, which fixes Tenderly simulations that rotate the first owner.

This only changes simulation authentication state. The simulated list has one extra owner, but remains internally consistent; task calldata, Safe transaction hashes, signatures, and onchain state are unchanged. Tasks that depend on the exact owner count or enumerate owners still require a different simulation strategy.

## Validation

- `forge test --match-contract StateOverrideManagerUnitTest --match-test test_getStateOverrides_appendsSimulationOwnerWithoutReplacingOwnerList -vv`
