### PR TITLE
docs: mark eth/063 and eth/064 as EXECUTED

### DIFF
--- a/src/tasks/eth/063-swell-l1-ownership-transfers/README.md
+++ b/src/tasks/eth/063-swell-l1-ownership-transfers/README.md
@@ -1,6 +1,6 @@
 # 063-swell-l1-ownership-transfers: Transfer L1 owners for Swell Mainnet (ProxyAdmin + DisputeGameFactory)
 
-Status: READY TO SIGN
+Status: [EXECUTED](https://etherscan.io/tx/0xc9051994cae6cd1aa668e73f4b768a6135da4f6504aca1d7740f460841ab6dcb)
 
 ## Objective
 

--- a/src/tasks/eth/064-swell-l2pao-transfer/README.md
+++ b/src/tasks/eth/064-swell-l2pao-transfer/README.md
@@ -1,6 +1,6 @@
 # 064-swell-l2pao-transfer: Transfer L2 ProxyAdmin Owner for Swell Mainnet
 
-Status: READY TO SIGN
+Status: [EXECUTED](https://etherscan.io/tx/0x99ed59760859782943f3598836a35b100fe93acd24fe7370bce174eccb38f50d)
 
 ## Objective
 


### PR DESCRIPTION
Swell Mainnet ownership transfer to AltLayer is complete on-chain.

| Task | Execution tx |
|---|---|
| `eth/063-swell-l1-ownership-transfers` | [`0xc9051994…1ab6dcb`](https://etherscan.io/tx/0xc9051994cae6cd1aa668e73f4b768a6135da4f6504aca1d7740f460841ab6dcb) |
| `eth/064-swell-l2pao-transfer` | [`0x99ed5976…cb38f50d`](https://etherscan.io/tx/0x99ed59760859782943f3598836a35b100fe93acd24fe7370bce174eccb38f50d) |

Both executed from the L1PAO Safe `0x5a0Aae59…`, 063 (block 25731698) before 064 (block 25731713).

Receipt checks:
- 063 emits `OwnershipTransferred(L1PAO → 0xa83F1334…)` on both the DisputeGameFactory `0x87690676…` and the ProxyAdmin `0x4C4710a4…`. `ProxyAdmin.owner()` now returns `0xa83F1334c6a8Daca576Dc14020d9d2b1b16a8Dfa`.
- 064 emits `TransactionDeposited` on the OptimismPortal `0x758E0EE6…` with `from = 0x6B1BAE59…` (alias of the L1PAO Safe) and `to = 0x4200…0018` (L2 ProxyAdmin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)