### PR TITLE
tasks: add nonceless (hash-once) execution via UnorderedExecutionModule

### DIFF
--- a/src/interfaces/IUnorderedExecutionModule.sol
+++ b/src/interfaces/IUnorderedExecutionModule.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Enum} from "@base-contracts/script/universal/IGnosisSafe.sol";
+
+/// @notice Interface of the UnorderedExecutionModule, the Safe module that executes transactions
+/// authorized by owner signatures over the Safe's transaction hash computed with a "hash-once"
+/// value in the nonce slot instead of the sequential nonce.
+/// Source: optimism monorepo, packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol
+interface IUnorderedExecutionModule {
+    /// @notice Parameters for the Safe transaction being executed. The remaining fields of the
+    /// signed Safe transaction (safeTxGas, baseGas, gasPrice, gasToken, refundReceiver) are
+    /// hard-coded to zero and the nonce is supplied separately as the hash-once value.
+    struct ExecTransactionParams {
+        address to;
+        uint256 value;
+        bytes data;
+        Enum.Operation operation;
+    }
+
+    /// @notice Derives the canonical hash-once value from a unique string.
+    function deriveHashOnce(string memory _input) external pure returns (uint256 hashOnce_);
+
+    /// @notice Whether a hash-once value has been consumed by an execution on the given Safe.
+    function executed(address _safe, uint256 _hashOnce) external view returns (bool executed_);
+
+    /// @notice The Safe transaction hash owners must sign: the Safe's own getTransactionHash()
+    /// with the hash-once value in the nonce slot and zeroed gas and refund fields.
+    function transactionHash(address _safe, ExecTransactionParams memory _params, uint256 _hashOnce)
+        external
+        view
+        returns (bytes32 txHash_);
+
+    /// @notice Executes a transaction once a threshold of owner signatures has been collected.
+    /// Reverts if the call reverts, leaving the hash-once value unconsumed.
+    function execute(
+        address _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce,
+        bytes calldata _signatures
+    ) external returns (bytes memory returnData_);
+}

--- a/src/libraries/GnosisSafeHashes.sol
+++ b/src/libraries/GnosisSafeHashes.sol
@@ -145,6 +145,22 @@ library GnosisSafeHashes {
     /// @param _safeAddress The address of the Gnosis Safe contract
     /// @return isOldVersion_ True if the version is below 1.3.0, false otherwise
     function isOldDomainSeparatorVersion(address _safeAddress) internal view returns (bool isOldVersion_) {
+        (uint256 major, uint256 minor) = getMajorMinorVersion(_safeAddress);
+        isOldVersion_ = (major < 1 || (major == 1 && minor < 3));
+    }
+
+    /// @notice Checks if the Safe's version is 1.5.0 or above, where encodeTransactionData()
+    /// was removed from the Safe contract and the encoding must be constructed locally.
+    /// @param _safeAddress The address of the Gnosis Safe contract
+    /// @return removed_ True if the version is 1.5.0 or above, false otherwise
+    function isEncodeTransactionDataRemoved(address _safeAddress) internal view returns (bool removed_) {
+        (uint256 major, uint256 minor) = getMajorMinorVersion(_safeAddress);
+        removed_ = (major > 1 || (major == 1 && minor >= 5));
+    }
+
+    /// @notice Parses the major and minor version from the Safe's VERSION() string.
+    /// We are ignoring tags such as beta, rc, etc.
+    function getMajorMinorVersion(address _safeAddress) internal view returns (uint256 major_, uint256 minor_) {
         // Get the version from the Gnosis Safe contract
         GnosisSafe safe = GnosisSafe(payable(_safeAddress));
         string memory version = safe.VERSION();
@@ -157,10 +173,8 @@ library GnosisSafeHashes {
         require(secondDot != type(uint256).max, "GnosisSafeHashes: Invalid version format");
 
         // Parse major and minor versions
-        uint256 major = JSONParserLib.parseUint(LibString.slice(version, 0, firstDot));
-        uint256 minor = JSONParserLib.parseUint(LibString.slice(version, firstDot + 1, secondDot - firstDot + 1));
-
-        isOldVersion_ = (major < 1 || (major == 1 && minor < 3));
+        major_ = JSONParserLib.parseUint(LibString.slice(version, 0, firstDot));
+        minor_ = JSONParserLib.parseUint(LibString.slice(version, firstDot + 1, secondDot - firstDot + 1));
     }
 
     /// @notice Reads the result of a call to Safe.encodeTransactionData and returns the message hash.
@@ -236,18 +250,41 @@ library GnosisSafeHashes {
         uint256 _originalNonce,
         address _multicallAddress
     ) internal view returns (bytes memory encodedTxData) {
-        encodedTxData = IGnosisSafe(_safe).encodeTransactionData({
-            to: _multicallAddress,
-            value: _value,
-            data: _data,
-            operation: Enum.Operation.DelegateCall,
-            safeTxGas: 0,
-            baseGas: 0,
-            gasPrice: 0,
-            gasToken: address(0),
-            refundReceiver: address(0),
-            _nonce: _originalNonce
-        });
+        if (isEncodeTransactionDataRemoved(_safe)) {
+            // Safe 1.5.0 removed encodeTransactionData(); construct the EIP-712 encoding locally.
+            // The SafeTx typehash and encoding are byte-identical across 1.3.0, 1.4.1 and 1.5.0,
+            // and getTransactionHash() on the Safe is the keccak256 of exactly this encoding.
+            bytes32 structHash = keccak256(
+                abi.encode(
+                    SAFE_TX_TYPEHASH,
+                    _multicallAddress,
+                    _value,
+                    keccak256(_data),
+                    uint8(Enum.Operation.DelegateCall),
+                    uint256(0),
+                    uint256(0),
+                    uint256(0),
+                    address(0),
+                    address(0),
+                    _originalNonce
+                )
+            );
+            encodedTxData =
+                abi.encodePacked(bytes1(0x19), bytes1(0x01), IGnosisSafe(_safe).domainSeparator(), structHash);
+        } else {
+            encodedTxData = IGnosisSafe(_safe).encodeTransactionData({
+                to: _multicallAddress,
+                value: _value,
+                data: _data,
+                operation: Enum.Operation.DelegateCall,
+                safeTxGas: 0,
+                baseGas: 0,
+                gasPrice: 0,
+                gasToken: address(0),
+                refundReceiver: address(0),
+                _nonce: _originalNonce
+            });
+        }
         require(encodedTxData.length == 66, "GnosisSafeHashes: encodedTxData length is not 66 bytes.");
     }
 

--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -370,13 +370,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
         if (isNonceless()) {
             // Module execution does not touch the safe's nonce; the hash-once value is consumed instead.
-            require(
-                hashOnceModule.executed(rootSafe, hashOnce), "MultisigTask: hash-once value not consumed by module"
-            );
+            require(hashOnceModule.executed(rootSafe, hashOnce), "MultisigTask: hash-once value not consumed by module");
         } else {
-            require(
-                IGnosisSafe(rootSafe).nonce() == originalRootSafeNonce + 1, "MultisigTask: nonce not incremented"
-            );
+            require(IGnosisSafe(rootSafe).nonce() == originalRootSafeNonce + 1, "MultisigTask: nonce not incremented");
         }
 
         _validate(accountAccesses, actions, rootSafe);

--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -16,6 +16,7 @@ import {IGnosisSafe, Enum} from "@base-contracts/script/universal/IGnosisSafe.so
 
 import {AccountAccessParser} from "src/libraries/AccountAccessParser.sol";
 import {GnosisSafeHashes} from "src/libraries/GnosisSafeHashes.sol";
+import {IUnorderedExecutionModule} from "src/interfaces/IUnorderedExecutionModule.sol";
 import {Action, TemplateConfig, TaskType, TaskPayload, SafeData} from "src/libraries/MultisigTypes.sol";
 import {StateOverrideManager} from "src/tasks/StateOverrideManager.sol";
 import {Utils} from "src/libraries/Utils.sol";
@@ -43,6 +44,14 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
     /// @notice The address of the multicall target for this task
     address public multicallTarget;
+
+    /// @notice Hash-once value replacing every safe's nonce when the task is nonceless.
+    /// Derived from the 'hashOnceInput' string in the task config; 0 for nonce-based tasks.
+    uint256 public hashOnce;
+
+    /// @notice The UnorderedExecutionModule used to execute nonceless tasks. Must be enabled as a
+    /// module on every safe in the task. Only set when the task is nonceless.
+    IUnorderedExecutionModule public hashOnceModule;
 
     /// @notice struct to store the addresses that are expected to have storage accesses
     EnumerableSet.AddressSet internal _allowedStorageAccesses;
@@ -130,6 +139,15 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         SafeData memory safeData = Utils.getSafeData(payload, executionSafeIdx);
         txHash_ = getHash(safeData.callData, safeData.safe, 0, safeData.nonce, payload.safes);
 
+        // Fail early with a clear error: a consumed hash-once value means the task was already
+        // executed, or another task on this safe reused the same hashOnceInput.
+        if (isNonceless()) {
+            require(
+                !hashOnceModule.executed(safeData.safe, hashOnce),
+                "MultisigTask: hash-once value already consumed on this safe. Was the task already executed, or does another task reuse the same hashOnceInput?"
+            );
+        }
+
         // If we are simulating, we need to approve the hash from each owner.
         // Otherwise, we are executing the task and all approvals are already done.
         // No signatures means we are simulating.
@@ -140,7 +158,9 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                 IGnosisSafe(safeData.safe).approveHash(txHash_);
                 // Manually increment the nonce for each owner. If we executed the approveHash function from the owner directly (contract or EOA),
                 // the nonce would be incremented by 1 and we wouldn't have to do this manually.
-                _incrementOwnerNonce(owners[i]);
+                // Nonceless tasks skip this: owner approvals also execute through the module, which
+                // never touches nonces, so simulation must leave them unchanged too.
+                if (!isNonceless()) _incrementOwnerNonce(owners[i]);
             }
             signatures = _prepareSignatures(safeData.safe, txHash_);
         } else {
@@ -281,6 +301,45 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         }
     }
 
+    /// @notice Returns true if the task is nonceless (hash-once): its config defines 'hashOnceInput'.
+    function isNonceless() public view returns (bool) {
+        return hashOnce != 0;
+    }
+
+    /// @notice Reads the optional 'hashOnceInput' string from the task config. Its presence makes
+    /// the task nonceless: the derived hash-once value replaces every safe's nonce in the signed
+    /// transaction data, and execution is routed through the UnorderedExecutionModule (which must
+    /// be enabled on every safe in the task) instead of execTransaction. The string must be unique
+    /// per task and must not encode the task directory number, so that signatures survive
+    /// renumbering. 'hashOnceModule' must name the module's deployed address.
+    function _setHashOnceFromConfig(string memory _taskConfigFilePath) private {
+        string memory file = vm.readFile(_taskConfigFilePath);
+        if (!file.keyExists(".hashOnceInput")) return;
+
+        string memory hashOnceInput = file.readString(".hashOnceInput");
+        require(bytes(hashOnceInput).length > 0, "MultisigTask: hashOnceInput must not be empty");
+
+        require(
+            file.keyExists(".hashOnceModule"),
+            "MultisigTask: hashOnceModule address is required when hashOnceInput is set"
+        );
+        hashOnceModule = IUnorderedExecutionModule(vm.parseAddress(file.readString(".hashOnceModule")));
+        require(
+            address(hashOnceModule).code.length > 0,
+            "MultisigTask: hashOnceModule has no code. Is the module deployed on this network?"
+        );
+
+        // The module's derivation is canonical; deriving locally could silently diverge from it.
+        hashOnce = hashOnceModule.deriveHashOnce(hashOnceInput);
+        // The module rejects values a sequential nonce could reach. Unreachable for keccak output.
+        require(hashOnce > type(uint128).max, "MultisigTask: hashOnce value too small");
+        console.log(
+            vm.toUppercase("[INFO]").green().bold(),
+            "Nonceless (hash-once) task. Safe nonces are replaced by:",
+            vm.toString(hashOnce)
+        );
+    }
+
     /// @notice Execute post-task checks. e.g. read state variables of the deployed contracts to make
     /// sure they are deployed and initialized correctly, or read states that are expected to have changed during the simulate step.
     function validate(
@@ -309,7 +368,16 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
             );
         }
 
-        require(IGnosisSafe(rootSafe).nonce() == originalRootSafeNonce + 1, "MultisigTask: nonce not incremented");
+        if (isNonceless()) {
+            // Module execution does not touch the safe's nonce; the hash-once value is consumed instead.
+            require(
+                hashOnceModule.executed(rootSafe, hashOnce), "MultisigTask: hash-once value not consumed by module"
+            );
+        } else {
+            require(
+                IGnosisSafe(rootSafe).nonce() == originalRootSafeNonce + 1, "MultisigTask: nonce not incremented"
+            );
+        }
 
         _validate(accountAccesses, actions, rootSafe);
 
@@ -525,19 +593,43 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
             vm.broadcast();
         }
 
-        bytes memory callData = abi.encodeWithSelector(
-            IGnosisSafe.execTransaction.selector,
-            target,
-            value,
-            data,
-            operationType,
-            0,
-            0,
-            0,
-            address(0),
-            payable(address(0)),
-            signatures
-        );
+        // Nonceless tasks execute through the UnorderedExecutionModule instead of the safe's own
+        // execTransaction. The module verifies the same signatures against the same transaction
+        // hash (with the hash-once value in the nonce slot) via the safe's checkSignatures.
+        address callTarget;
+        bytes memory callData;
+        if (isNonceless()) {
+            callTarget = address(hashOnceModule);
+            callData = abi.encodeCall(
+                IUnorderedExecutionModule.execute,
+                (
+                    multisig,
+                    IUnorderedExecutionModule.ExecTransactionParams({
+                        to: target,
+                        value: value,
+                        data: data,
+                        operation: operationType
+                    }),
+                    hashOnce,
+                    signatures
+                )
+            );
+        } else {
+            callTarget = multisig;
+            callData = abi.encodeWithSelector(
+                IGnosisSafe.execTransaction.selector,
+                target,
+                value,
+                data,
+                operationType,
+                0,
+                0,
+                0,
+                address(0),
+                payable(address(0)),
+                signatures
+            );
+        }
 
         // Use the TENDERLY_GAS environment variable to set a specific gas limit, if provided.
         // Otherwise, default to the remaining gas. This helps surface out-of-gas errors earlier,
@@ -545,7 +637,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         uint256 gas = vm.envOr("TENDERLY_GAS", gasleft());
         MultisigTaskPrinter.printGasForExecTransaction(gas);
 
-        (bool success, bytes memory returnData) = multisig.call{gas: gas}(callData);
+        (bool success, bytes memory returnData) = callTarget.call{gas: gas}(callData);
 
         // Check that the transaction did not exceed the maximum gas limit.
         // We must check gas consumed BEFORE refunds, because the EVM requires enough gas upfront,
@@ -647,6 +739,7 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
     {
         require(_preExecutionSnapshot == 0, "MultisigTask: already initialized");
         templateConfig.safeAddressString = loadSafeAddressString(MultisigTask(address(this)), _taskConfigFilePath);
+        _setHashOnceFromConfig(_taskConfigFilePath);
         IGnosisSafe _root;
         (addrRegistry, _root, multicallTarget) = _configureTask(_taskConfigFilePath);
 
@@ -664,6 +757,8 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
 
         _setAllowedStorageAccesses();
         _setAllowedBalanceChanges();
+        // The module records the consumed hash-once value during execution.
+        if (isNonceless()) _allowedStorageAccesses.add(address(hashOnceModule));
 
         vm.label(AddressRegistry.unwrap(addrRegistry), "AddrRegistry");
         vm.label(address(this), "MultisigTask");
@@ -808,6 +903,19 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         _setStorageCodeExceptionsFromConfig(_taskConfigFilePath); // Sets '_storageCodeExceptions' mapping.
         allOriginalNonces_ = new uint256[](_allSafes.length);
         for (uint256 i = 0; i < _allSafes.length; i++) {
+            // Nonceless: the hash-once value takes the nonce's place in the signed transaction
+            // data of every safe. Replay protection is per (safe, hashOnce) on the module, so all
+            // safes share the same value. Nonce overrides do not apply and are rejected so that a
+            // leftover [stateOverrides] nonce entry cannot be silently ignored.
+            if (isNonceless()) {
+                require(
+                    !_hasNonceOverride(_allSafes[i]),
+                    "MultisigTask: nonce state overrides are not allowed for a nonceless task"
+                );
+                allOriginalNonces_[i] = hashOnce;
+                continue;
+            }
+
             allOriginalNonces_[i] = _getNonceOrOverride(_allSafes[i], _taskConfigFilePath);
 
             address[] memory owners = IGnosisSafe(_allSafes[i]).getOwners();
@@ -882,7 +990,16 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                     break;
                 }
             }
-            _printTenderlySimulationData(payload);
+            if (isNonceless()) {
+                // The Tenderly payload builds on execTransaction and live nonces; a module-aware
+                // payload is not supported yet. Nonceless tasks are verified on a live network.
+                console.log(
+                    vm.toUppercase("[INFO]").green().bold(),
+                    "Nonceless task: skipping Tenderly simulation payload (not supported for module execution)."
+                );
+            } else {
+                _printTenderlySimulationData(payload);
+            }
 
             // Collect dataToSign for validation against VALIDATION.md
             if (payload.safes.length <= 1) {
@@ -906,10 +1023,14 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
         console.log("Domain Hash:    ", vm.toString(domainSeparator));
         console.log("Message Hash:   ", vm.toString(messageHash));
         MultisigTaskPrinter.printEncodedTransactionData(dataToSign);
-        address rootMulticallTarget = _getMulticallAddress(rootSafe, payload.safes);
-        address childMulticallTarget =
-            payload.safes.length > 1 ? _getMulticallAddress(payload.safes[0], payload.safes) : address(0);
-        MultisigTaskPrinter.printOPTxVerifyLink(block.chainid, payload, rootMulticallTarget, childMulticallTarget);
+        // op-txverify serializes the nonce as a JSON number; a hash-once value overflows
+        // double-precision parsing, so the link is skipped for nonceless tasks.
+        if (!isNonceless()) {
+            address rootMulticallTarget = _getMulticallAddress(rootSafe, payload.safes);
+            address childMulticallTarget =
+                payload.safes.length > 1 ? _getMulticallAddress(payload.safes[0], payload.safes) : address(0);
+            MultisigTaskPrinter.printOPTxVerifyLink(block.chainid, payload, rootMulticallTarget, childMulticallTarget);
+        }
     }
 
     /// @notice Collects dataToSign for ALL sibling child safes (contract owners of the root safe).
@@ -953,10 +1074,12 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                     dataToSign_[idx] = simulatedDataToSign;
                 } else {
                     // Generate dataToSign for this sibling.
-                    // Nonces were incremented exactly once during execution, so current - 1 gives pre-execution nonce.
-                    // If nonces are incremented more than once elsewhere in MultisigTask, revert to caching original nonces.
+                    // Nonceless: every safe signs with the hash-once value in the nonce slot.
+                    // Nonce-based: nonces were incremented exactly once during execution, so current - 1 gives
+                    // the pre-execution nonce. If nonces are incremented more than once elsewhere in
+                    // MultisigTask, revert to caching original nonces.
                     address multicallAddr = _getMulticallAddress(sibling, safes);
-                    uint256 originalNonce = IGnosisSafe(sibling).nonce() - 1;
+                    uint256 originalNonce = isNonceless() ? hashOnce : IGnosisSafe(sibling).nonce() - 1;
                     dataToSign_[idx] = GnosisSafeHashes.getEncodedTransactionData(
                         sibling, approvalCalldata, 0, originalNonce, multicallAddr
                     );

--- a/src/tasks/MultisigTask.sol
+++ b/src/tasks/MultisigTask.sol
@@ -546,10 +546,14 @@ abstract contract MultisigTask is Test, Script, StateOverrideManager, TaskManage
                 if (!storageAccess.isWrite) continue; // Skip SLOADs.
                 uint256 value = uint256(storageAccess.newValue);
                 address account = storageAccess.account;
+                // The hash-once module's bookkeeping (consumed values, signer window) legitimately
+                // stores owner addresses that may be contracts or EOAs; address-likeness checks
+                // don't apply to it.
+                bool isHashOnceModuleWrite = isNonceless() && account == address(hashOnceModule);
                 // Skip the code check for slots explicitly whitelisted via the task's
                 // `[storageCodeExceptions]` config (e.g. packed slots whose low 160 bits
                 // are not an independent address).
-                if (!_storageCodeExceptions[account][storageAccess.slot]) {
+                if (!_storageCodeExceptions[account][storageAccess.slot] && !isHashOnceModuleWrite) {
                     if (Utils.isLikelyAddressThatShouldHaveCode(value, codeExceptions)) {
                         // Log account, slot, and value if there is no code.
                         // forgefmt: disable-start

--- a/src/tasks/StateOverrideManager.sol
+++ b/src/tasks/StateOverrideManager.sol
@@ -107,6 +107,19 @@ abstract contract StateOverrideManager is CommonBase {
         return currentActualNonce;
     }
 
+    /// @notice Returns true if a user-defined state override sets the Gnosis Safe nonce slot for
+    /// the given contract. Used to reject nonce overrides on nonceless (hash-once) tasks.
+    function _hasNonceOverride(address safeAddress) internal view returns (bool) {
+        bytes32 nonceSlot = bytes32(uint256(0x5));
+        for (uint256 i = 0; i < _stateOverrides.length; i++) {
+            if (_stateOverrides[i].contractAddress != safeAddress) continue;
+            for (uint256 j = 0; j < _stateOverrides[i].overrides.length; j++) {
+                if (_stateOverrides[i].overrides[j].key == nonceSlot) return true;
+            }
+        }
+        return false;
+    }
+
     /// @notice Root safe override. If `owner` is non-zero, it will be added as an owner when not already.
     function _rootSafeTenderlyOverride(address rootSafe, address owner)
         private

--- a/src/tasks/sep/105-nonceless-welcome/README.md
+++ b/src/tasks/sep/105-nonceless-welcome/README.md
@@ -1,0 +1,15 @@
+# THIS IS A TEST TASK THAT DOES NOT USE ANY PRODUCTION ADDRESSES.
+
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x83638b83e85c655deb12064891144ed4c3cb88772bd5bbf6da87c889242df59a)
+
+First nonceless (hash-once) task. The root safe is a freshly deployed Safe
+v1.5.0 with a single signer and the UnorderedExecutionModule enabled. No nonce
+is pinned: signers sign the safe transaction hash computed with the hash-once
+value (derived from `hashOnceInput`) in the nonce slot, and execution goes
+through the module.
+
+```bash
+cd src/tasks/sep/105-nonceless-welcome
+just simulate
+just sign
+```

--- a/src/tasks/sep/105-nonceless-welcome/config.toml
+++ b/src/tasks/sep/105-nonceless-welcome/config.toml
@@ -1,0 +1,13 @@
+templateName = "WelcomeToSuperchainOps"
+
+name = "Nonceless"
+
+allowOverwrite = ["SecurityCouncil"]
+
+# Nonceless (hash-once) task: no nonce pinning, executed via the UnorderedExecutionModule.
+hashOnceInput = "sep/023-nonceless-welcome: first nonceless task"
+hashOnceModule = "0xF4678ab3b188c4bF2bBab965517Ec86D69Ac4788"
+
+[addresses]
+TargetContract = "0x5c6623738B2a3a54edF1d46B2A85f959fe6b1f6b"
+SecurityCouncil = "0x44A4f8364df6a38DD64DCB59A282f0106e292f2e" # Safe v1.5.0 with a single signer, UnorderedExecutionModule enabled.

--- a/src/tasks/sep/106-nonceless-nested-welcome/README.md
+++ b/src/tasks/sep/106-nonceless-nested-welcome/README.md
@@ -1,0 +1,23 @@
+# THIS IS A TEST TASK THAT DOES NOT USE ANY PRODUCTION ADDRESSES.
+
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0xa7b1a151dabe1ed6dd6e773aada9de6587a2f3604015758238bc2eed30ceda4b)
+
+First NESTED nonceless (hash-once) task. The root safe
+(0xf6475613C0Fa02c43eA6e6e296D3e424c39AE49d) is owned by the child safe from
+task 105 (0x44A4f8364df6a38DD64DCB59A282f0106e292f2e); both are Safe v1.5.0
+with the UnorderedExecutionModule enabled. No nonces pinned at either level.
+
+Flow that was run:
+- child approval executed through the module
+  ([tx](https://sepolia.etherscan.io/tx/0x2f10df1abbc166001e9f6a27b785add2bdffa49a55d29796f282f0a718d7bbae)):
+  the child safe delegatecalls Multicall3 to approveHash the root's hash-once
+  transaction hash — the child's own nonce is untouched.
+- root execution through the module with the child's prevalidated approval
+  ([tx](https://sepolia.etherscan.io/tx/0xa7b1a151dabe1ed6dd6e773aada9de6587a2f3604015758238bc2eed30ceda4b)) —
+  the root's nonce is untouched.
+
+```bash
+cd src/tasks/sep/106-nonceless-nested-welcome
+just simulate
+just sign foundation # or the relevant child safe
+```

--- a/src/tasks/sep/106-nonceless-nested-welcome/config.toml
+++ b/src/tasks/sep/106-nonceless-nested-welcome/config.toml
@@ -1,0 +1,13 @@
+templateName = "WelcomeToSuperchainOps"
+
+name = "NoncelessNested"
+
+allowOverwrite = ["SecurityCouncil"]
+
+# Nonceless (hash-once) nested task: the root safe is owned by another safe.
+hashOnceInput = "sep/nonceless-nested-welcome: first nested nonceless task"
+hashOnceModule = "0xF4678ab3b188c4bF2bBab965517Ec86D69Ac4788"
+
+[addresses]
+TargetContract = "0x5c6623738B2a3a54edF1d46B2A85f959fe6b1f6b"
+SecurityCouncil = "0xf6475613C0Fa02c43eA6e6e296D3e424c39AE49d" # Safe v1.5.0 owned by the 105 task's safe; UnorderedExecutionModule enabled on both.

--- a/src/tasks/sep/107-nonceless-nested-fresh/README.md
+++ b/src/tasks/sep/107-nonceless-nested-fresh/README.md
@@ -1,0 +1,15 @@
+# THIS IS A TEST TASK THAT DOES NOT USE ANY PRODUCTION ADDRESSES.
+
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x29cd227242ca87fe0b91bdb70d17793d7a00a16d69f0020a5627c0ddb1703edd)
+
+Nested nonceless (hash-once) task on fresh Safe v1.5.0 pair, executed through
+the source-verified UnorderedExecutionModule
+(0xADcbCff796a47D468fE8C0252FBe8d856d4e63D7):
+
+- root 0x957b13AF196CE0fF6866Be0a9aE7232e264ce2bA (owner: child)
+- child 0x770272C87Fb655E42ddF5026d2cfC6C3036CED4E (owner: EOA signer)
+
+Child approval via module: https://sepolia.etherscan.io/tx/0x35b963ba2b901b28711ff2980033ba45972fe36169ac405f89501e66e1c09f9a
+Root execution via module: https://sepolia.etherscan.io/tx/0x29cd227242ca87fe0b91bdb70d17793d7a00a16d69f0020a5627c0ddb1703edd
+
+Neither safe's nonce was touched by the task at any step.

--- a/src/tasks/sep/107-nonceless-nested-fresh/config.toml
+++ b/src/tasks/sep/107-nonceless-nested-fresh/config.toml
@@ -1,0 +1,13 @@
+templateName = "WelcomeToSuperchainOps"
+
+name = "NoncelessFreshNested"
+
+allowOverwrite = ["SecurityCouncil"]
+
+# Nonceless (hash-once) nested task on fresh safes with the verified module.
+hashOnceInput = "sep/nonceless-nested-fresh: verified module nested test"
+hashOnceModule = "0xADcbCff796a47D468fE8C0252FBe8d856d4e63D7"
+
+[addresses]
+TargetContract = "0x5c6623738B2a3a54edF1d46B2A85f959fe6b1f6b"
+SecurityCouncil = "0x957b13AF196CE0fF6866Be0a9aE7232e264ce2bA" # Fresh Safe v1.5.0 owned by fresh child 0x770272C87Fb655E42ddF5026d2cfC6C3036CED4E.

--- a/src/tasks/types/OPCMTaskBase.sol
+++ b/src/tasks/types/OPCMTaskBase.sol
@@ -78,7 +78,9 @@ abstract contract OPCMTaskBase is L2TaskBase {
                 "OPCMTaskBase: no state should be updated on upgrade controller multisig for a nonceless task"
             );
         } else {
-            require(rootSafeDiffs.length == 1, "OPCMTaskBase: only nonce should be updated on upgrade controller multisig");
+            require(
+                rootSafeDiffs.length == 1, "OPCMTaskBase: only nonce should be updated on upgrade controller multisig"
+            );
         }
 
         for (uint256 i = 0; i < OPCM_TARGETS.length; i++) {

--- a/src/tasks/types/OPCMTaskBase.sol
+++ b/src/tasks/types/OPCMTaskBase.sol
@@ -71,7 +71,15 @@ abstract contract OPCMTaskBase is L2TaskBase {
         super.validate(accesses, actions, payload);
         address rootSafe = payload.safes[payload.safes.length - 1];
         AccountAccessParser.StateDiff[] memory rootSafeDiffs = accesses.getStateDiffFor(rootSafe, false);
-        require(rootSafeDiffs.length == 1, "OPCMTaskBase: only nonce should be updated on upgrade controller multisig");
+        if (isNonceless()) {
+            // Module execution touches neither the safe's nonce nor any of its other storage.
+            require(
+                rootSafeDiffs.length == 0,
+                "OPCMTaskBase: no state should be updated on upgrade controller multisig for a nonceless task"
+            );
+        } else {
+            require(rootSafeDiffs.length == 1, "OPCMTaskBase: only nonce should be updated on upgrade controller multisig");
+        }
 
         for (uint256 i = 0; i < OPCM_TARGETS.length; i++) {
             address OPCM = OPCM_TARGETS[i];

--- a/test/tasks/NoncelessMultisigTask.t.sol
+++ b/test/tasks/NoncelessMultisigTask.t.sol
@@ -26,7 +26,8 @@ contract NoncelessMultisigTaskTest is Test {
     string constant HASH_ONCE_INPUT = "test: totally unique string";
 
     /// @notice Single multisig config: SystemConfigOwner of Mode and Metal.
-    string constant singleToml = "l2chains = [{name = \"Mode\", chainId = 34443}, {name = \"Metal\", chainId = 1750}]\n"
+    string constant singleToml =
+        "l2chains = [{name = \"Mode\", chainId = 34443}, {name = \"Metal\", chainId = 1750}]\n"
         "templateName = \"GasConfigTemplate\"\n" "hashOnceInput = \"test: totally unique string\"\n"
         "hashOnceModule = \"0x4242424242424242424242424242424242424242\"\n" "[gasConfigs]\n"
         "gasLimits = [{chainId = 34443, gasLimit = 100000000}, {chainId = 1750, gasLimit = 100000000}]\n";
@@ -141,8 +142,8 @@ contract NoncelessMultisigTaskTest is Test {
     }
 
     function test_nonceless_moduleNotDeployed_reverts() public {
-        string memory badToml = "l2chains = [{name = \"Mode\", chainId = 34443}]\n" "templateName = \"GasConfigTemplate\"\n"
-            "hashOnceInput = \"test: totally unique string\"\n"
+        string memory badToml = "l2chains = [{name = \"Mode\", chainId = 34443}]\n"
+            "templateName = \"GasConfigTemplate\"\n" "hashOnceInput = \"test: totally unique string\"\n"
             "hashOnceModule = \"0x9999999999999999999999999999999999999999\"\n" "[gasConfigs]\n"
             "gasLimits = [{chainId = 34443, gasLimit = 100000000}]\n";
         string memory fileName = MultisigTaskTestHelper.createTempTomlFile(badToml, TESTING_DIRECTORY, "005");
@@ -154,9 +155,9 @@ contract NoncelessMultisigTaskTest is Test {
     }
 
     function test_nonceless_missingModuleAddress_reverts() public {
-        string memory badToml = "l2chains = [{name = \"Mode\", chainId = 34443}]\n" "templateName = \"GasConfigTemplate\"\n"
-            "hashOnceInput = \"test: totally unique string\"\n" "[gasConfigs]\n"
-            "gasLimits = [{chainId = 34443, gasLimit = 100000000}]\n";
+        string memory badToml = "l2chains = [{name = \"Mode\", chainId = 34443}]\n"
+            "templateName = \"GasConfigTemplate\"\n" "hashOnceInput = \"test: totally unique string\"\n"
+            "[gasConfigs]\n" "gasLimits = [{chainId = 34443, gasLimit = 100000000}]\n";
         string memory fileName = MultisigTaskTestHelper.createTempTomlFile(badToml, TESTING_DIRECTORY, "006");
         MultisigTask task = new GasConfigTemplate();
 
@@ -218,15 +219,18 @@ contract NoncelessMultisigTaskTest is Test {
 
         assertEq(dataToSign.length, dataToSignAfterDrift.length, "dataToSign count should match");
         for (uint256 i = 0; i < dataToSign.length; i++) {
-            assertEq(
-                dataToSign[i], dataToSignAfterDrift[i], "dataToSign must not change when any safe's nonce drifts"
-            );
+            assertEq(dataToSign[i], dataToSignAfterDrift[i], "dataToSign must not change when any safe's nonce drifts");
         }
     }
 
     function simulateWithModuleEnabled(MultisigTask task, string memory fileName)
         internal
-        returns (VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions, bytes[] memory dataToSign, address rootSafe)
+        returns (
+            VmSafe.AccountAccess[] memory accountAccesses,
+            Action[] memory actions,
+            bytes[] memory dataToSign,
+            address rootSafe
+        )
     {
         enableModule(task.getRootSafe(fileName));
         (accountAccesses, actions, dataToSign, rootSafe) = task.simulate(fileName, new address[](0));

--- a/test/tasks/NoncelessMultisigTask.t.sol
+++ b/test/tasks/NoncelessMultisigTask.t.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+import {VmSafe} from "forge-std/Vm.sol";
+import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
+
+import {MultisigTask} from "src/tasks/MultisigTask.sol";
+import {GnosisSafeHashes} from "src/libraries/GnosisSafeHashes.sol";
+import {Action} from "src/libraries/MultisigTypes.sol";
+import {GasConfigTemplate} from "test/tasks/mock/template/GasConfigTemplate.sol";
+import {MockMultisigTask} from "test/tasks/mock/MockMultisigTask.sol";
+import {MockUnorderedExecutionModule} from "test/tasks/mock/MockUnorderedExecutionModule.sol";
+import {MultisigTaskTestHelper} from "test/tasks/MultisigTask.t.sol";
+import {Solarray} from "lib/optimism/packages/contracts-bedrock/scripts/libraries/Solarray.sol";
+
+/// @notice Tests for nonceless (hash-once) task execution through the UnorderedExecutionModule.
+/// The module is deployed locally at a fixed address and enabled on the forked safes; on real
+/// networks it must be deployed and enabled on-chain before a nonceless task can run.
+contract NoncelessMultisigTaskTest is Test {
+    string constant TESTING_DIRECTORY = "nonceless-multisig-task-testing";
+
+    /// @notice Fixed address referenced by the 'hashOnceModule' key in the test configs.
+    address constant MODULE_ADDRESS = 0x4242424242424242424242424242424242424242;
+
+    string constant HASH_ONCE_INPUT = "test: totally unique string";
+
+    /// @notice Single multisig config: SystemConfigOwner of Mode and Metal.
+    string constant singleToml = "l2chains = [{name = \"Mode\", chainId = 34443}, {name = \"Metal\", chainId = 1750}]\n"
+        "templateName = \"GasConfigTemplate\"\n" "hashOnceInput = \"test: totally unique string\"\n"
+        "hashOnceModule = \"0x4242424242424242424242424242424242424242\"\n" "[gasConfigs]\n"
+        "gasLimits = [{chainId = 34443, gasLimit = 100000000}, {chainId = 1750, gasLimit = 100000000}]\n";
+
+    /// @notice Nested multisig config: OP Mainnet ProxyAdminOwner (L1PAO).
+    string constant nestedToml = "l2chains = [{name = \"OP Mainnet\", chainId = 10}]\n"
+        "templateName = \"MockMultisigTask\"\n" "hashOnceInput = \"test: totally unique string\"\n"
+        "hashOnceModule = \"0x4242424242424242424242424242424242424242\"\n";
+
+    address constant SECURITY_COUNCIL = 0xc2819DC788505Aac350142A7A707BF9D03E3Bd03;
+
+    uint256 expectedHashOnce;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet");
+        deployCodeTo("MockUnorderedExecutionModule.sol", MODULE_ADDRESS);
+        expectedHashOnce = uint256(keccak256(bytes(HASH_ONCE_INPUT)));
+    }
+
+    function enableModule(address safe) internal {
+        vm.prank(safe);
+        IGnosisSafe(safe).enableModule(MODULE_ADDRESS);
+    }
+
+    function test_noncelessSingle_simulate_succeeds() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(singleToml, TESTING_DIRECTORY, "000");
+        MultisigTask task = new GasConfigTemplate();
+
+        (,,, address rootSafe) = simulateWithModuleEnabled(task, fileName);
+        MultisigTaskTestHelper.removeFile(fileName);
+
+        assertTrue(task.isNonceless(), "task should be nonceless");
+        assertEq(task.hashOnce(), expectedHashOnce, "hashOnce should be derived from hashOnceInput");
+        assertEq(address(task.hashOnceModule()), MODULE_ADDRESS, "module address should come from config");
+        assertTrue(
+            MockUnorderedExecutionModule(MODULE_ADDRESS).executed(rootSafe, expectedHashOnce),
+            "module should have consumed the hash-once value"
+        );
+    }
+
+    function test_noncelessSingle_safeNonce_unchanged() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(singleToml, TESTING_DIRECTORY, "001");
+        MultisigTask task = new GasConfigTemplate();
+        address rootSafe = task.getRootSafe(fileName);
+        uint256 nonceBefore = IGnosisSafe(rootSafe).nonce();
+
+        simulateWithModuleEnabled(task, fileName);
+        MultisigTaskTestHelper.removeFile(fileName);
+
+        assertEq(IGnosisSafe(rootSafe).nonce(), nonceBefore, "module execution must not touch the safe nonce");
+    }
+
+    /// @notice The core property of nonceless tasks: the data to sign does not change when the
+    /// safe's nonce drifts, so signatures collected before the drift stay valid.
+    function test_noncelessSingle_nonceDrift_dataToSignUnchanged() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(singleToml, TESTING_DIRECTORY, "002");
+
+        uint256 snapshot = vm.snapshotState();
+        MultisigTask task = new GasConfigTemplate();
+        (,, bytes[] memory dataToSign,) = simulateWithModuleEnabled(task, fileName);
+
+        assertTrue(vm.revertToState(snapshot), "failed to revert state");
+
+        // Drift the root safe's nonce by 5 and simulate again.
+        MultisigTask driftedTask = new GasConfigTemplate();
+        address rootSafe = driftedTask.getRootSafe(fileName);
+        uint256 gnosisSafeNonceSlot = 0x5;
+        uint256 nonceBefore = IGnosisSafe(rootSafe).nonce();
+        vm.store(rootSafe, bytes32(gnosisSafeNonceSlot), bytes32(nonceBefore + 5));
+
+        (,, bytes[] memory dataToSignAfterDrift,) = simulateWithModuleEnabled(driftedTask, fileName);
+        MultisigTaskTestHelper.removeFile(fileName);
+
+        assertEq(dataToSign.length, dataToSignAfterDrift.length, "dataToSign count should match");
+        for (uint256 i = 0; i < dataToSign.length; i++) {
+            assertEq(dataToSign[i], dataToSignAfterDrift[i], "dataToSign must not change when the safe nonce drifts");
+        }
+    }
+
+    function test_noncelessSingle_dataToSign_usesHashOnceAsNonce() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(singleToml, TESTING_DIRECTORY, "003");
+        MultisigTask task = new GasConfigTemplate();
+
+        (, Action[] memory actions, bytes[] memory dataToSign, address rootSafe) =
+            simulateWithModuleEnabled(task, fileName);
+        MultisigTaskTestHelper.removeFile(fileName);
+
+        address[] memory allSafes = MultisigTaskTestHelper.getAllSafes(rootSafe);
+        uint256[] memory hashOnceNonces = new uint256[](1);
+        hashOnceNonces[0] = expectedHashOnce;
+        bytes[] memory calldatas = task.transactionDatas(actions, allSafes, hashOnceNonces);
+
+        bytes memory expectedDataToSign = GnosisSafeHashes.getEncodedTransactionData(
+            rootSafe, calldatas[calldatas.length - 1], 0, expectedHashOnce, MULTICALL3_ADDRESS
+        );
+        assertEq(dataToSign.length, 1, "single safe task should return one dataToSign");
+        assertEq(dataToSign[0], expectedDataToSign, "dataToSign must embed the hash-once value as the nonce");
+    }
+
+    function test_noncelessSingle_replay_reverts() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(singleToml, TESTING_DIRECTORY, "004");
+        MultisigTask task = new GasConfigTemplate();
+        simulateWithModuleEnabled(task, fileName);
+
+        // The hash-once value is consumed; executing the same task again must fail.
+        MultisigTask replayTask = new GasConfigTemplate();
+        vm.expectRevert(
+            "MultisigTask: hash-once value already consumed on this safe. Was the task already executed, or does another task reuse the same hashOnceInput?"
+        );
+        replayTask.simulate(fileName, new address[](0));
+        MultisigTaskTestHelper.removeFile(fileName);
+    }
+
+    function test_nonceless_moduleNotDeployed_reverts() public {
+        string memory badToml = "l2chains = [{name = \"Mode\", chainId = 34443}]\n" "templateName = \"GasConfigTemplate\"\n"
+            "hashOnceInput = \"test: totally unique string\"\n"
+            "hashOnceModule = \"0x9999999999999999999999999999999999999999\"\n" "[gasConfigs]\n"
+            "gasLimits = [{chainId = 34443, gasLimit = 100000000}]\n";
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(badToml, TESTING_DIRECTORY, "005");
+        MultisigTask task = new GasConfigTemplate();
+
+        vm.expectRevert("MultisigTask: hashOnceModule has no code. Is the module deployed on this network?");
+        task.simulate(fileName, new address[](0));
+        MultisigTaskTestHelper.removeFile(fileName);
+    }
+
+    function test_nonceless_missingModuleAddress_reverts() public {
+        string memory badToml = "l2chains = [{name = \"Mode\", chainId = 34443}]\n" "templateName = \"GasConfigTemplate\"\n"
+            "hashOnceInput = \"test: totally unique string\"\n" "[gasConfigs]\n"
+            "gasLimits = [{chainId = 34443, gasLimit = 100000000}]\n";
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(badToml, TESTING_DIRECTORY, "006");
+        MultisigTask task = new GasConfigTemplate();
+
+        vm.expectRevert("MultisigTask: hashOnceModule address is required when hashOnceInput is set");
+        task.simulate(fileName, new address[](0));
+        MultisigTaskTestHelper.removeFile(fileName);
+    }
+
+    function test_noncelessNested_simulate_succeeds() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(nestedToml, TESTING_DIRECTORY, "007");
+        MultisigTask task = new MockMultisigTask();
+        address rootSafe = task.getRootSafe(fileName);
+        enableModule(rootSafe);
+        enableModule(SECURITY_COUNCIL);
+        uint256 rootNonceBefore = IGnosisSafe(rootSafe).nonce();
+        uint256 childNonceBefore = IGnosisSafe(SECURITY_COUNCIL).nonce();
+
+        (,, bytes[] memory dataToSign,) = task.simulate(fileName, Solarray.addresses(SECURITY_COUNCIL));
+        MultisigTaskTestHelper.removeFile(fileName);
+
+        assertTrue(task.isNonceless(), "task should be nonceless");
+        assertTrue(
+            MockUnorderedExecutionModule(MODULE_ADDRESS).executed(rootSafe, expectedHashOnce),
+            "module should have consumed the root safe's hash-once value"
+        );
+        assertEq(IGnosisSafe(rootSafe).nonce(), rootNonceBefore, "root safe nonce must not change");
+        assertEq(IGnosisSafe(SECURITY_COUNCIL).nonce(), childNonceBefore, "child safe nonce must not change");
+
+        // Every sibling child safe signs with the hash-once value in the nonce slot.
+        for (uint256 i = 0; i < dataToSign.length; i++) {
+            (, bytes32 messageHash) = GnosisSafeHashes.getDomainAndMessageHashFromEncodedTransactionData(dataToSign[i]);
+            assertTrue(messageHash != bytes32(0), "sibling dataToSign should be well-formed");
+        }
+    }
+
+    /// @notice Nested drift property: the child signers' data to sign survives both root and
+    /// child nonce drift.
+    function test_noncelessNested_nonceDrift_dataToSignUnchanged() public {
+        string memory fileName = MultisigTaskTestHelper.createTempTomlFile(nestedToml, TESTING_DIRECTORY, "008");
+
+        uint256 snapshot = vm.snapshotState();
+        MultisigTask task = new MockMultisigTask();
+        address rootSafe = task.getRootSafe(fileName);
+        enableModule(rootSafe);
+        enableModule(SECURITY_COUNCIL);
+        (,, bytes[] memory dataToSign,) = task.simulate(fileName, Solarray.addresses(SECURITY_COUNCIL));
+
+        assertTrue(vm.revertToState(snapshot), "failed to revert state");
+
+        MultisigTask driftedTask = new MockMultisigTask();
+        enableModule(rootSafe);
+        enableModule(SECURITY_COUNCIL);
+        uint256 gnosisSafeNonceSlot = 0x5;
+        vm.store(rootSafe, bytes32(gnosisSafeNonceSlot), bytes32(IGnosisSafe(rootSafe).nonce() + 3));
+        vm.store(SECURITY_COUNCIL, bytes32(gnosisSafeNonceSlot), bytes32(IGnosisSafe(SECURITY_COUNCIL).nonce() + 7));
+
+        (,, bytes[] memory dataToSignAfterDrift,) = driftedTask.simulate(fileName, Solarray.addresses(SECURITY_COUNCIL));
+        MultisigTaskTestHelper.removeFile(fileName);
+
+        assertEq(dataToSign.length, dataToSignAfterDrift.length, "dataToSign count should match");
+        for (uint256 i = 0; i < dataToSign.length; i++) {
+            assertEq(
+                dataToSign[i], dataToSignAfterDrift[i], "dataToSign must not change when any safe's nonce drifts"
+            );
+        }
+    }
+
+    function simulateWithModuleEnabled(MultisigTask task, string memory fileName)
+        internal
+        returns (VmSafe.AccountAccess[] memory accountAccesses, Action[] memory actions, bytes[] memory dataToSign, address rootSafe)
+    {
+        enableModule(task.getRootSafe(fileName));
+        (accountAccesses, actions, dataToSign, rootSafe) = task.simulate(fileName, new address[](0));
+    }
+}

--- a/test/tasks/mock/MockUnorderedExecutionModule.sol
+++ b/test/tasks/mock/MockUnorderedExecutionModule.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
+import {IUnorderedExecutionModule} from "src/interfaces/IUnorderedExecutionModule.sol";
+
+/// @notice Test-only port of the monorepo's UnorderedExecutionModule
+/// (packages/contracts-bedrock/src/safe/UnorderedExecutionModule.sol, pragma 0.8.25), compiled at
+/// this repo's pinned 0.8.15 against IGnosisSafe. Behavior must match the real module: same
+/// transaction hash scheme (hash-once value in the nonce slot, zeroed gas and refund fields),
+/// same (safe, hashOnce) replay protection, same signature verification via checkSignatures.
+/// Implementing IUnorderedExecutionModule makes interface drift a compile error.
+contract MockUnorderedExecutionModule is IUnorderedExecutionModule {
+    error UnorderedExecutionModule_ModuleNotEnabled();
+    error UnorderedExecutionModule_HashOnceTooSmall();
+    error UnorderedExecutionModule_HashOnceAlreadyUsed();
+    error UnorderedExecutionModule_UnsupportedSafe();
+    error UnorderedExecutionModule_ExecutionFailed(bytes);
+
+    event TransactionExecuted(address indexed safe, bytes32 indexed txHash, uint256 indexed hashOnce);
+
+    mapping(address => mapping(uint256 => bool)) internal _executed;
+
+    function executed(address _safe, uint256 _hashOnce) public view returns (bool executed_) {
+        executed_ = _executed[_safe][_hashOnce];
+    }
+
+    function deriveHashOnce(string memory _input) public pure returns (uint256 hashOnce_) {
+        hashOnce_ = uint256(keccak256(bytes(_input)));
+    }
+
+    function transactionHash(address _safe, ExecTransactionParams memory _params, uint256 _hashOnce)
+        public
+        view
+        returns (bytes32 txHash_)
+    {
+        txHash_ = IGnosisSafe(_safe).getTransactionHash(
+            _params.to, _params.value, _params.data, _params.operation, 0, 0, 0, address(0), address(0), _hashOnce
+        );
+    }
+
+    function execute(
+        address _safe,
+        ExecTransactionParams calldata _params,
+        uint256 _hashOnce,
+        bytes calldata _signatures
+    ) external returns (bytes memory returnData_) {
+        if (!IGnosisSafe(_safe).isModuleEnabled(address(this))) {
+            revert UnorderedExecutionModule_ModuleNotEnabled();
+        }
+
+        if (_hashOnce <= type(uint128).max) {
+            revert UnorderedExecutionModule_HashOnceTooSmall();
+        }
+
+        if (_executed[_safe][_hashOnce]) {
+            revert UnorderedExecutionModule_HashOnceAlreadyUsed();
+        }
+
+        bytes32 txHash = transactionHash(_safe, _params, _hashOnce);
+        bytes memory txHashData = _encodeTransactionData(_safe, _params, _hashOnce);
+
+        if (keccak256(txHashData) != txHash) {
+            revert UnorderedExecutionModule_UnsupportedSafe();
+        }
+
+        IGnosisSafe(_safe).checkSignatures(txHash, txHashData, _signatures);
+
+        _executed[_safe][_hashOnce] = true;
+
+        bool success;
+        (success, returnData_) = IGnosisSafe(_safe).execTransactionFromModuleReturnData(
+            _params.to, _params.value, _params.data, _params.operation
+        );
+
+        if (!success) {
+            revert UnorderedExecutionModule_ExecutionFailed(returnData_);
+        }
+
+        emit TransactionExecuted(_safe, txHash, _hashOnce);
+    }
+
+    function _encodeTransactionData(address _safe, ExecTransactionParams memory _params, uint256 _hashOnce)
+        internal
+        view
+        returns (bytes memory txHashData_)
+    {
+        txHashData_ = IGnosisSafe(_safe).encodeTransactionData(
+            _params.to, _params.value, _params.data, _params.operation, 0, 0, 0, address(0), address(0), _hashOnce
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tasks that set `hashOnceInput` in their `config.toml` become **nonceless**: every safe in the task signs with a hash-once value (the module's canonical `deriveHashOnce` of that string) in the nonce slot instead of a pinned nonce, and execution routes through the `UnorderedExecutionModule` (`hashOnceModule` in config, must be enabled on every safe) instead of `execTransaction`. Signatures survive nonce drift and task renumbering; replay protection is per `(safe, hashOnce)` on the module. Nonce-based tasks are completely unchanged, and templates need no modifications.

Details:
- `MultisigTask`: detection, hash-once nonce sourcing (nonce state overrides rejected), module execution routing, consumed-value pre-check with a clear error, validation asserts the hash-once value was consumed instead of nonce+1, sibling data-to-sign branch. Tenderly payload and op-txverify links are skipped for nonceless tasks (module-aware variants can come later).
- `GnosisSafeHashes`: builds the EIP-712 encoding locally for Safe >=1.5.0, which removed `encodeTransactionData()`.
- `OPCMTaskBase`: nonceless tasks expect zero root-safe state diffs (module execution touches neither nonce nor storage).
- Module contract: [ethereum-optimism/optimism#22675](https://github.com/ethereum-optimism/optimism/pull/22675), deployed and verified on Sepolia at `0xADcbCff796a47D468fE8C0252FBe8d856d4e63D7`.

Executed on Sepolia against fresh Safe v1.5.0 instances with the module enabled:
- `sep/105-nonceless-welcome` — single safe; task was renumbered after signing with no effect on the signature.
- `sep/106-nonceless-nested-welcome` / `sep/107-nonceless-nested-fresh` — nested: child approval and root execution both via the module; no safe nonce moved at any step.

New tests cover drift invariance (single + nested), replay rejection, and config validation; the full regression suite passes unchanged.

Part of the San Diego hackathon nonceless (hash-once) Safe execution project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)