### PR TITLE
Ink FOS > FUS transfer cleanup

### DIFF
--- a/src/tasks/eth/065-ink-system-config-owner-to-fus/README.md
+++ b/src/tasks/eth/065-ink-system-config-owner-to-fus/README.md
@@ -24,7 +24,7 @@ just simulate-stack eth 065-ink-system-config-owner-to-fus
 Signing commands:
 ```bash
 cd src/tasks/eth/065-ink-system-config-owner-to-fus
-SKIP_DECODE_AND_PRINT=1 just --dotenv-path $(pwd)/.env sign
+SKIP_DECODE_AND_PRINT=1 just sign-stack eth 065-ink-system-config-owner-to-fus
 ```
 
 ## Validation

--- a/src/tasks/eth/065-ink-system-config-owner-to-fus/README.md
+++ b/src/tasks/eth/065-ink-system-config-owner-to-fus/README.md
@@ -1,20 +1,17 @@
 # 065-ink-system-config-owner-to-fus
 
-Status: READY TO SIGN
+Status: [READY TO SIGN]
 
 ## Objective
 
-Transfers ownership of the **Ink Mainnet** (chainId 57073) `SystemConfigProxy` from the **Foundation Operations Safe (FOS)** to the **Foundation Upgrade Safe (FUS)**, as a follow-up to the completed Gelato → OP Enterprise rollup-operator migration ([solutions#973](https://github.com/ethereum-optimism/solutions/issues/973)).
+Transfers ownership of the **Ink Mainnet** (chainId 57073) `SystemConfigProxy` from the **Foundation Operations Safe (FOS)** to the **Foundation Upgrade Safe (FUS)**, as a follow-up to the completed Gelato > OP Enterprise migration.
 
-- **Current owner** (signer): [`0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A`](https://etherscan.io/address/0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A) — **Foundation Operations Safe** (5-of-7)
-- **New owner**: [`0x847B5c174615B1B7fDF770882256e2D3E95b9D92`](https://etherscan.io/address/0x847B5c174615B1B7fDF770882256e2D3E95b9D92) — **Foundation Upgrade Safe** (5-of-7)
-- **Target**: `SystemConfigProxy` [`0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364`](https://etherscan.io/address/0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364) (resolved from the superchain-registry)
+- **Current owner** (signer): [`0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A`](https://github.com/ethereum-optimism/superchain-ops/blob/ecef506a2033a8d0c62a41af7f26892a27859338/src/addresses.toml#L10) — **Foundation Operations Safe**. This Safe received SystemConfig ownership from the Gelato Safe with the migration cutover
+- **New owner**: [`0x847B5c174615B1B7fDF770882256e2D3E95b9D92`](https://github.com/ethereum-optimism/superchain-ops/blob/ecef506a2033a8d0c62a41af7f26892a27859338/src/addresses.toml#L6) — **Foundation Upgrade Safe**
+- **Target**: `SystemConfigProxy` [`0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364`](https://github.com/ethereum-optimism/superchain-registry/blob/bb104b09fcd60fc01c8f8daf0f534aee88ff26de/superchain/configs/mainnet/ink.toml#L51)
 
 > [!IMPORTANT]
-> **Policy going forward: the FUS is the standard owner for all `SystemConfig` proxies.** New chains and migrations should set (or transfer) `SystemConfig` ownership to the FUS, matching the Foundation-owned chains where the FUS already holds this role (e.g. OP Mainnet). This task brings Ink Mainnet in line with that policy; [sep/104](../../sep/104-ink-sepolia-system-config-owner-to-fus/README.md) does the same for Ink Sepolia.
-
-> [!CAUTION]
-> Ownership transfers are **irreversible** (only the new owner could transfer it back). Verify the `newOwner` address against `src/addresses.toml` (`FoundationUpgradeSafe`, `[eth]`) with **≥3 OP Labs engineers** before signing.
+> Ownership transfers are **irreversible**, verify the `newOwner` address before signing.
 
 ## Simulation & Signing
 

--- a/src/tasks/eth/065-ink-system-config-owner-to-fus/VALIDATION.md
+++ b/src/tasks/eth/065-ink-system-config-owner-to-fus/VALIDATION.md
@@ -1,24 +1,16 @@
 # Validation
 
-This document can be used to validate the inputs and result of the execution of the
-transfer transaction which you are signing.
-
-The steps are:
-
-1. [Validate the Addresses](#address-sources)
-2. [Validate the Domain and Message Hashes](#expected-domain-and-message-hashes)
-3. [Transaction Inputs](config.toml): inputs can be verified in the config.toml file.
-4. State Changes: the template's `_validate` block asserts `SystemConfig.owner() == newOwner`. State changes can also be reviewed in Tenderly via the link printed during simulation.
+This document can be used to validate the inputs and result of the execution of the transaction you are signing.
 
 ## Address Sources
 
 | Address | Role | Source |
 |---|---|---|
-| `0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364` | Ink Mainnet `SystemConfigProxy` (target) | [superchain-registry: `superchain/configs/mainnet/ink.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/superchain/configs/mainnet/ink.toml) (`addresses.SystemConfigProxy`) |
-| `0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A` | Foundation Operations Safe (current owner, signer) | [`src/addresses.toml`](../../../addresses.toml) `[eth].FoundationOperationsSafe`; cross-reference: same Safe listed as `challenger` in [superchain-registry: `validation/standard/standard-config-roles-mainnet.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-roles-mainnet.toml) |
+| `0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364` | Ink Mainnet `SystemConfigProxy` (target) | [superchain-registry: `superchain/configs/mainnet/ink.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/bb104b09fcd60fc01c8f8daf0f534aee88ff26de/superchain/configs/mainnet/ink.toml#L51) |
+| `0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A` | Foundation Operations Safe (current owner, signer) | [`src/addresses.toml`](../../../addresses.toml) `[eth].FoundationOperationsSafe` |
 | `0x847B5c174615B1B7fDF770882256e2D3E95b9D92` | Foundation Upgrade Safe (`newOwner`) | [`src/addresses.toml`](../../../addresses.toml) `[eth].FoundationUpgradeSafe`; cross-references: same Safe listed as `protocolVersionsOwner` in [superchain-registry: `validation/standard/standard-config-roles-mainnet.toml`](https://github.com/ethereum-optimism/superchain-registry/blob/main/validation/standard/standard-config-roles-mainnet.toml), and it is the current OP Mainnet `SystemConfig` owner (`cast call 0x229047fed2591dbec1eF1118d64F7aF3dB9EB290 "owner()(address)" --rpc-url https://ethereum-rpc.publicnode.com`) |
 
-Verify the current owner on-chain:
+To verify the current owner on-chain:
 
 ```bash
 cast call 0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364 "owner()(address)" --rpc-url https://ethereum-rpc.publicnode.com

--- a/src/tasks/eth/065-ink-system-config-owner-to-fus/config.toml
+++ b/src/tasks/eth/065-ink-system-config-owner-to-fus/config.toml
@@ -15,7 +15,7 @@ l2chains = [
 
 [stateOverrides]
 # FOS nonce pinned for stable domain/message hashes. Live value at
-# authoring (2026-08-04) = 121. Re-verify before signing:
+# authoring (2026-08-04) = 121. To re-verify before signing:
 # cast call 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A "nonce()(uint256)" --rpc-url https://ethereum-rpc.publicnode.com
 
 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A = [

--- a/src/tasks/eth/065-ink-system-config-owner-to-fus/config.toml
+++ b/src/tasks/eth/065-ink-system-config-owner-to-fus/config.toml
@@ -1,21 +1,12 @@
-# Ink Mainnet (chainId 57073) — SystemConfig ownership transfer, post-migration follow-up.
-#
-# Transfers ownership of the Ink Mainnet SystemConfigProxy from the Foundation
-# Operations Safe (FOS) to the Foundation Upgrade Safe (FUS), completing the
-# Gelato -> OP Enterprise migration follow-ups (solutions#973). Going forward the
-# FUS is the standard owner for all SystemConfig proxies.
-#
-# The FOS (0x9BA6…6b3A) is the current on-chain SystemConfig owner. Verify:
-#   cast call 0x62C0a111929fA32ceC2F76aDba54C16aFb6E8364 "owner()(address)" --rpc-url mainnet
-
 templateName = "TransferSystemConfigOwnership"
 
-# The current SystemConfig owner and root Safe for this task: Foundation Operations
-# Safe (eth), resolved from src/addresses.toml.
+# The current SystemConfig owner and root Safe for this task: Mainnet Foundation Operations
+# Safe, resolved from src/addresses.toml
+
 safeAddressString = "FoundationOperationsSafe"
 
-# Foundation Upgrade Safe (eth), per src/addresses.toml. ⚠ Ownership transfers are
-# irreversible — verify with ≥3 OP Labs engineers before signing.
+# Mainnet Foundation Upgrade Safe, per src/addresses.toml
+
 newOwner = "0x847B5c174615B1B7fDF770882256e2D3E95b9D92"
 
 l2chains = [
@@ -23,9 +14,10 @@ l2chains = [
 ]
 
 [stateOverrides]
-# FOS nonce (slot 5) pinned for stable domain/message hashes. Live value at
+# FOS nonce pinned for stable domain/message hashes. Live value at
 # authoring (2026-08-04) = 121. Re-verify before signing:
-#   cast call 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A "nonce()(uint256)" --rpc-url mainnet
+# cast call 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A "nonce()(uint256)" --rpc-url https://ethereum-rpc.publicnode.com
+
 0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A = [
     {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = 121}
 ]

--- a/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/README.md
+++ b/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/README.md
@@ -24,7 +24,7 @@ just simulate-stack sep 104-ink-sepolia-system-config-owner-to-fus
 Signing commands:
 ```bash
 cd src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus
-SKIP_DECODE_AND_PRINT=1 just --dotenv-path $(pwd)/.env sign
+SKIP_DECODE_AND_PRINT=1 just sign-stack sep 104-ink-sepolia-system-config-owner-to-fus
 ```
 
 ## Validation

--- a/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/README.md
+++ b/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/README.md
@@ -1,20 +1,17 @@
 # 104-ink-sepolia-system-config-owner-to-fus
 
-Status: READY TO SIGN
+Status: [READY TO SIGN]
 
 ## Objective
 
-Transfers ownership of the **Ink Sepolia** (chainId 763373) `SystemConfigProxy` from the **Foundation Operations Safe (FOS)** to the **Foundation Upgrade Safe (FUS)**, as a follow-up to the completed Gelato → OP Enterprise rollup-operator migration ([solutions#973](https://github.com/ethereum-optimism/solutions/issues/973)).
+Transfers ownership of the **Ink Sepolia** (chainId 763373) `SystemConfigProxy` from the **Foundation Operations Safe (FOS)** to the **Foundation Upgrade Safe (FUS)**, as a follow-up to the completed Gelato > OP Enterprise migration.
 
-- **Current owner** (signer): [`0x837DE453AD5F21E89771e3c06239d8236c0EFd5E`](https://sepolia.etherscan.io/address/0x837DE453AD5F21E89771e3c06239d8236c0EFd5E) — **Foundation Operations Safe** (2-of-N). This Safe received SystemConfig ownership from the Gelato Safe during the migration cutover.
-- **New owner**: [`0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B`](https://sepolia.etherscan.io/address/0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B) — **Foundation Upgrade Safe**
-- **Target**: `SystemConfigProxy` [`0x05C993e60179f28bF649a2Bb5b00b5F4283bD525`](https://sepolia.etherscan.io/address/0x05C993e60179f28bF649a2Bb5b00b5F4283bD525) (resolved from the superchain-registry)
+- **Current owner** (signer): [`0x837DE453AD5F21E89771e3c06239d8236c0EFd5E`](https://github.com/ethereum-optimism/superchain-ops/blob/ecef506a2033a8d0c62a41af7f26892a27859338/src/addresses.toml#L21) — **Foundation Operations Safe**. This Safe received SystemConfig ownership from the Gelato Safe with the migration cutover
+- **New owner**: [`0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B`](https://github.com/ethereum-optimism/superchain-ops/blob/ecef506a2033a8d0c62a41af7f26892a27859338/src/addresses.toml#L18) — **Foundation Upgrade Safe**
+- **Target**: `SystemConfigProxy` [`0x05C993e60179f28bF649a2Bb5b00b5F4283bD525`](https://github.com/ethereum-optimism/superchain-registry/blob/bb104b09fcd60fc01c8f8daf0f534aee88ff26de/superchain/configs/sepolia/ink.toml#L52)
 
 > [!IMPORTANT]
-> **Policy going forward: the FUS is the standard owner for all `SystemConfig` proxies.** New chains and migrations should set (or transfer) `SystemConfig` ownership to the FUS, matching the Foundation-owned chains where the FUS already holds this role (e.g. OP Mainnet). This task brings Ink Sepolia in line with that policy; [eth/065](../../eth/065-ink-system-config-owner-to-fus/README.md) does the same for Ink Mainnet.
-
-> [!CAUTION]
-> Ownership transfers are **irreversible** (only the new owner could transfer it back). Verify the `newOwner` address against `src/addresses.toml` (`FoundationUpgradeSafe`, `[sep]`) with **≥3 OP Labs engineers** before signing.
+> Ownership transfers are **irreversible**, verify the `newOwner` address before signing.
 
 ## Simulation & Signing
 

--- a/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/VALIDATION.md
+++ b/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/VALIDATION.md
@@ -1,14 +1,6 @@
 # Validation
 
-This document can be used to validate the inputs and result of the execution of the
-transfer transaction which you are signing.
-
-The steps are:
-
-1. [Validate the Addresses](#address-sources)
-2. [Validate the Domain and Message Hashes](#expected-domain-and-message-hashes)
-3. [Transaction Inputs](config.toml): inputs can be verified in the config.toml file.
-4. State Changes: the template's `_validate` block asserts `SystemConfig.owner() == newOwner`. State changes can also be reviewed in Tenderly via the link printed during simulation.
+This document can be used to validate the inputs and result of the execution of the transaction you are signing.
 
 ## Address Sources
 
@@ -18,9 +10,7 @@ The steps are:
 | `0x837DE453AD5F21E89771e3c06239d8236c0EFd5E` | Foundation Operations Safe (current owner, signer) | [`src/addresses.toml`](../../../addresses.toml) `[sep].FoundationOperationsSafe` |
 | `0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B` | Foundation Upgrade Safe (`newOwner`) | [`src/addresses.toml`](../../../addresses.toml) `[sep].FoundationUpgradeSafe` |
 
-Note: the superchain-registry's `validation/standard/standard-config-roles-sepolia.toml` does not track the Foundation Safes on Sepolia (the standard Sepolia roles use an EOA), so [`src/addresses.toml`](../../../addresses.toml) is the source of truth for the FOS/FUS addresses here — cross-check it against prior Sepolia tasks signed by these Safes (e.g. `sep/101`–`sep/103`).
-
-Verify the current owner on-chain:
+To verify the current owner on-chain:
 
 ```bash
 cast call 0x05C993e60179f28bF649a2Bb5b00b5F4283bD525 "owner()(address)" --rpc-url https://ethereum-sepolia-rpc.publicnode.com

--- a/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/config.toml
+++ b/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/config.toml
@@ -1,22 +1,12 @@
-# Ink Sepolia (chainId 763373) — SystemConfig ownership transfer, post-migration follow-up.
-#
-# Transfers ownership of the Ink Sepolia SystemConfigProxy from the Foundation
-# Operations Safe (FOS) to the Foundation Upgrade Safe (FUS), completing the
-# Gelato -> OP Enterprise migration follow-ups (solutions#973). Going forward the
-# FUS is the standard owner for all SystemConfig proxies.
-#
-# The FOS (0x837D…Fd5E) is the current on-chain SystemConfig owner — it received
-# ownership from the Gelato Safe during the migration cutover (step W26). Verify:
-#   cast call 0x05C993e60179f28bF649a2Bb5b00b5F4283bD525 "owner()(address)" --rpc-url sepolia
-
 templateName = "TransferSystemConfigOwnership"
 
-# The current SystemConfig owner and root Safe for this task: Foundation Operations
-# Safe (sep), resolved from src/addresses.toml.
+# The current SystemConfig owner and root Safe for this task: Sepolia Foundation Operations
+# Safe, resolved from src/addresses.toml
+
 safeAddressString = "FoundationOperationsSafe"
 
-# Foundation Upgrade Safe (sep), per src/addresses.toml. ⚠ Ownership transfers are
-# irreversible — verify with ≥3 OP Labs engineers before signing.
+# Sepolia Foundation Upgrade Safe, per src/addresses.toml
+
 newOwner = "0xDEe57160aAfCF04c34C887B5962D0a69676d3C8B"
 
 l2chains = [
@@ -24,9 +14,10 @@ l2chains = [
 ]
 
 [stateOverrides]
-# FOS nonce (slot 5) pinned for stable domain/message hashes. Live value at
+# FOS nonce pinned for stable domain/message hashes. Live value at
 # authoring (2026-08-04) = 14. Re-verify before signing:
-#   cast call 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E "nonce()(uint256)" --rpc-url sepolia
+# cast call 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E "nonce()(uint256)" --rpc-url https://ethereum-sepolia-rpc.publicnode.com
+
 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E = [
     {key = "0x0000000000000000000000000000000000000000000000000000000000000005", value = 14}
 ]

--- a/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/config.toml
+++ b/src/tasks/sep/104-ink-sepolia-system-config-owner-to-fus/config.toml
@@ -15,7 +15,7 @@ l2chains = [
 
 [stateOverrides]
 # FOS nonce pinned for stable domain/message hashes. Live value at
-# authoring (2026-08-04) = 14. Re-verify before signing:
+# authoring (2026-08-04) = 14. To re-verify before signing:
 # cast call 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E "nonce()(uint256)" --rpc-url https://ethereum-sepolia-rpc.publicnode.com
 
 0x837DE453AD5F21E89771e3c06239d8236c0EFd5E = [


### PR DESCRIPTION
This PR cleans up and streamlines comments on the FOS > FUS transfer tasks.

It does NOT introduce any changes to the inputs or alter the expected changes.