### PR TITLE
docs: mark eth tasks 056-059 as EXECUTED

### DIFF
--- a/.claude/skills/mark-task-executed/SKILL.md
+++ b/.claude/skills/mark-task-executed/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: mark-task-executed
+description: Mark one or more superchain-ops tasks as EXECUTED by updating each task README's Status line to link the on-chain execution transaction, then open a PR. Use when a task (or batch of tasks) has been executed on-chain and someone shares the execution tx hash(es).
+---
+
+# Mark a superchain-ops task as EXECUTED
+
+When a governance task has been executed on-chain, its `README.md` status line
+must be updated from the pre-execution state to `EXECUTED` with a link to the
+execution transaction. This is a docs-only change — no Solidity, config, or
+validation files change.
+
+## The convention
+
+Every task `README.md` begins with a title and a status line:
+
+```markdown
+# 056-fus-rotation-1
+
+Status: [READY TO SIGN]()
+```
+
+Marking it executed means replacing **only** the status line's label and link:
+
+```markdown
+Status: [EXECUTED](https://etherscan.io/tx/0x<hash>)
+```
+
+- The status label may currently be `[READY TO SIGN]()`, `[READY TO EXECUTE]()`,
+  `[SIGNED]()`, etc. — replace whatever is there with `[EXECUTED](<tx-url>)`.
+- **Network → explorer base URL:**
+  - `src/tasks/eth/...` (Ethereum mainnet) → `https://etherscan.io/tx/<hash>`
+  - `src/tasks/sep/...` (Sepolia) → `https://sepolia.etherscan.io/tx/<hash>`
+  - For other networks, use that network's canonical block explorer tx URL.
+- Do not touch any other line in the README, and do not edit `config.toml` or
+  `VALIDATION.md`.
+
+## Steps
+
+1. **Map each task to its execution tx hash.** The requester usually provides
+   them (e.g. "056 → 0xabc…"). Match by the leading task number. If a mapping is
+   ambiguous, ask rather than guess — a wrong tx link on a governance task is a
+   correctness bug.
+2. **Find each task directory:** `src/tasks/<network>/<###>-<name>/README.md`.
+   (`ls src/tasks/eth | grep '^056'`.)
+3. **Edit the status line** per the convention above for each task.
+4. **Verify** each edited line: `grep -rn '^Status:' src/tasks/**/README.md`.
+   Confirm the label is `EXECUTED`, the hash matches what was provided, and the
+   explorer base URL matches the network.
+5. **Open a PR** (docs-only, no CI simulation needed). Use a title like
+   `docs: mark <network> tasks <###>-<###> as EXECUTED`. List each task and its
+   tx link in the body so reviewers can spot-check hashes against the explorer.
+
+## Notes
+
+- This is a fast, cheap, low-risk change: string edits to markdown status lines.
+  Batch multiple tasks into one PR.
+- Recent examples for the exact diff shape: PRs #1494, #1457, and the
+  "executed" PRs in the merge history.
+- Reviewers should confirm each tx hash on the linked explorer actually
+  corresponds to the task's execution (correct Safe, correct calldata) before
+  merging.

--- a/src/tasks/eth/056-fus-rotation-1/README.md
+++ b/src/tasks/eth/056-fus-rotation-1/README.md
@@ -1,6 +1,6 @@
 # 056-fus-rotation-1
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://etherscan.io/tx/0xbb0cece7d5f45ce07894be038b83af893b894a3337a5dda22b79b46097c4ce96)
 
 ## Objective
 

--- a/src/tasks/eth/057-fus-rotation-2/README.md
+++ b/src/tasks/eth/057-fus-rotation-2/README.md
@@ -1,6 +1,6 @@
 # 057-fus-rotation-2
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://etherscan.io/tx/0x087cbb21ebc9739c7afed878236a9cba9b1e129adc6a976fefe5571b88452ce8)
 
 ## Objective
 

--- a/src/tasks/eth/058-fos-rotation-1/README.md
+++ b/src/tasks/eth/058-fos-rotation-1/README.md
@@ -1,6 +1,6 @@
 # 058-fos-rotation-1
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://etherscan.io/tx/0xd3a6afeef57d1e1b7fde86a4b0dd5de6fb6747cec75d6d9edecf54e7eacb19ea)
 
 ## Objective
 

--- a/src/tasks/eth/059-fos-rotation-2/README.md
+++ b/src/tasks/eth/059-fos-rotation-2/README.md
@@ -1,6 +1,6 @@
 # 059-fos-rotation-2
 
-Status: [READY TO SIGN]()
+Status: [EXECUTED](https://etherscan.io/tx/0x86366bc8466b0b45ece66d277ec47f988cfad38a3147c6d71b623e104d9d2ab5)
 
 ## Objective
 


### PR DESCRIPTION
## What

Marks four executed OP Mainnet governance tasks as `EXECUTED` in their task READMEs, linking each to its on-chain execution transaction. Docs-only change (no Solidity/config/validation edits).

The signer rotations on the Foundation Upgrade Safe (056, 057) and Foundation Operations Safe (058, 059) were executed on mainnet.

| Task | Tx |
|------|----|
| `eth/056-fus-rotation-1` | [`0xbb0cece7…`](https://etherscan.io/tx/0xbb0cece7d5f45ce07894be038b83af893b894a3337a5dda22b79b46097c4ce96) |
| `eth/057-fus-rotation-2` | [`0x087cbb21…`](https://etherscan.io/tx/0x087cbb21ebc9739c7afed878236a9cba9b1e129adc6a976fefe5571b88452ce8) |
| `eth/058-fos-rotation-1` | [`0xd3a6afee…`](https://etherscan.io/tx/0xd3a6afeef57d1e1b7fde86a4b0dd5de6fb6747cec75d6d9edecf54e7eacb19ea) |
| `eth/059-fos-rotation-2` | [`0x86366bc8…`](https://etherscan.io/tx/0x86366bc8466b0b45ece66d277ec47f988cfad38a3147c6d71b623e104d9d2ab5) |

Each README's status line changes from `Status: [READY TO SIGN]()` to `Status: [EXECUTED](<tx-url>)`, following the same convention as #1494 and #1457.

## Agent skill

Also adds `.claude/skills/mark-task-executed/SKILL.md` so agents can perform this status-update-and-PR flow quickly and cheaply going forward, documenting the status-line convention, the network→explorer mapping, and the verification/PR steps.

## Review notes

Reviewers should confirm each tx hash on Etherscan corresponds to the intended task execution (correct Safe, correct calldata).

Prompted by: @mds1
