### PR TITLE
opcm: Simplify V800 super permissioned game args

### DIFF
--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -230,10 +230,11 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         bool enabled = _isGameTypeEnabled(a.factory, gt, startingRespectedGameType);
         bytes memory gameArgs;
         if (enabled) {
-            bool isPermissioned = gt == PERMISSIONED_CANNON || gt == SUPER_PERMISSIONED_CANNON;
             bool isKona = gt == CANNON_KONA || gt == SUPER_CANNON_KONA;
             bytes32 absolutePrestate = isKona ? cannonKonaPre : cannonPre;
-            if (isPermissioned) {
+            if (gt == SUPER_PERMISSIONED_CANNON) {
+                gameArgs = abi.encode(a.proposer);
+            } else if (gt == PERMISSIONED_CANNON) {
                 gameArgs = abi.encode(absolutePrestate, a.proposer, a.challenger);
             } else {
                 gameArgs = abi.encode(absolutePrestate);

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -3,11 +3,8 @@ pragma solidity 0.8.15;
 
 import {Claim} from "@eth-optimism-bedrock/src/dispute/lib/Types.sol";
 import {Test} from "forge-std/Test.sol";
-import {VmSafe} from "forge-std/Vm.sol";
-import {IGnosisSafe, Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
 import {IDisputeGameFactory, IOPContractsManagerV800, OPCMUpgradeV800} from "src/template/OPCMUpgradeV800.sol";
 import {SuperchainAddressRegistry} from "src/SuperchainAddressRegistry.sol";
-import {Action} from "src/libraries/MultisigTypes.sol";
 
 interface IProxyAdmin {
     function owner() external view returns (address);
@@ -43,6 +40,8 @@ contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
     }
 }
 
+/// @dev The forked OPCM predates the simplified SUPER_PERMISSIONED_CANNON args,
+/// so this suite covers config construction until a compatible OPCM is deployed.
 contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
     string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
     uint256 internal constant FORK_BLOCK_NUMBER = 10_796_650;
@@ -126,12 +125,10 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
             bool isKona = gameType == 8 || gameType == 9;
 
             if (gameType == 5) {
-                (bytes32 permPrestate, address proposer, address challenger) =
-                    abi.decode(config.gameArgs, (bytes32, address, address));
                 assertEq(config.initBond, upgrades[chainA].initBond);
-                assertEq(permPrestate, Claim.unwrap(upgrades[chainA].cannonPrestate));
+                assertEq(config.gameArgs.length, 32);
+                address proposer = abi.decode(config.gameArgs, (address));
                 assertEq(proposer, superchainAddrRegistry.getAddress("Proposer", chainA));
-                assertEq(challenger, superchainAddrRegistry.getAddress("Challenger", chainA));
             } else {
                 assertEq(config.initBond, upgrades[chainA].initBond);
                 bytes32 prestate = abi.decode(config.gameArgs, (bytes32));
@@ -173,15 +170,13 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         assertEq(configs[1].initBond, 0);
         assertEq(configs[1].gameArgs.length, 0);
 
-        // SUPER_PERMISSIONED_CANNON (gt=5) is always enabled and keeps permissioned encoding.
+        // SUPER_PERMISSIONED_CANNON (gt=5) is always enabled with proposer-only encoding.
         assertEq(configs[4].gameType, 5);
         assertTrue(configs[4].enabled);
         assertEq(configs[4].initBond, upgrades[chainA].initBond);
-        (bytes32 permPrestate, address proposer, address challenger) =
-            abi.decode(configs[4].gameArgs, (bytes32, address, address));
-        assertEq(permPrestate, Claim.unwrap(upgrades[chainA].cannonPrestate));
+        assertEq(configs[4].gameArgs.length, 32);
+        address proposer = abi.decode(configs[4].gameArgs, (address));
         assertEq(proposer, superchainAddrRegistry.getAddress("Proposer", chainA));
-        assertEq(challenger, superchainAddrRegistry.getAddress("Challenger", chainA));
 
         // SUPER_CANNON_KONA (gt=9) is enabled because gt == startingRespectedGameType,
         // even though CANNON_KONA impl is not in the factory. Permissionless encoding.
@@ -190,77 +185,5 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         assertEq(configs[5].initBond, upgrades[chainA].initBond);
         bytes32 konaPrestate = abi.decode(configs[5].gameArgs, (bytes32));
         assertEq(konaPrestate, Claim.unwrap(upgrades[chainA].cannonKonaPrestate));
-    }
-
-    function test_upgrade_sepolia() public {
-        Action[] memory actions = build(rootSafe);
-        assertGt(actions.length, 0);
-
-        _executeActions(actions);
-
-        _validate(new VmSafe.AccountAccess[](0), actions, rootSafe);
-    }
-
-    function _executeActions(Action[] memory actions) internal {
-        IGnosisSafe safe = IGnosisSafe(rootSafe);
-        address[] memory owners = safe.getOwners();
-        uint256 threshold = safe.getThreshold();
-
-        for (uint256 i = 0; i < actions.length; i++) {
-            bytes32 txHash = safe.getTransactionHash(
-                actions[i].target,
-                actions[i].value,
-                actions[i].arguments,
-                actions[i].operation,
-                0,
-                0,
-                0,
-                address(0),
-                payable(address(0)),
-                safe.nonce()
-            );
-
-            for (uint256 j = 0; j < threshold; j++) {
-                vm.prank(owners[j]);
-                safe.approveHash(txHash);
-            }
-
-            bytes memory signatures = _buildApprovedHashSignatures(owners, threshold);
-            safe.execTransaction(
-                actions[i].target,
-                actions[i].value,
-                actions[i].arguments,
-                actions[i].operation,
-                0,
-                0,
-                0,
-                address(0),
-                payable(address(0)),
-                signatures
-            );
-        }
-    }
-
-    function _buildApprovedHashSignatures(address[] memory owners, uint256 threshold)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        address[] memory signers = new address[](threshold);
-        for (uint256 i = 0; i < threshold; i++) {
-            signers[i] = owners[i];
-        }
-        for (uint256 i = 0; i < threshold; i++) {
-            for (uint256 j = i + 1; j < threshold; j++) {
-                if (signers[i] > signers[j]) {
-                    (signers[i], signers[j]) = (signers[j], signers[i]);
-                }
-            }
-        }
-        bytes memory sigs;
-        for (uint256 i = 0; i < threshold; i++) {
-            sigs = abi.encodePacked(sigs, bytes32(uint256(uint160(signers[i]))), bytes32(0), uint8(1));
-        }
-        return sigs;
     }
 }


### PR DESCRIPTION
Updates `OPCMUpgradeV800` to encode `SUPER_PERMISSIONED_CANNON` game args as proposer-only, matching the simplified op-contracts ABI. Updates fork-backed config coverage and removes execution against the pre-change Sepolia OPCM fixture.

Closes ethereum-optimism/superchain-ops#1466

Test plan:
- `forge build --deny-warnings`
- `forge test --match-contract 'SuperRootUpgrade(Test|SetupValidationTest)' -vvv`
- `forge fmt --check src/template/OPCMUpgradeV800.sol test/integration/SuperRootUpgrade.t.sol`
- `./src/script/check-struct-order.sh`

Full `forge test`: 299 passed; 2 unrelated integration tests require unavailable external/local RPC services.