### PR TITLE
fix: simulate Safe tasks from an existing owner

### DIFF
--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -971,6 +971,15 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         address targetAddress;
         bytes memory finalExec;
         address rootSafe = payload.safes[payload.safes.length - 1];
+
+        uint256 postExecuteSnapshot = vm.snapshotState();
+        // Roll back state changes so the Tenderly payload uses the pre-execution owner list.
+        require(
+            vm.revertToState(_preExecutionSnapshot),
+            "MultisigTask: failed to revert back to _preExecutionSnapshot before printing Tenderly simulation data."
+        );
+
+        address simulationSender = IGnosisSafe(rootSafe).getOwners()[0];
         Simulation.StateOverride[] memory overrides;
         if (payload.safes.length > 1) {
             // Transaction involves multiple safes.
@@ -984,20 +993,12 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
             finalExec = GnosisSafeHashes.encodeExecTransactionCalldata(
                 targetAddress,
                 payload.calldatas[payload.calldatas.length - 1],
-                Signatures.genPrevalidatedSignature(msg.sender),
+                Signatures.genPrevalidatedSignature(simulationSender),
                 _getMulticallAddress(rootSafe, payload.safes)
             );
             overrides = getStateOverrides(rootSafe, new address[](0));
         }
-
-        uint256 postExecuteSnapshot = vm.snapshotState();
-        // Roll back state changes. The Tenderly link generation checks owners for overrides and expects pre-execution state.
-        // We should ensure the original owners are present (e.g. if an owner was removed as part of the task).
-        require(
-            vm.revertToState(_preExecutionSnapshot),
-            "MultisigTask: failed to revert back to _preExecutionSnapshot before printing Tenderly simulation data."
-        );
-        MultisigTaskPrinter.printTenderlySimulationData(targetAddress, finalExec, msg.sender, overrides);
+        MultisigTaskPrinter.printTenderlySimulationData(targetAddress, finalExec, simulationSender, overrides);
 
         // Apply the post execution state changes. Many tests rely on the assumption that the transaction was executed.
         require(

--- a/src/tasks/StateOverrideManager.sol
+++ b/src/tasks/StateOverrideManager.sol
@@ -27,8 +27,9 @@ abstract contract StateOverrideManager is CommonBase {
         uint256 childCount = childSafes.length;
         Simulation.StateOverride[] memory defaultOverrides = new Simulation.StateOverride[](1 + childCount);
 
-        // Root safe override: set threshold to 1. Add owner only for single-safe.
-        defaultOverrides[0] = _rootSafeTenderlyOverride(rootSafe, childCount > 0 ? address(0) : msg.sender);
+        // Root safe override: set threshold to 1. Use an existing owner for single-safe.
+        defaultOverrides[0] =
+            _rootSafeTenderlyOverride(rootSafe, childCount > 0 ? address(0) : IGnosisSafe(rootSafe).getOwners()[0]);
 
         // For each child: threshold=1 and add MULTICALL3_ADDRESS as owner
         for (uint256 i = 0; i < childCount; i++) {

--- a/test/tasks/StateOverrideManager.t.sol
+++ b/test/tasks/StateOverrideManager.t.sol
@@ -450,13 +450,13 @@ contract StateOverrideManagerUnitTest is Test {
         Simulation.StateOverride[] memory allOverrides = som.wrapperGetStateOverrides(rootSafe, new address[](0));
         assertTrue(allOverrides.length == 1, "Expected 1 state override");
         assertEq(allOverrides[0].contractAddress, rootSafe, "Root safe address mismatch");
-        assertEq(allOverrides[0].overrides.length, 4, "Expected 4 storage overrides");
+        assertEq(allOverrides[0].overrides.length, 1, "Expected 1 storage override");
 
         address rootSafeWithThresholdAlreadyOne = address(0xbefe941b3C4a6AaEe1eb050358064F0bA326975a); // Single Safe
         allOverrides = som.wrapperGetStateOverrides(rootSafeWithThresholdAlreadyOne, new address[](0));
         assertTrue(allOverrides.length == 1, "Expected 1 state override");
         assertEq(allOverrides[0].contractAddress, rootSafeWithThresholdAlreadyOne, "Root safe address mismatch");
-        assertEq(allOverrides[0].overrides.length, 3, "Expected 3 storage overrides");
+        assertEq(allOverrides[0].overrides.length, 0, "Expected 0 storage overrides");
     }
 
     function test_getStateOverrides_oneLevelNesting() public {
@@ -597,9 +597,7 @@ contract StateOverrideManagerUnitTest is Test {
         if (isNested) {
             assertTrue(parentLen >= 1, string.concat("Parent overrides >= 1, found: ", LibString.toString(parentLen)));
         } else {
-            assertTrue(parentLen == 4, string.concat("Parent overrides == 4, found: ", LibString.toString(parentLen)));
-            // In single execution, the parent owner override should be address(this).
-            assertOwnerOverrides(parent, address(this));
+            assertTrue(parentLen == 1, string.concat("Parent overrides == 1, found: ", LibString.toString(parentLen)));
         }
 
         assertEq(parent.overrides[0].key, bytes32(uint256(0x4)), "Parent: threshold key");


### PR DESCRIPTION
## Summary

Use an existing pre-execution Safe owner as the Tenderly simulation sender. This leaves the root Safe owner list and `ownerCount` unchanged, fixing first-owner rotations such as task 057.

Stacked simulations previously used an internal contract caller and made it a synthetic owner. Child Safe simulation overrides are unchanged.

## Validation

- `mise exec -- forge fmt --check`
- `mise exec -- forge build`
