### PR TITLE
eth/062: remove key-control-proof signing gate

### DIFF
--- a/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
+++ b/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
@@ -19,7 +19,6 @@ Both cost vaults end with a **0.15 ETH minimum withdrawal** — low enough to ke
 
 ## Signing gates — do not sign until ALL are cleared
 
-1. **Template dependency:** `SetFeeVaultConfig` merges via [#1504](https://github.com/ethereum-optimism/superchain-ops/pull/1504) — this task's PR is stacked on it and can only merge after it.
 2. **Governance:** the signer is the L1 ProxyAdminOwner (nested 2-of-2: Foundation Upgrade Safe + Security Council), so execution requires the Ink chain-servicer-migration Maintenance Upgrade proposal to clear its optimistic-approval veto window.
 3. **Ordering:** the nonce pins in [config.toml](./config.toml) assume `eth/061-ink-proposer-rotation` ([#1490](https://github.com/ethereum-optimism/superchain-ops/pull/1490), signed by the same nested L1PAO) executes first. Re-simulate and regenerate the [VALIDATION.md](./VALIDATION.md) hashes if the ordering changes or any live nonce drifts.
 

--- a/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
+++ b/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
@@ -19,8 +19,8 @@ Both cost vaults end with a **0.15 ETH minimum withdrawal** — low enough to ke
 
 ## Signing gates — do not sign until ALL are cleared
 
-2. **Governance:** the signer is the L1 ProxyAdminOwner (nested 2-of-2: Foundation Upgrade Safe + Security Council), so execution requires the Ink chain-servicer-migration Maintenance Upgrade proposal to clear its optimistic-approval veto window.
-3. **Ordering:** the nonce pins in [config.toml](./config.toml) assume `eth/061-ink-proposer-rotation` ([#1490](https://github.com/ethereum-optimism/superchain-ops/pull/1490), signed by the same nested L1PAO) executes first. Re-simulate and regenerate the [VALIDATION.md](./VALIDATION.md) hashes if the ordering changes or any live nonce drifts.
+1. **Governance:** the signer is the L1 ProxyAdminOwner (nested 2-of-2: Foundation Upgrade Safe + Security Council), so execution requires the Ink chain-servicer-migration Maintenance Upgrade proposal to clear its optimistic-approval veto window.
+2. **Ordering:** the nonce pins in [config.toml](./config.toml) assume `eth/061-ink-proposer-rotation` ([#1490](https://github.com/ethereum-optimism/superchain-ops/pull/1490), signed by the same nested L1PAO) executes first. Re-simulate and regenerate the [VALIDATION.md](./VALIDATION.md) hashes if the ordering changes or any live nonce drifts.
 
 ## Mechanism
 

--- a/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
+++ b/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
@@ -15,14 +15,13 @@ For **Ink Mainnet** (chainId 57073), transfer the two cost-covering fee vaults t
 
 Both cost vaults end with a **0.15 ETH minimum withdrawal** — low enough to keep cost-recipient sweeps frequent (`withdraw()` is permissionless; no automated trigger is planned), and non-zero so `withdraw()` reverts below the threshold, making zero/dust-value L2→L1 withdrawal spam impossible. Sweep triggering remains a manual, operator-owned action until a keeper exists.
 
-**Cost recipient provenance:** `0x1eB630b2e7409597D462dd5f3D21E305FC56B8C9` is an L1 EOA whose key is managed in Google KMS (key ring `ink-mainnet-0`, key `cost-recipient`). Source of truth: `k8s-netchef-prod` — `manifests/ink-mainnet-0/mn-ink-mainnet-0-op-signer/mn-ink-mainnet-0-op-signer.yaml`, auth entry `mn-ink-mainnet-0-cost-recipient` (chainID 1). It will fund Ink's L1 operating costs (batcher / proposer / challenger top-ups). Note: the address is freshly created and **unused as of 2026-07-21** (nonce 0, balance 0 on L1) — a never-seen address is expected here, and key control must be proven before signing (see below).
+**Cost recipient provenance:** `0x1eB630b2e7409597D462dd5f3D21E305FC56B8C9` is an L1 EOA whose key is managed in Google KMS (key ring `ink-mainnet-0`, key `cost-recipient`). Source of truth: `k8s-netchef-prod` — `manifests/ink-mainnet-0/mn-ink-mainnet-0-op-signer/mn-ink-mainnet-0-op-signer.yaml`, auth entry `mn-ink-mainnet-0-cost-recipient` (chainID 1). It will fund Ink's L1 operating costs (batcher / proposer / challenger top-ups). Note: the address is freshly created and **unused as of 2026-07-21** (nonce 0, balance 0 on L1) — a never-seen address is expected here.
 
 ## Signing gates — do not sign until ALL are cleared
 
 1. **Template dependency:** `SetFeeVaultConfig` merges via [#1504](https://github.com/ethereum-optimism/superchain-ops/pull/1504) — this task's PR is stacked on it and can only merge after it.
 2. **Governance:** the signer is the L1 ProxyAdminOwner (nested 2-of-2: Foundation Upgrade Safe + Security Council), so execution requires the Ink chain-servicer-migration Maintenance Upgrade proposal to clear its optimistic-approval veto window.
 3. **Ordering:** the nonce pins in [config.toml](./config.toml) assume `eth/061-ink-proposer-rotation` ([#1490](https://github.com/ethereum-optimism/superchain-ops/pull/1490), signed by the same nested L1PAO) executes first. Re-simulate and regenerate the [VALIDATION.md](./VALIDATION.md) hashes if the ordering changes or any live nonce drifts.
-4. **Key-control proof:** before signing, the cost-recipient key holder must demonstrate control of `0x1eB630b2e7409597D462dd5f3D21E305FC56B8C9` (a dust transaction from the address, or a signed message verified against it) — the address has never transacted, and a wrong recipient is only recoverable via another full nested-L1PAO task.
 
 ## Mechanism
 

--- a/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
+++ b/src/tasks/eth/062-ink-fee-vault-recipient-update/README.md
@@ -20,7 +20,9 @@ Both cost vaults end with a **0.15 ETH minimum withdrawal** — low enough to ke
 ## Signing gates — do not sign until ALL are cleared
 
 1. **Governance:** the signer is the L1 ProxyAdminOwner (nested 2-of-2: Foundation Upgrade Safe + Security Council), so execution requires the Ink chain-servicer-migration Maintenance Upgrade proposal to clear its optimistic-approval veto window.
+   **✅ Cleared 2026-07-29:** the [proposal](https://gov.optimism.io/t/maintenance-upgrade-proposal-ink-mainnet-fee-vault-config-update-and-proposer-rotation/10776) was submitted 2026-07-22 and its optimistic-approval vote [SUCCEEDED](https://vote.optimism.io/proposals/98596515698156453044551125843803184999481750957062514239597457651661195220288) — the veto window ended 2026-07-28 with 0.2% of votable supply against (20% veto quorum not reached).
 2. **Ordering:** the nonce pins in [config.toml](./config.toml) assume `eth/061-ink-proposer-rotation` ([#1490](https://github.com/ethereum-optimism/superchain-ops/pull/1490), signed by the same nested L1PAO) executes first. Re-simulate and regenerate the [VALIDATION.md](./VALIDATION.md) hashes if the ordering changes or any live nonce drifts.
+   **Status 2026-07-29 — holds as planned:** live L1PAO / FUS / SC nonces are 36 / 62 / 60, exactly the expected pre-061 values; the pins (37 / 63 / 61) anticipate 061 executing first, so they are correct for the planned order and signing can proceed in parallel with the 061 ceremony. This gate only fails if the execution order changes or the live nonces move past the expected +1 bump — re-check with `cast call <safe> "nonce()(uint256)"` immediately before executing.
 
 ## Mechanism
 


### PR DESCRIPTION
## What

- Removes **signing gate 4 (key-control proof)** from the `eth/062-ink-fee-vault-recipient-update` README, along with the now-dangling "key control must be proven before signing (see below)" forward reference in the cost-recipient provenance note.
- Also removes **signing gate 1 (template dependency)** — satisfied since [#1504](https://github.com/ethereum-optimism/superchain-ops/pull/1504) merged (added via an accepted review suggestion from @matthew; the description originally said gates 1–3 were untouched, now corrected).
- Annotates the two remaining gates with live status as of 2026-07-29:
  - **Governance: cleared.** [Forum proposal](https://gov.optimism.io/t/maintenance-upgrade-proposal-ink-mainnet-fee-vault-config-update-and-proposer-rotation/10776) submitted 2026-07-22; the [Agora optimistic-approval vote](https://vote.optimism.io/proposals/98596515698156453044551125843803184999481750957062514239597457651661195220288) SUCCEEDED — veto window ended 2026-07-28 with 0.2% against vs the 20% quorum.
  - **Ordering: holds as planned.** Live L1PAO/FUS/SC nonces are 36/62/60 (expected pre-061 values); the pins (37/63/61) deliberately anticipate `eth/061` executing first.

## Why

Requested by matthew in the 061/062 signing-ceremony thread: signers walking the checklist (including assistant-driven walkthroughs) stall on gates that are satisfied, stale, or misread as drift.

## Note for reviewers

For an informed decision on the gate-4 removal, the facts as of 2026-07-29:

- `0x1eB630b2e7409597D462dd5f3D21E305FC56B8C9` remains **unused on L1** (nonce 0, balance 0, no code). No key-control proof (dust tx or signed message) has been produced yet.
- The k8s manifest is the *source* of the address, so its presence there confirms config consistency but not key control.
- Merging this removes the requirement to demonstrate control of the KMS key (`ink-mainnet-0/cost-recipient`) before the ceremony signs. A wrong/uncontrolled recipient after execution is only recoverable via another full nested-L1PAO task.
- Alternative that was considered: keep the gate and clear it with an op-signer signed message verified via `cast wallet verify`, annotated in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)