### PR TITLE
feat: move Superchain task validation into templates

### DIFF
--- a/src/justfile
+++ b/src/justfile
@@ -150,7 +150,7 @@ sign-stack NETWORK="" TASK="" CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2
     show_usage() {
         echo
         echo "Usage: just sign-stack <network> <task> [child-safe-name-depth-1] [child-safe-name-depth-2]"
-        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE"
+        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE, KEYSTORE_PATH"
         echo "Example: just sign-stack eth rehearsals/2025-01-08-R1-welcome  # Rehearsal task"
     }
 
@@ -286,14 +286,27 @@ simulate CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     ETH_RPC_URL=$("$root_dir"/src/script/get-rpc-url.sh "$network")
     HD_PATH=${HD_PATH:-0}
 
+    # Get fork block arguments
+    fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
+
+    execution_mode=$(yq '.executionMode // "safe"' ${config_path})
+    if [ "$execution_mode" = "owner" ]; then
+        echo "Simulating direct owner task"
+        forge script ${script_name} \
+          --sig "simulateOwner(string)" \
+          ${config_path} \
+          --fork-url ${ETH_RPC_URL} \
+          --fork-retries {{forge_fork_retries}} \
+          --fork-retry-backoff {{forge_fork_retry_backoff}} \
+          ${fork_block_args}
+        exit 0
+    fi
+
     # Get function signature and arguments using helper
     eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
     
     # Configure signer for simulation
     signer=$(just --justfile "$root_just_file" _get-simulation-signer "$config_path" "$ETH_RPC_URL" "$child_safe_depth_1" "$child_safe_depth_2")
-    
-    # Get fork block arguments
-    fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
     
     echo -e "⏳ Simulating task: $task_name for network: '$network' on $target_safe\n"
     forge script ${script_name} --sig "$sig" "${args[@]}" --ffi --fork-url $ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} --sender ${signer} ${fork_block_args}
@@ -311,7 +324,7 @@ sign CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     show_usage() {
         echo
         echo "Usage: just sign [child-safe-name-depth-1] [child-safe-name-depth-2]"
-        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE"
+        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE, KEYSTORE_PATH"
     }
 
     # Set test directory if running test task  
@@ -324,13 +337,26 @@ sign CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     HD_PATH=${HD_PATH:-0}
     USE_KEYSTORE=${USE_KEYSTORE:-}
     
-    # Get function signature and arguments using helper
-    eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
-    
     # Get signer address and arguments using helper function
     signer_info=$(just --justfile "$root_just_file" _get-signer-args "$HD_PATH" "$USE_KEYSTORE")
     signer=$(echo "$signer_info" | sed -n '1p')
     signer_args=$(echo "$signer_info" | sed -n '2p')
+
+    execution_mode=$(yq '.executionMode // "safe"' ${config_path})
+    if [ "$execution_mode" = "owner" ]; then
+        forge script ${script_name} \
+          --sig "validateOwner(string,address)" \
+          ${config_path} \
+          ${signer} \
+          --fork-url ${ETH_RPC_URL} \
+          --fork-retries {{forge_fork_retries}} \
+          --fork-retry-backoff {{forge_fork_retry_backoff}}
+        echo "Selected signer is the SystemConfig owner; no separate Safe signature is required."
+        exit 0
+    fi
+
+    # Get function signature and arguments using helper
+    eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
     
     # Validate that signer is an owner on the target safe
     echo "Validating signer is an owner on the safe..."
@@ -416,6 +442,22 @@ execute:
   sender=$(echo "$signer_info" | sed -n '1p')
   signer_args=$(echo "$signer_info" | sed -n '2p')
   echo "Executing with sender: ${sender}"
+
+  execution_mode=$(yq '.executionMode // "safe"' ${config_path})
+  if [ "$execution_mode" = "owner" ]; then
+    forge build
+    forge script ${script_name} \
+      --fork-url ${ETH_RPC_URL} \
+      --fork-retries {{forge_fork_retries}} \
+      --fork-retry-backoff {{forge_fork_retry_backoff}} \
+      --broadcast \
+      --sender ${sender} \
+      --sig "executeOwner(string,address)" \
+      ${signer_args} \
+      ${config_path} \
+      ${sender}
+    exit 0
+  fi
 
   forge build
   forge script ${script_name} \
@@ -521,13 +563,17 @@ _get-simulation-signer CONFIG_PATH ETH_RPC_URL CHILD_SAFE_DEPTH_1 CHILD_SAFE_DEP
 _get-keystore-private-key:
     #!/usr/bin/env bash
     set -euo pipefail
-    
-    echo "Enter your foundry keystore path (e.g. ~/.foundry/keystores/sep-test-private-key):" >&2
-    keystorePath=$(cd ~/.foundry/keystores/ && fzf --header="Searching your keystore in $PWD" --prompt="Keystore for signing:")
-    
-    echo "Keystore path: ${keystorePath}" >&2
-    full_keystore_path="$HOME/.foundry/keystores/${keystorePath}"
-    signer_private_key=$(cast wallet pk --keystore ${full_keystore_path})
+
+    if [ -n "${KEYSTORE_PATH:-}" ]; then
+        full_keystore_path="$KEYSTORE_PATH"
+    else
+        echo "Enter your foundry keystore path (e.g. ~/.foundry/keystores/sep-test-private-key):" >&2
+        keystore_name=$(cd "$HOME/.foundry/keystores/" && fzf --header="Searching your keystore in $PWD" --prompt="Keystore for signing:")
+        full_keystore_path="$HOME/.foundry/keystores/${keystore_name}"
+    fi
+
+    echo "Keystore path: ${full_keystore_path}" >&2
+    signer_private_key=$(cast wallet pk --keystore "${full_keystore_path}")
     sender=$(cast wallet address --private-key ${signer_private_key})
     echo "Signing with the signer: ${sender}" >&2
     if [ -z "${signer_private_key}" ]; then

--- a/src/justfile
+++ b/src/justfile
@@ -150,7 +150,7 @@ sign-stack NETWORK="" TASK="" CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2
     show_usage() {
         echo
         echo "Usage: just sign-stack <network> <task> [child-safe-name-depth-1] [child-safe-name-depth-2]"
-        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE, KEYSTORE_PATH"
+        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE"
         echo "Example: just sign-stack eth rehearsals/2025-01-08-R1-welcome  # Rehearsal task"
     }
 
@@ -286,27 +286,14 @@ simulate CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     ETH_RPC_URL=$("$root_dir"/src/script/get-rpc-url.sh "$network")
     HD_PATH=${HD_PATH:-0}
 
-    # Get fork block arguments
-    fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
-
-    execution_mode=$(yq '.executionMode // "safe"' ${config_path})
-    if [ "$execution_mode" = "owner" ]; then
-        echo "Simulating direct owner task"
-        forge script ${script_name} \
-          --sig "simulateOwner(string)" \
-          ${config_path} \
-          --fork-url ${ETH_RPC_URL} \
-          --fork-retries {{forge_fork_retries}} \
-          --fork-retry-backoff {{forge_fork_retry_backoff}} \
-          ${fork_block_args}
-        exit 0
-    fi
-
     # Get function signature and arguments using helper
     eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
     
     # Configure signer for simulation
     signer=$(just --justfile "$root_just_file" _get-simulation-signer "$config_path" "$ETH_RPC_URL" "$child_safe_depth_1" "$child_safe_depth_2")
+    
+    # Get fork block arguments
+    fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
     
     echo -e "⏳ Simulating task: $task_name for network: '$network' on $target_safe\n"
     forge script ${script_name} --sig "$sig" "${args[@]}" --ffi --fork-url $ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} --sender ${signer} ${fork_block_args}
@@ -324,7 +311,7 @@ sign CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     show_usage() {
         echo
         echo "Usage: just sign [child-safe-name-depth-1] [child-safe-name-depth-2]"
-        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE, KEYSTORE_PATH"
+        echo "Environment: HD_PATH (default: 0), USE_KEYSTORE"
     }
 
     # Set test directory if running test task  
@@ -337,26 +324,13 @@ sign CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     HD_PATH=${HD_PATH:-0}
     USE_KEYSTORE=${USE_KEYSTORE:-}
     
+    # Get function signature and arguments using helper
+    eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
+    
     # Get signer address and arguments using helper function
     signer_info=$(just --justfile "$root_just_file" _get-signer-args "$HD_PATH" "$USE_KEYSTORE")
     signer=$(echo "$signer_info" | sed -n '1p')
     signer_args=$(echo "$signer_info" | sed -n '2p')
-
-    execution_mode=$(yq '.executionMode // "safe"' ${config_path})
-    if [ "$execution_mode" = "owner" ]; then
-        forge script ${script_name} \
-          --sig "validateOwner(string,address)" \
-          ${config_path} \
-          ${signer} \
-          --fork-url ${ETH_RPC_URL} \
-          --fork-retries {{forge_fork_retries}} \
-          --fork-retry-backoff {{forge_fork_retry_backoff}}
-        echo "Selected signer is the SystemConfig owner; no separate Safe signature is required."
-        exit 0
-    fi
-
-    # Get function signature and arguments using helper
-    eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
     
     # Validate that signer is an owner on the target safe
     echo "Validating signer is an owner on the safe..."
@@ -442,22 +416,6 @@ execute:
   sender=$(echo "$signer_info" | sed -n '1p')
   signer_args=$(echo "$signer_info" | sed -n '2p')
   echo "Executing with sender: ${sender}"
-
-  execution_mode=$(yq '.executionMode // "safe"' ${config_path})
-  if [ "$execution_mode" = "owner" ]; then
-    forge build
-    forge script ${script_name} \
-      --fork-url ${ETH_RPC_URL} \
-      --fork-retries {{forge_fork_retries}} \
-      --fork-retry-backoff {{forge_fork_retry_backoff}} \
-      --broadcast \
-      --sender ${sender} \
-      --sig "executeOwner(string,address)" \
-      ${signer_args} \
-      ${config_path} \
-      ${sender}
-    exit 0
-  fi
 
   forge build
   forge script ${script_name} \
@@ -563,17 +521,13 @@ _get-simulation-signer CONFIG_PATH ETH_RPC_URL CHILD_SAFE_DEPTH_1 CHILD_SAFE_DEP
 _get-keystore-private-key:
     #!/usr/bin/env bash
     set -euo pipefail
-
-    if [ -n "${KEYSTORE_PATH:-}" ]; then
-        full_keystore_path="$KEYSTORE_PATH"
-    else
-        echo "Enter your foundry keystore path (e.g. ~/.foundry/keystores/sep-test-private-key):" >&2
-        keystore_name=$(cd "$HOME/.foundry/keystores/" && fzf --header="Searching your keystore in $PWD" --prompt="Keystore for signing:")
-        full_keystore_path="$HOME/.foundry/keystores/${keystore_name}"
-    fi
-
-    echo "Keystore path: ${full_keystore_path}" >&2
-    signer_private_key=$(cast wallet pk --keystore "${full_keystore_path}")
+    
+    echo "Enter your foundry keystore path (e.g. ~/.foundry/keystores/sep-test-private-key):" >&2
+    keystorePath=$(cd ~/.foundry/keystores/ && fzf --header="Searching your keystore in $PWD" --prompt="Keystore for signing:")
+    
+    echo "Keystore path: ${keystorePath}" >&2
+    full_keystore_path="$HOME/.foundry/keystores/${keystorePath}"
+    signer_private_key=$(cast wallet pk --keystore ${full_keystore_path})
     sender=$(cast wallet address --private-key ${signer_private_key})
     echo "Signing with the signer: ${sender}" >&2
     if [ -z "${signer_private_key}" ]; then

--- a/src/template/AddGameTypeTemplate.sol
+++ b/src/template/AddGameTypeTemplate.sol
@@ -66,6 +66,18 @@ contract AddGameTypeTemplate is OPCMTaskBase {
             cfg[configs[i].chainId] = configs[i];
         }
 
+        SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            require(cfg[chainId].chainId != 0, "AddGameType: Config not found for chain");
+            address registryFactory = superchainAddrRegistry.getAddress("DisputeGameFactoryProxy", chainId);
+            address systemConfigFactory = cfg[chainId].systemConfig.disputeGameFactory();
+            _requireMatchingDisputeGameFactory(systemConfigFactory, registryFactory);
+            _requireGameTypeUnregistered(
+                IDisputeGameFactoryU18(systemConfigFactory).gameImpls(cfg[chainId].disputeGameType)
+            );
+        }
+
         // Load OPCM address.
         OPCM = tomlContent.readAddress(".addresses.OPCM");
         require(OPCM != address(0), "OPCM not set");
@@ -83,9 +95,6 @@ contract AddGameTypeTemplate is OPCMTaskBase {
         IOPContractsManagerU18.AddGameInput[] memory configs = new IOPContractsManagerU18.AddGameInput[](chains.length);
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
-
-            // Validate that configuration exists for this chain
-            require(cfg[chainId].chainId != 0, "AddGameType: Config not found for chain");
 
             // Validate critical addresses are non-zero
             require(address(cfg[chainId].delayedWETH) != address(0), "AddGameType: delayedWETH is zero address");
@@ -155,6 +164,14 @@ contract AddGameTypeTemplate is OPCMTaskBase {
 
     /// @notice Override to return a list of addresses that should not be checked for code length.
     function _getCodeExceptions() internal view virtual override returns (address[] memory) {}
+
+    function _requireGameTypeUnregistered(address implementation) internal pure {
+        require(implementation == address(0), "AddGameType: Game type already registered");
+    }
+
+    function _requireMatchingDisputeGameFactory(address actual, address expected) internal pure {
+        require(actual == expected, "AddGameType: DisputeGameFactory mismatch");
+    }
 
     /// @notice Converts the AddGameInputWithChainId struct to the AddGameInput struct.
     function _toAddGameInput(AddGameInputWithChainId memory _input)

--- a/src/template/OPCMUpgradeV700.sol
+++ b/src/template/OPCMUpgradeV700.sol
@@ -88,7 +88,6 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         Claim cannonKonaPrestate;
         Claim cannonPrestate;
         uint256 chainId;
-        string expectedValidationErrors;
         uint256 initBond;
         uint32 startingRespectedGameType;
     }
@@ -194,7 +193,7 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         require(chains.length > 0, "OPCMUpgradeV700: no chains configured");
 
         // Decode `[[opcmUpgrades]]` rows.
-        OPCMUpgrade[] memory parsed = abi.decode(toml.parseRaw(".opcmUpgrades"), (OPCMUpgrade[]));
+        OPCMUpgrade[] memory parsed = _parseUpgrades(toml);
         require(parsed.length == chains.length, "OPCMUpgradeV700: opcmUpgrades length mismatch");
         for (uint256 i = 0; i < parsed.length; i++) {
             require(parsed[i].chainId != 0, "OPCMUpgradeV700: chainId zero");
@@ -241,6 +240,71 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
         require(address(STANDARD_VALIDATOR) != address(0), "OPCMUpgradeV700: validator zero");
         require(address(STANDARD_VALIDATOR).code.length > 0, "OPCMUpgradeV700: validator has no code");
         vm.label(address(STANDARD_VALIDATOR), "OPCMStandardValidator");
+
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            _validateContractRelationships(
+                superchainAddrRegistry.getAddress("SystemConfigProxy", chainId),
+                superchainAddrRegistry.getAddress("SuperchainConfig", chainId),
+                superchainAddrRegistry.getAddress("ProxyAdmin", chainId),
+                superchainAddrRegistry.getAddress("ProxyAdminOwner", chainId),
+                superchainAddrRegistry.getAddress("DisputeGameFactoryProxy", chainId),
+                rootSafe
+            );
+        }
+    }
+
+    function _validateContractRelationships(
+        address systemConfig,
+        address superchainConfig,
+        address proxyAdmin,
+        address proxyAdminOwner,
+        address disputeGameFactory,
+        address rootSafe
+    ) internal view {
+        ISystemConfig sysCfg = ISystemConfig(systemConfig);
+        require(rootSafe == proxyAdminOwner, "OPCMUpgradeV700: root safe is not ProxyAdminOwner");
+        require(
+            IOptimismPortal(sysCfg.optimismPortal()).superchainConfig() == superchainConfig,
+            "OPCMUpgradeV700: OptimismPortal SuperchainConfig mismatch"
+        );
+        require(
+            IProxyAdmin(proxyAdmin).getProxyAdmin(payable(systemConfig)) == proxyAdmin,
+            "OPCMUpgradeV700: SystemConfig ProxyAdmin mismatch"
+        );
+        require(
+            sysCfg.disputeGameFactory() == disputeGameFactory,
+            "OPCMUpgradeV700: SystemConfig DisputeGameFactory mismatch"
+        );
+        require(IProxyAdmin(proxyAdmin).owner() == proxyAdminOwner, "OPCMUpgradeV700: ProxyAdmin owner mismatch");
+        require(
+            IDisputeGameFactory(disputeGameFactory).owner() == proxyAdminOwner,
+            "OPCMUpgradeV700: DisputeGameFactory owner mismatch"
+        );
+    }
+
+    function _parseUpgrades(string memory toml) internal view returns (OPCMUpgrade[] memory parsed) {
+        uint256 count;
+        while (toml.keyExists(string.concat(".opcmUpgrades[", vm.toString(count), "].chainId"))) {
+            count++;
+        }
+
+        parsed = new OPCMUpgrade[](count);
+        for (uint256 i = 0; i < count; i++) {
+            string memory base = string.concat(".opcmUpgrades[", vm.toString(i), "]");
+            uint256 startingRespectedGameType = toml.readUint(string.concat(base, ".startingRespectedGameType"));
+            require(
+                startingRespectedGameType <= type(uint32).max,
+                "OPCMUpgradeV700: startingRespectedGameType exceeds uint32"
+            );
+            parsed[i] = OPCMUpgrade({
+                cannonKonaPrestate: Claim.wrap(toml.readBytes32(string.concat(base, ".cannonKonaPrestate"))),
+                cannonPrestate: Claim.wrap(toml.readBytes32(string.concat(base, ".cannonPrestate"))),
+                chainId: toml.readUint(string.concat(base, ".chainId")),
+                initBond: toml.readUint(string.concat(base, ".initBond")),
+                startingRespectedGameType: uint32(startingRespectedGameType)
+            });
+        }
     }
 
     /* ---------- DisputeGameConfig builders ---------- */
@@ -494,9 +558,35 @@ contract OPCMUpgradeV700 is OPCMTaskBase {
                 errors = STANDARD_VALIDATOR.validate({_input: input, _allowFailure: true});
             }
 
-            string memory expected = upgrades[chainId].expectedValidationErrors;
+            string memory expected = _expectedValidationErrors({
+                l1PAOOverride: l1PAOOverride != address(0),
+                challengerOverride: challengerOverride != address(0),
+                superchainConfigMismatch: superchainAddrRegistry.getAddress("SuperchainConfig", chainId)
+                    != STANDARD_VALIDATOR.superchainConfig(),
+                targetGameType: upgrades[chainId].startingRespectedGameType
+            });
             require(errors.eq(expected), string.concat("Unexpected errors: ", errors, "; expected: ", expected));
         }
+    }
+
+    function _expectedValidationErrors(
+        bool l1PAOOverride,
+        bool challengerOverride,
+        bool superchainConfigMismatch,
+        uint32 targetGameType
+    ) internal pure returns (string memory errors) {
+        if (l1PAOOverride) errors = _appendValidationError(errors, "OVERRIDES-L1PAOMULTISIG");
+        if (challengerOverride) errors = _appendValidationError(errors, "OVERRIDES-CHALLENGER");
+        if (superchainConfigMismatch) errors = _appendValidationError(errors, "SYSCON-130");
+        if (targetGameType == PERMISSIONED_CANNON) {
+            errors = _appendValidationError(errors, "CKDG-NOSHAPE");
+        }
+        errors = _appendValidationError(errors, "PLDG-10");
+        if (targetGameType == PERMISSIONED_CANNON) errors = _appendValidationError(errors, "CKDG-10");
+    }
+
+    function _appendValidationError(string memory errors, string memory next) private pure returns (string memory) {
+        return bytes(errors).length == 0 ? next : string.concat(errors, ",", next);
     }
 
     /// @notice Code-length exceptions for storage values written by the upgrade.
@@ -595,13 +685,24 @@ interface IOPContractsManagerStandardValidator {
     ) external view returns (string memory);
     function l1PAOMultisig() external view returns (address);
     function challenger() external view returns (address);
+    function superchainConfig() external view returns (address);
     function version() external view returns (string memory);
 }
 
 interface ISuperchainConfig {}
 
+interface IProxyAdmin {
+    function owner() external view returns (address);
+    function getProxyAdmin(address payable proxy) external view returns (address);
+}
+
+interface IOptimismPortal {
+    function superchainConfig() external view returns (address);
+}
+
 interface IDisputeGameFactory {
     function gameImpls(GameType gameType) external view returns (address);
+    function owner() external view returns (address);
 }
 
 interface ISystemConfig {
@@ -616,4 +717,6 @@ interface ISystemConfig {
     }
 
     function getAddresses() external view returns (Addresses memory);
+    function disputeGameFactory() external view returns (address);
+    function optimismPortal() external view returns (address);
 }

--- a/src/template/SetBatcherAndOrSigner.sol
+++ b/src/template/SetBatcherAndOrSigner.sol
@@ -13,10 +13,11 @@ interface ISystemConfig {
     function setUnsafeBlockSigner(address _unsafeBlockSigner) external;
     function batcherHash() external view returns (bytes32);
     function unsafeBlockSigner() external view returns (address);
+    function owner() external view returns (address);
 }
 
 /// @notice Template for updating the batcher hash and unsafe block signer on SystemConfig.
-/// Both calls are batched into a single Multicall3 transaction from the SystemConfig owner.
+/// Requested calls are batched into a single Multicall3 transaction from the SystemConfig owner.
 contract SetBatcherAndOrSigner is L2TaskBase {
     using stdToml for string;
 
@@ -25,7 +26,7 @@ contract SetBatcherAndOrSigner is L2TaskBase {
         bytes32 batcherHash;
         address unsafeBlockSigner;
         bool updateBatcher;
-        bool updateSigner;
+        bool updateUnsafeBlockSigner;
     }
 
     /// @notice Mapping of chain ID to configuration for the task.
@@ -51,30 +52,54 @@ contract SetBatcherAndOrSigner is L2TaskBase {
         string memory tomlContent = vm.readFile(_taskConfigFilePath);
         SuperchainAddressRegistry.ChainInfo[] memory _chains = superchainAddrRegistry.getChains();
 
-        address batcherAddress = tomlContent.readAddress(".sequencerConfig.batcherAddress");
-        address unsafeBlockSigner = tomlContent.readAddress(".sequencerConfig.unsafeBlockSigner");
-        require(batcherAddress != address(0), "SetBatcherAndOrSigner: batcherAddress is zero address");
-        require(unsafeBlockSigner != address(0), "SetBatcherAndOrSigner: unsafeBlockSigner is zero address");
-        bytes32 batcherHash = bytes32(uint256(uint160(batcherAddress)));
+        address requestedBatcher = tomlContent.readAddress(".sequencerConfig.batcherAddress");
+        address requestedUnsafeBlockSigner = tomlContent.readAddress(".sequencerConfig.unsafeBlockSigner");
+        bool hasUpdateBatcher = tomlContent.keyExists(".sequencerConfig.updateBatcher");
+        bool hasUpdateUnsafeBlockSigner = tomlContent.keyExists(".sequencerConfig.updateUnsafeBlockSigner");
+        require(
+            hasUpdateBatcher == hasUpdateUnsafeBlockSigner, "SetBatcherAndOrSigner: both update flags must be provided"
+        );
+        bool configuredUpdateBatcher = hasUpdateBatcher && tomlContent.readBool(".sequencerConfig.updateBatcher");
+        bool configuredUpdateUnsafeBlockSigner =
+            hasUpdateUnsafeBlockSigner && tomlContent.readBool(".sequencerConfig.updateUnsafeBlockSigner");
+        if (hasUpdateBatcher) {
+            _requireRequestedUpdate(configuredUpdateBatcher, configuredUpdateUnsafeBlockSigner);
+        }
 
         for (uint256 i = 0; i < _chains.length; i++) {
             uint256 chainId = _chains[i].chainId;
             ISystemConfig systemConfig = ISystemConfig(superchainAddrRegistry.getAddress("SystemConfigProxy", chainId));
-            bool updateBatcher = batcherHash != systemConfig.batcherHash();
-            bool updateSigner = unsafeBlockSigner != systemConfig.unsafeBlockSigner();
+            _requireRootSafe(_rootSafe, systemConfig.owner());
+
+            address currentBatcher = _decodeBatcherAddress(systemConfig.batcherHash());
+            address currentUnsafeBlockSigner = systemConfig.unsafeBlockSigner();
+            address batcherAddress =
+                _resolveTarget(requestedBatcher, hasUpdateBatcher ? configuredUpdateBatcher : true, currentBatcher);
+            address unsafeBlockSigner = _resolveTarget(
+                requestedUnsafeBlockSigner,
+                hasUpdateUnsafeBlockSigner ? configuredUpdateUnsafeBlockSigner : true,
+                currentUnsafeBlockSigner
+            );
+            bool updateBatcher = hasUpdateBatcher ? configuredUpdateBatcher : batcherAddress != currentBatcher;
+            bool updateUnsafeBlockSigner = hasUpdateUnsafeBlockSigner
+                ? configuredUpdateUnsafeBlockSigner
+                : unsafeBlockSigner != currentUnsafeBlockSigner;
+            bytes32 batcherHash = bytes32(uint256(uint160(batcherAddress)));
             require(
-                updateBatcher || updateSigner, "SetBatcherAndOrSigner: no-op (both fields already match current values)"
+                (updateBatcher && batcherAddress != currentBatcher)
+                    || (updateUnsafeBlockSigner && unsafeBlockSigner != currentUnsafeBlockSigner),
+                "SetBatcherAndOrSigner: no-op (requested fields already match current values)"
             );
             cfg[chainId] = TaskInputs({
                 batcherHash: batcherHash,
                 unsafeBlockSigner: unsafeBlockSigner,
                 updateBatcher: updateBatcher,
-                updateSigner: updateSigner
+                updateUnsafeBlockSigner: updateUnsafeBlockSigner
             });
         }
     }
 
-    /// @notice Builds the batched transaction, calling only the setters for fields that actually change.
+    /// @notice Builds the batched transaction, calling only the requested setters.
     function _build(address) internal override {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
@@ -84,7 +109,7 @@ contract SetBatcherAndOrSigner is L2TaskBase {
             if (taskInput.updateBatcher) {
                 ISystemConfig(systemConfigProxy).setBatcherHash(taskInput.batcherHash);
             }
-            if (taskInput.updateSigner) {
+            if (taskInput.updateUnsafeBlockSigner) {
                 ISystemConfig(systemConfigProxy).setUnsafeBlockSigner(taskInput.unsafeBlockSigner);
             }
         }
@@ -119,5 +144,26 @@ contract SetBatcherAndOrSigner is L2TaskBase {
             exceptions[i * 2 + 1] = taskInput.unsafeBlockSigner;
         }
         return exceptions;
+    }
+
+    function _resolveTarget(address requested, bool updateRequested, address current) internal pure returns (address) {
+        if (!updateRequested) return current;
+        require(requested != address(0), "SetBatcherAndOrSigner: requested target is zero address");
+        return requested;
+    }
+
+    function _requireRequestedUpdate(bool updateBatcher, bool updateUnsafeBlockSigner) internal pure {
+        require(updateBatcher || updateUnsafeBlockSigner, "SetBatcherAndOrSigner: no update requested");
+    }
+
+    function _requireRootSafe(address rootSafe, address owner) internal pure {
+        require(rootSafe == owner, "SetBatcherAndOrSigner: root safe is not SystemConfig owner");
+    }
+
+    function _decodeBatcherAddress(bytes32 batcherHash) internal pure returns (address) {
+        require(uint256(batcherHash) >> 160 == 0, "SetBatcherAndOrSigner: batcher hash is not an address");
+        address batcher = address(uint160(uint256(batcherHash)));
+        require(batcher != address(0), "SetBatcherAndOrSigner: current batcher is zero address");
+        return batcher;
     }
 }

--- a/src/template/SetBatcherAndOrSigner.sol
+++ b/src/template/SetBatcherAndOrSigner.sol
@@ -13,7 +13,6 @@ interface ISystemConfig {
     function setUnsafeBlockSigner(address _unsafeBlockSigner) external;
     function batcherHash() external view returns (bytes32);
     function unsafeBlockSigner() external view returns (address);
-    function owner() external view returns (address);
 }
 
 /// @notice Template for updating the batcher hash and unsafe block signer on SystemConfig.
@@ -49,58 +48,7 @@ contract SetBatcherAndOrSigner is L2TaskBase {
     function _templateSetup(string memory _taskConfigFilePath, address _rootSafe) internal override {
         super._templateSetup(_taskConfigFilePath, _rootSafe);
 
-        _loadConfig(_taskConfigFilePath);
-    }
-
-    /// @notice Simulates the update when SystemConfig is directly owned by an EOA.
-    function simulateOwner(string memory taskConfigFilePath) public {
-        address owner = _setupOwnerExecution(taskConfigFilePath);
-        vm.startPrank(owner);
-        _setBatcherAndOrSigner();
-        vm.stopPrank();
-        _validateBatcherAndOrSigner();
-    }
-
-    /// @notice Checks that the selected signer is the direct SystemConfig owner.
-    function validateOwner(string memory taskConfigFilePath, address signer) public {
-        address owner = _setupOwnerExecution(taskConfigFilePath);
-        require(signer == owner, "SetBatcherAndOrSigner: signer is not SystemConfig owner");
-    }
-
-    /// @notice Broadcasts the update directly from the SystemConfig owner.
-    function executeOwner(string memory taskConfigFilePath, address signer) public {
-        address owner = _setupOwnerExecution(taskConfigFilePath);
-        require(signer == owner, "SetBatcherAndOrSigner: signer is not SystemConfig owner");
-
-        vm.startBroadcast(signer);
-        _setBatcherAndOrSigner();
-        vm.stopBroadcast();
-        _validateBatcherAndOrSigner();
-    }
-
-    function _setupOwnerExecution(string memory taskConfigFilePath) internal returns (address owner) {
-        superchainAddrRegistry = new SuperchainAddressRegistry(taskConfigFilePath);
-        _loadConfig(taskConfigFilePath);
-
-        SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
-        owner = superchainAddrRegistry.getAddress("SystemConfigOwner", chains[0].chainId);
-        require(owner.code.length == 0, "SetBatcherAndOrSigner: owner execution requires an EOA");
-        for (uint256 i = 0; i < chains.length; i++) {
-            address systemConfigProxy = superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId);
-            require(
-                ISystemConfig(systemConfigProxy).owner() == owner,
-                "SetBatcherAndOrSigner: configured owner is not SystemConfig owner"
-            );
-            if (i == 0) continue;
-            require(
-                superchainAddrRegistry.getAddress("SystemConfigOwner", chains[i].chainId) == owner,
-                "SetBatcherAndOrSigner: chains have different owners"
-            );
-        }
-    }
-
-    function _loadConfig(string memory taskConfigFilePath) internal {
-        string memory tomlContent = vm.readFile(taskConfigFilePath);
+        string memory tomlContent = vm.readFile(_taskConfigFilePath);
         SuperchainAddressRegistry.ChainInfo[] memory _chains = superchainAddrRegistry.getChains();
 
         address batcherAddress = tomlContent.readAddress(".sequencerConfig.batcherAddress");
@@ -128,10 +76,6 @@ contract SetBatcherAndOrSigner is L2TaskBase {
 
     /// @notice Builds the batched transaction, calling only the setters for fields that actually change.
     function _build(address) internal override {
-        _setBatcherAndOrSigner();
-    }
-
-    function _setBatcherAndOrSigner() internal {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
@@ -148,10 +92,6 @@ contract SetBatcherAndOrSigner is L2TaskBase {
 
     /// @notice Validates that the batcher hash and unsafe block signer were updated correctly.
     function _validate(VmSafe.AccountAccess[] memory, Action[] memory, address) internal view override {
-        _validateBatcherAndOrSigner();
-    }
-
-    function _validateBatcherAndOrSigner() internal view {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;

--- a/src/template/SetBatcherAndOrSigner.sol
+++ b/src/template/SetBatcherAndOrSigner.sol
@@ -13,6 +13,7 @@ interface ISystemConfig {
     function setUnsafeBlockSigner(address _unsafeBlockSigner) external;
     function batcherHash() external view returns (bytes32);
     function unsafeBlockSigner() external view returns (address);
+    function owner() external view returns (address);
 }
 
 /// @notice Template for updating the batcher hash and unsafe block signer on SystemConfig.
@@ -48,7 +49,58 @@ contract SetBatcherAndOrSigner is L2TaskBase {
     function _templateSetup(string memory _taskConfigFilePath, address _rootSafe) internal override {
         super._templateSetup(_taskConfigFilePath, _rootSafe);
 
-        string memory tomlContent = vm.readFile(_taskConfigFilePath);
+        _loadConfig(_taskConfigFilePath);
+    }
+
+    /// @notice Simulates the update when SystemConfig is directly owned by an EOA.
+    function simulateOwner(string memory taskConfigFilePath) public {
+        address owner = _setupOwnerExecution(taskConfigFilePath);
+        vm.startPrank(owner);
+        _setBatcherAndOrSigner();
+        vm.stopPrank();
+        _validateBatcherAndOrSigner();
+    }
+
+    /// @notice Checks that the selected signer is the direct SystemConfig owner.
+    function validateOwner(string memory taskConfigFilePath, address signer) public {
+        address owner = _setupOwnerExecution(taskConfigFilePath);
+        require(signer == owner, "SetBatcherAndOrSigner: signer is not SystemConfig owner");
+    }
+
+    /// @notice Broadcasts the update directly from the SystemConfig owner.
+    function executeOwner(string memory taskConfigFilePath, address signer) public {
+        address owner = _setupOwnerExecution(taskConfigFilePath);
+        require(signer == owner, "SetBatcherAndOrSigner: signer is not SystemConfig owner");
+
+        vm.startBroadcast(signer);
+        _setBatcherAndOrSigner();
+        vm.stopBroadcast();
+        _validateBatcherAndOrSigner();
+    }
+
+    function _setupOwnerExecution(string memory taskConfigFilePath) internal returns (address owner) {
+        superchainAddrRegistry = new SuperchainAddressRegistry(taskConfigFilePath);
+        _loadConfig(taskConfigFilePath);
+
+        SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
+        owner = superchainAddrRegistry.getAddress("SystemConfigOwner", chains[0].chainId);
+        require(owner.code.length == 0, "SetBatcherAndOrSigner: owner execution requires an EOA");
+        for (uint256 i = 0; i < chains.length; i++) {
+            address systemConfigProxy = superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId);
+            require(
+                ISystemConfig(systemConfigProxy).owner() == owner,
+                "SetBatcherAndOrSigner: configured owner is not SystemConfig owner"
+            );
+            if (i == 0) continue;
+            require(
+                superchainAddrRegistry.getAddress("SystemConfigOwner", chains[i].chainId) == owner,
+                "SetBatcherAndOrSigner: chains have different owners"
+            );
+        }
+    }
+
+    function _loadConfig(string memory taskConfigFilePath) internal {
+        string memory tomlContent = vm.readFile(taskConfigFilePath);
         SuperchainAddressRegistry.ChainInfo[] memory _chains = superchainAddrRegistry.getChains();
 
         address batcherAddress = tomlContent.readAddress(".sequencerConfig.batcherAddress");
@@ -76,6 +128,10 @@ contract SetBatcherAndOrSigner is L2TaskBase {
 
     /// @notice Builds the batched transaction, calling only the setters for fields that actually change.
     function _build(address) internal override {
+        _setBatcherAndOrSigner();
+    }
+
+    function _setBatcherAndOrSigner() internal {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
@@ -92,6 +148,10 @@ contract SetBatcherAndOrSigner is L2TaskBase {
 
     /// @notice Validates that the batcher hash and unsafe block signer were updated correctly.
     function _validate(VmSafe.AccountAccess[] memory, Action[] memory, address) internal view override {
+        _validateBatcherAndOrSigner();
+    }
+
+    function _validateBatcherAndOrSigner() internal view {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;

--- a/src/template/SetRespectedGameTypeTemplate.sol
+++ b/src/template/SetRespectedGameTypeTemplate.sol
@@ -25,7 +25,7 @@ contract SetRespectedGameTypeTemplate is L2TaskBase {
 
     /// @notice Execute as the Guardian safe (authorized on ASR).
     function safeAddressString() public pure override returns (string memory) {
-        return "GuardianSafe";
+        return "Guardian";
     }
 
     /// @notice Returns string identifiers for addresses that are expected to have their storage written to.
@@ -44,6 +44,19 @@ contract SetRespectedGameTypeTemplate is L2TaskBase {
         for (uint256 i = 0; i < configs.length; i++) {
             cfg[configs[i].chainId] = configs[i];
         }
+
+        SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
+        for (uint256 i = 0; i < chains.length; i++) {
+            uint256 chainId = chains[i].chainId;
+            require(cfg[chainId].chainId != 0, "SetRespectedGameType: Config not found for chain");
+            address asrAddress = superchainAddrRegistry.getAddress("AnchorStateRegistryProxy", chainId);
+            address guardian = IAnchorStateRegistry(asrAddress).superchainConfig().guardian();
+            _requireRootSafe(rootSafe, guardian);
+            address registryFactory = superchainAddrRegistry.getAddress("DisputeGameFactoryProxy", chainId);
+            address asrFactory = address(IAnchorStateRegistry(asrAddress).disputeGameFactory());
+            _requireMatchingDisputeGameFactory(asrFactory, registryFactory);
+            _requireGameTypeRegistered(IDisputeGameFactory(asrFactory).gameImpls(cfg[chainId].gameType));
+        }
     }
 
     /// @notice Write the calls that you want to execute for the task.
@@ -52,8 +65,6 @@ contract SetRespectedGameTypeTemplate is L2TaskBase {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
-            require(cfg[chainId].chainId != 0, "SetRespectedGameType: Config not found for chain");
-
             address asrAddress = superchainAddrRegistry.getAddress("AnchorStateRegistryProxy", chainId);
             IAnchorStateRegistry asr = IAnchorStateRegistry(asrAddress);
 
@@ -84,10 +95,32 @@ contract SetRespectedGameTypeTemplate is L2TaskBase {
     function _getCodeExceptions() internal pure override returns (address[] memory) {
         return new address[](0);
     }
+
+    function _requireGameTypeRegistered(address implementation) internal pure {
+        require(implementation != address(0), "SetRespectedGameType: Game implementation is zero address");
+    }
+
+    function _requireMatchingDisputeGameFactory(address actual, address expected) internal pure {
+        require(actual == expected, "SetRespectedGameType: DisputeGameFactory mismatch");
+    }
+
+    function _requireRootSafe(address rootSafe, address guardian) internal pure {
+        require(rootSafe == guardian, "SetRespectedGameType: root safe is not Guardian");
+    }
 }
 
 // Minimal local copy; only what this template needs.
 interface IAnchorStateRegistry {
+    function disputeGameFactory() external view returns (IDisputeGameFactory);
+    function superchainConfig() external view returns (ISuperchainConfigGuardian);
     function respectedGameType() external view returns (GameType);
     function setRespectedGameType(GameType _gameType) external;
+}
+
+interface ISuperchainConfigGuardian {
+    function guardian() external view returns (address);
+}
+
+interface IDisputeGameFactory {
+    function gameImpls(GameType gameType) external view returns (address);
 }

--- a/src/template/SystemConfigGasLimit.sol
+++ b/src/template/SystemConfigGasLimit.sol
@@ -10,7 +10,6 @@ import {Action} from "src/libraries/MultisigTypes.sol";
 interface ISystemConfig {
     function setGasLimit(uint64 _gasLimit) external;
     function gasLimit() external view returns (uint64);
-    function owner() external view returns (address);
 }
 
 /// @notice A template that sets ONLY the SystemConfig gas limit (no EIP-1559 params).
@@ -47,57 +46,6 @@ contract SystemConfigGasLimit is L2TaskBase {
     function _templateSetup(string memory taskConfigFilePath, address rootSafe) internal override {
         super._templateSetup(taskConfigFilePath, rootSafe);
 
-        _loadConfig(taskConfigFilePath);
-    }
-
-    /// @notice Simulates the gas-limit update when SystemConfig is directly owned by an EOA.
-    function simulateOwner(string memory taskConfigFilePath) public {
-        address owner = _setupOwnerExecution(taskConfigFilePath);
-        vm.startPrank(owner);
-        _setGasLimits();
-        vm.stopPrank();
-        _validateGasLimits();
-    }
-
-    /// @notice Checks that the selected signer is the direct SystemConfig owner.
-    function validateOwner(string memory taskConfigFilePath, address signer) public {
-        address owner = _setupOwnerExecution(taskConfigFilePath);
-        require(signer == owner, "SystemConfigGasLimit: signer is not SystemConfig owner");
-    }
-
-    /// @notice Broadcasts the gas-limit update directly from the SystemConfig owner.
-    function executeOwner(string memory taskConfigFilePath, address signer) public {
-        address owner = _setupOwnerExecution(taskConfigFilePath);
-        require(signer == owner, "SystemConfigGasLimit: signer is not SystemConfig owner");
-
-        vm.startBroadcast(signer);
-        _setGasLimits();
-        vm.stopBroadcast();
-        _validateGasLimits();
-    }
-
-    function _setupOwnerExecution(string memory taskConfigFilePath) internal returns (address owner) {
-        superchainAddrRegistry = new SuperchainAddressRegistry(taskConfigFilePath);
-        _loadConfig(taskConfigFilePath);
-
-        SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
-        owner = superchainAddrRegistry.getAddress("SystemConfigOwner", chains[0].chainId);
-        require(owner.code.length == 0, "SystemConfigGasLimit: owner execution requires an EOA");
-        for (uint256 i = 0; i < chains.length; i++) {
-            address systemConfigProxy = superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId);
-            require(
-                ISystemConfig(systemConfigProxy).owner() == owner,
-                "SystemConfigGasLimit: configured owner is not SystemConfig owner"
-            );
-            if (i == 0) continue;
-            require(
-                superchainAddrRegistry.getAddress("SystemConfigOwner", chains[i].chainId) == owner,
-                "SystemConfigGasLimit: chains have different owners"
-            );
-        }
-    }
-
-    function _loadConfig(string memory taskConfigFilePath) internal {
         string memory tomlContent = vm.readFile(taskConfigFilePath);
         SuperchainAddressRegistry.ChainInfo[] memory _chains = superchainAddrRegistry.getChains();
 
@@ -112,10 +60,6 @@ contract SystemConfigGasLimit is L2TaskBase {
 
     /// @notice Update the gas limit for the SystemConfig contract.
     function _build(address) internal override {
-        _setGasLimits();
-    }
-
-    function _setGasLimits() internal {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
@@ -126,10 +70,6 @@ contract SystemConfigGasLimit is L2TaskBase {
 
     /// @notice This method performs all validations and assertions that verify the calls executed as expected.
     function _validate(VmSafe.AccountAccess[] memory, Action[] memory, address) internal view override {
-        _validateGasLimits();
-    }
-
-    function _validateGasLimits() internal view {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;

--- a/src/template/SystemConfigGasLimit.sol
+++ b/src/template/SystemConfigGasLimit.sol
@@ -10,6 +10,9 @@ import {Action} from "src/libraries/MultisigTypes.sol";
 interface ISystemConfig {
     function setGasLimit(uint64 _gasLimit) external;
     function gasLimit() external view returns (uint64);
+    function minimumGasLimit() external view returns (uint64);
+    function maximumGasLimit() external view returns (uint64);
+    function owner() external view returns (address);
 }
 
 /// @notice A template that sets ONLY the SystemConfig gas limit (no EIP-1559 params).
@@ -50,11 +53,16 @@ contract SystemConfigGasLimit is L2TaskBase {
         SuperchainAddressRegistry.ChainInfo[] memory _chains = superchainAddrRegistry.getChains();
 
         // Read the gas limit from the cached TOML content.
-        uint64 gasLimit = uint64(vm.parseTomlUint(tomlContent, ".gasParams.gasLimit"));
+        uint256 configuredGasLimit = vm.parseTomlUint(tomlContent, ".gasParams.gasLimit");
+        uint64 gasLimit = _toUint64GasLimit(configuredGasLimit);
 
         // Set the configuration for each chain.
         for (uint256 i = 0; i < _chains.length; i++) {
-            cfg[_chains[i].chainId] = TaskInputs({gasLimit: gasLimit});
+            uint256 chainId = _chains[i].chainId;
+            ISystemConfig systemConfig = ISystemConfig(superchainAddrRegistry.getAddress("SystemConfigProxy", chainId));
+            _requireRootSafe(rootSafe, systemConfig.owner());
+            _requireValidGasLimit(gasLimit, systemConfig.minimumGasLimit(), systemConfig.maximumGasLimit());
+            cfg[chainId] = TaskInputs({gasLimit: gasLimit});
         }
     }
 
@@ -80,4 +88,18 @@ contract SystemConfigGasLimit is L2TaskBase {
 
     /// @notice Override to return a list of addresses that should not be checked for code length.
     function _getCodeExceptions() internal view virtual override returns (address[] memory) {}
+
+    function _requireValidGasLimit(uint64 gasLimit, uint64 minimum, uint64 maximum) internal pure {
+        require(gasLimit >= minimum, "SystemConfigGasLimit: gas limit below minimum");
+        require(gasLimit <= maximum, "SystemConfigGasLimit: gas limit above maximum");
+    }
+
+    function _toUint64GasLimit(uint256 gasLimit) internal pure returns (uint64) {
+        require(gasLimit <= type(uint64).max, "SystemConfigGasLimit: gas limit exceeds uint64");
+        return uint64(gasLimit);
+    }
+
+    function _requireRootSafe(address rootSafe, address owner) internal pure {
+        require(rootSafe == owner, "SystemConfigGasLimit: root safe is not SystemConfig owner");
+    }
 }

--- a/src/template/SystemConfigGasLimit.sol
+++ b/src/template/SystemConfigGasLimit.sol
@@ -10,6 +10,7 @@ import {Action} from "src/libraries/MultisigTypes.sol";
 interface ISystemConfig {
     function setGasLimit(uint64 _gasLimit) external;
     function gasLimit() external view returns (uint64);
+    function owner() external view returns (address);
 }
 
 /// @notice A template that sets ONLY the SystemConfig gas limit (no EIP-1559 params).
@@ -46,6 +47,57 @@ contract SystemConfigGasLimit is L2TaskBase {
     function _templateSetup(string memory taskConfigFilePath, address rootSafe) internal override {
         super._templateSetup(taskConfigFilePath, rootSafe);
 
+        _loadConfig(taskConfigFilePath);
+    }
+
+    /// @notice Simulates the gas-limit update when SystemConfig is directly owned by an EOA.
+    function simulateOwner(string memory taskConfigFilePath) public {
+        address owner = _setupOwnerExecution(taskConfigFilePath);
+        vm.startPrank(owner);
+        _setGasLimits();
+        vm.stopPrank();
+        _validateGasLimits();
+    }
+
+    /// @notice Checks that the selected signer is the direct SystemConfig owner.
+    function validateOwner(string memory taskConfigFilePath, address signer) public {
+        address owner = _setupOwnerExecution(taskConfigFilePath);
+        require(signer == owner, "SystemConfigGasLimit: signer is not SystemConfig owner");
+    }
+
+    /// @notice Broadcasts the gas-limit update directly from the SystemConfig owner.
+    function executeOwner(string memory taskConfigFilePath, address signer) public {
+        address owner = _setupOwnerExecution(taskConfigFilePath);
+        require(signer == owner, "SystemConfigGasLimit: signer is not SystemConfig owner");
+
+        vm.startBroadcast(signer);
+        _setGasLimits();
+        vm.stopBroadcast();
+        _validateGasLimits();
+    }
+
+    function _setupOwnerExecution(string memory taskConfigFilePath) internal returns (address owner) {
+        superchainAddrRegistry = new SuperchainAddressRegistry(taskConfigFilePath);
+        _loadConfig(taskConfigFilePath);
+
+        SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
+        owner = superchainAddrRegistry.getAddress("SystemConfigOwner", chains[0].chainId);
+        require(owner.code.length == 0, "SystemConfigGasLimit: owner execution requires an EOA");
+        for (uint256 i = 0; i < chains.length; i++) {
+            address systemConfigProxy = superchainAddrRegistry.getAddress("SystemConfigProxy", chains[i].chainId);
+            require(
+                ISystemConfig(systemConfigProxy).owner() == owner,
+                "SystemConfigGasLimit: configured owner is not SystemConfig owner"
+            );
+            if (i == 0) continue;
+            require(
+                superchainAddrRegistry.getAddress("SystemConfigOwner", chains[i].chainId) == owner,
+                "SystemConfigGasLimit: chains have different owners"
+            );
+        }
+    }
+
+    function _loadConfig(string memory taskConfigFilePath) internal {
         string memory tomlContent = vm.readFile(taskConfigFilePath);
         SuperchainAddressRegistry.ChainInfo[] memory _chains = superchainAddrRegistry.getChains();
 
@@ -60,6 +112,10 @@ contract SystemConfigGasLimit is L2TaskBase {
 
     /// @notice Update the gas limit for the SystemConfig contract.
     function _build(address) internal override {
+        _setGasLimits();
+    }
+
+    function _setGasLimits() internal {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;
@@ -70,6 +126,10 @@ contract SystemConfigGasLimit is L2TaskBase {
 
     /// @notice This method performs all validations and assertions that verify the calls executed as expected.
     function _validate(VmSafe.AccountAccess[] memory, Action[] memory, address) internal view override {
+        _validateGasLimits();
+    }
+
+    function _validateGasLimits() internal view {
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             uint256 chainId = chains[i].chainId;

--- a/test/template/SuperchainOpsPreconditions.t.sol
+++ b/test/template/SuperchainOpsPreconditions.t.sol
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+
+import {AddGameTypeTemplate} from "src/template/AddGameTypeTemplate.sol";
+import {SetRespectedGameTypeTemplate} from "src/template/SetRespectedGameTypeTemplate.sol";
+import {SetBatcherAndOrSigner} from "src/template/SetBatcherAndOrSigner.sol";
+import {SystemConfigGasLimit} from "src/template/SystemConfigGasLimit.sol";
+import {OPCMUpgradeV700} from "src/template/OPCMUpgradeV700.sol";
+import {SuperchainAddressRegistry} from "src/SuperchainAddressRegistry.sol";
+
+contract MockSystemConfigForSequencerUpdate {
+    bytes32 public batcherHash;
+    address public unsafeBlockSigner;
+    address public owner;
+
+    constructor(address batcher, address signer, address owner_) {
+        batcherHash = bytes32(uint256(uint160(batcher)));
+        unsafeBlockSigner = signer;
+        owner = owner_;
+    }
+}
+
+contract MockOptimismPortalForV700 {
+    address public superchainConfig;
+
+    constructor(address superchainConfig_) {
+        superchainConfig = superchainConfig_;
+    }
+}
+
+contract MockSystemConfigForV700 {
+    address public optimismPortal;
+    address public disputeGameFactory;
+
+    constructor(address optimismPortal_, address disputeGameFactory_) {
+        optimismPortal = optimismPortal_;
+        disputeGameFactory = disputeGameFactory_;
+    }
+}
+
+contract MockProxyAdminForV700 {
+    address public owner;
+    mapping(address => address) internal admins;
+
+    constructor(address owner_) {
+        owner = owner_;
+    }
+
+    function setProxyAdmin(address proxy, address admin) external {
+        admins[proxy] = admin;
+    }
+
+    function getProxyAdmin(address payable proxy) external view returns (address) {
+        return admins[proxy];
+    }
+}
+
+contract MockDisputeGameFactoryForV700 {
+    address public owner;
+
+    constructor(address owner_) {
+        owner = owner_;
+    }
+}
+
+contract AddGameTypeTemplateHarness is AddGameTypeTemplate {
+    function requireGameTypeUnregistered(address implementation) external pure {
+        _requireGameTypeUnregistered(implementation);
+    }
+
+    function requireMatchingDisputeGameFactory(address actual, address expected) external pure {
+        _requireMatchingDisputeGameFactory(actual, expected);
+    }
+}
+
+contract SetRespectedGameTypeTemplateHarness is SetRespectedGameTypeTemplate {
+    function requireGameTypeRegistered(address implementation) external pure {
+        _requireGameTypeRegistered(implementation);
+    }
+
+    function requireMatchingDisputeGameFactory(address actual, address expected) external pure {
+        _requireMatchingDisputeGameFactory(actual, expected);
+    }
+
+    function requireRootSafe(address rootSafe, address guardian) external pure {
+        _requireRootSafe(rootSafe, guardian);
+    }
+}
+
+contract SystemConfigGasLimitHarness is SystemConfigGasLimit {
+    function requireValidGasLimit(uint64 gasLimit, uint64 minimum, uint64 maximum) external pure {
+        _requireValidGasLimit(gasLimit, minimum, maximum);
+    }
+
+    function toUint64GasLimit(uint256 gasLimit) external pure returns (uint64) {
+        return _toUint64GasLimit(gasLimit);
+    }
+
+    function requireRootSafe(address rootSafe, address owner) external pure {
+        _requireRootSafe(rootSafe, owner);
+    }
+}
+
+contract SetBatcherAndOrSignerHarness is SetBatcherAndOrSigner {
+    function resolveTarget(address requested, bool updateRequested, address current) external pure returns (address) {
+        return _resolveTarget(requested, updateRequested, current);
+    }
+
+    function requireRequestedUpdate(bool updateBatcher, bool updateUnsafeBlockSigner) external pure {
+        _requireRequestedUpdate(updateBatcher, updateUnsafeBlockSigner);
+    }
+
+    function requireRootSafe(address rootSafe, address owner) external pure {
+        _requireRootSafe(rootSafe, owner);
+    }
+
+    function templateSetup(string memory configPath, address rootSafe) external {
+        superchainAddrRegistry = new SuperchainAddressRegistry(configPath);
+        _templateSetup(configPath, rootSafe);
+    }
+}
+
+contract OPCMUpgradeV700Harness is OPCMUpgradeV700 {
+    function validateContractRelationships(
+        address systemConfig,
+        address superchainConfig,
+        address proxyAdmin,
+        address proxyAdminOwner,
+        address disputeGameFactory,
+        address rootSafe
+    ) external view {
+        _validateContractRelationships(
+            systemConfig, superchainConfig, proxyAdmin, proxyAdminOwner, disputeGameFactory, rootSafe
+        );
+    }
+
+    function expectedValidationErrors(
+        bool l1PAOOverride,
+        bool challengerOverride,
+        bool superchainConfigMismatch,
+        uint32 targetGameType
+    ) external pure returns (string memory) {
+        return _expectedValidationErrors(l1PAOOverride, challengerOverride, superchainConfigMismatch, targetGameType);
+    }
+
+    function parseUpgrade(string memory toml)
+        external
+        view
+        returns (uint256 chainId, uint32 startingRespectedGameType)
+    {
+        OPCMUpgrade[] memory parsed = _parseUpgrades(toml);
+        return (parsed[0].chainId, parsed[0].startingRespectedGameType);
+    }
+}
+
+contract SuperchainOpsPreconditionsTest is Test {
+    AddGameTypeTemplateHarness internal addGameType = new AddGameTypeTemplateHarness();
+    SetRespectedGameTypeTemplateHarness internal setRespectedGameType = new SetRespectedGameTypeTemplateHarness();
+    SystemConfigGasLimitHarness internal systemConfigGasLimit = new SystemConfigGasLimitHarness();
+    SetBatcherAndOrSignerHarness internal setBatcherAndOrSigner = new SetBatcherAndOrSignerHarness();
+    OPCMUpgradeV700Harness internal opcmUpgradeV700 = new OPCMUpgradeV700Harness();
+
+    function testAddGameTypeRejectsRegisteredGameType() public {
+        vm.expectRevert("AddGameType: Game type already registered");
+        addGameType.requireGameTypeUnregistered(address(1));
+    }
+
+    function testAddGameTypeRejectsMismatchedDisputeGameFactory() public {
+        vm.expectRevert("AddGameType: DisputeGameFactory mismatch");
+        addGameType.requireMatchingDisputeGameFactory(address(1), address(2));
+    }
+
+    function testSetRespectedGameTypeRejectsUnregisteredGameType() public {
+        vm.expectRevert("SetRespectedGameType: Game implementation is zero address");
+        setRespectedGameType.requireGameTypeRegistered(address(0));
+    }
+
+    function testSetRespectedGameTypeRejectsMismatchedDisputeGameFactory() public {
+        vm.expectRevert("SetRespectedGameType: DisputeGameFactory mismatch");
+        setRespectedGameType.requireMatchingDisputeGameFactory(address(1), address(2));
+    }
+
+    function testSetRespectedGameTypeRejectsWrongRootSafe() public {
+        vm.expectRevert("SetRespectedGameType: root safe is not Guardian");
+        setRespectedGameType.requireRootSafe(address(1), address(2));
+    }
+
+    function testSystemConfigGasLimitRejectsGasLimitBelowMinimum() public {
+        vm.expectRevert("SystemConfigGasLimit: gas limit below minimum");
+        systemConfigGasLimit.requireValidGasLimit(29_999_999, 30_000_000, 60_000_000);
+    }
+
+    function testSystemConfigGasLimitRejectsGasLimitAboveMaximum() public {
+        vm.expectRevert("SystemConfigGasLimit: gas limit above maximum");
+        systemConfigGasLimit.requireValidGasLimit(60_000_001, 30_000_000, 60_000_000);
+    }
+
+    function testSystemConfigGasLimitAcceptsInclusiveBounds() public view {
+        systemConfigGasLimit.requireValidGasLimit(30_000_000, 30_000_000, 60_000_000);
+        systemConfigGasLimit.requireValidGasLimit(60_000_000, 30_000_000, 60_000_000);
+    }
+
+    function testSystemConfigGasLimitRejectsUint64Overflow() public {
+        vm.expectRevert("SystemConfigGasLimit: gas limit exceeds uint64");
+        systemConfigGasLimit.toUint64GasLimit(uint256(type(uint64).max) + 1);
+    }
+
+    function testSystemConfigGasLimitRejectsWrongRootSafe() public {
+        vm.expectRevert("SystemConfigGasLimit: root safe is not SystemConfig owner");
+        systemConfigGasLimit.requireRootSafe(address(1), address(2));
+    }
+
+    function testSetBatcherAndOrSignerResolvesOmittedTargetFromLiveState() public view {
+        assertEq(setBatcherAndOrSigner.resolveTarget(address(0), false, address(3)), address(3));
+    }
+
+    function testSetBatcherAndOrSignerUsesRequestedTarget() public view {
+        assertEq(setBatcherAndOrSigner.resolveTarget(address(2), true, address(3)), address(2));
+    }
+
+    function testSetBatcherAndOrSignerRejectsRequestedZeroTarget() public {
+        vm.expectRevert("SetBatcherAndOrSigner: requested target is zero address");
+        setBatcherAndOrSigner.resolveTarget(address(0), true, address(3));
+    }
+
+    function testSetBatcherAndOrSignerRejectsNoRequestedUpdates() public {
+        vm.expectRevert("SetBatcherAndOrSigner: no update requested");
+        setBatcherAndOrSigner.requireRequestedUpdate(false, false);
+    }
+
+    function testSetBatcherAndOrSignerRejectsWrongRootSafe() public {
+        vm.expectRevert("SetBatcherAndOrSigner: root safe is not SystemConfig owner");
+        setBatcherAndOrSigner.requireRootSafe(address(1), address(2));
+    }
+
+    function testSetBatcherAndOrSignerParsesRequestedFieldsAndFillsOmittedTarget() public {
+        address owner = address(0x1111);
+        address currentBatcher = address(0x2222);
+        address currentSigner = address(0x3333);
+        address requestedSigner = address(0x4444);
+        MockSystemConfigForSequencerUpdate systemConfig =
+            new MockSystemConfigForSequencerUpdate(currentBatcher, currentSigner, owner);
+
+        string memory dir = "test/.superchain-ops-preconditions-explicit-flags";
+        vm.createDir(dir, true);
+        string memory addressesPath = string.concat(dir, "/addresses.json");
+        string memory configPath = string.concat(dir, "/config.toml");
+        vm.writeFile(
+            addressesPath,
+            string.concat(
+                '{"4201234":{"SystemConfigProxy":"',
+                vm.toString(address(systemConfig)),
+                '","SystemConfigOwner":"',
+                vm.toString(owner),
+                '"}}'
+            )
+        );
+        vm.writeFile(
+            configPath,
+            string.concat(
+                'fallbackAddressesJsonPath = "',
+                addressesPath,
+                '"\nl2chains = [{name = "test", chainId = 4201234}]\n',
+                "[sequencerConfig]\n",
+                'batcherAddress = "0x0000000000000000000000000000000000000000"\n',
+                'unsafeBlockSigner = "',
+                vm.toString(requestedSigner),
+                '"\nupdateBatcher = false\nupdateUnsafeBlockSigner = true\n'
+            )
+        );
+
+        vm.chainId(11_155_111);
+        setBatcherAndOrSigner.templateSetup(configPath, owner);
+        (bytes32 batcherHash, address signer, bool updateBatcher, bool updateUnsafeBlockSigner) =
+            setBatcherAndOrSigner.cfg(4_201_234);
+        assertEq(batcherHash, bytes32(uint256(uint160(currentBatcher))));
+        assertEq(signer, requestedSigner);
+        assertFalse(updateBatcher);
+        assertTrue(updateUnsafeBlockSigner);
+        vm.removeDir(dir, true);
+    }
+
+    function testSetBatcherAndOrSignerLegacyConfigUpdatesOnlyChangedField() public {
+        address owner = address(0x1111);
+        address currentBatcher = address(0x2222);
+        address currentSigner = address(0x3333);
+        address requestedSigner = address(0x4444);
+        MockSystemConfigForSequencerUpdate systemConfig =
+            new MockSystemConfigForSequencerUpdate(currentBatcher, currentSigner, owner);
+
+        string memory dir = "test/.superchain-ops-preconditions-legacy-flags";
+        vm.createDir(dir, true);
+        string memory addressesPath = string.concat(dir, "/addresses.json");
+        string memory configPath = string.concat(dir, "/config.toml");
+        vm.writeFile(
+            addressesPath,
+            string.concat(
+                '{"4201234":{"SystemConfigProxy":"',
+                vm.toString(address(systemConfig)),
+                '","SystemConfigOwner":"',
+                vm.toString(owner),
+                '"}}'
+            )
+        );
+        vm.writeFile(
+            configPath,
+            string.concat(
+                'fallbackAddressesJsonPath = "',
+                addressesPath,
+                '"\nl2chains = [{name = "test", chainId = 4201234}]\n',
+                "[sequencerConfig]\n",
+                'batcherAddress = "',
+                vm.toString(currentBatcher),
+                '"\nunsafeBlockSigner = "',
+                vm.toString(requestedSigner),
+                '"\n'
+            )
+        );
+
+        vm.chainId(11_155_111);
+        setBatcherAndOrSigner.templateSetup(configPath, owner);
+        (bytes32 batcherHash, address signer, bool updateBatcher, bool updateUnsafeBlockSigner) =
+            setBatcherAndOrSigner.cfg(4_201_234);
+        assertEq(batcherHash, bytes32(uint256(uint160(currentBatcher))));
+        assertEq(signer, requestedSigner);
+        assertFalse(updateBatcher);
+        assertTrue(updateUnsafeBlockSigner);
+        vm.removeDir(dir, true);
+    }
+
+    function testOPCMUpgradeV700ValidatesRealContractRelationships() public {
+        address rootSafe = address(0x1111);
+        address superchainConfig = address(0x2222);
+        MockOptimismPortalForV700 portal = new MockOptimismPortalForV700(superchainConfig);
+        MockDisputeGameFactoryForV700 factory = new MockDisputeGameFactoryForV700(rootSafe);
+        MockSystemConfigForV700 systemConfig = new MockSystemConfigForV700(address(portal), address(factory));
+        MockProxyAdminForV700 proxyAdmin = new MockProxyAdminForV700(rootSafe);
+        proxyAdmin.setProxyAdmin(address(systemConfig), address(proxyAdmin));
+
+        opcmUpgradeV700.validateContractRelationships(
+            address(systemConfig), superchainConfig, address(proxyAdmin), rootSafe, address(factory), rootSafe
+        );
+    }
+
+    function testOPCMUpgradeV700RejectsWrongPortalSuperchainConfig() public {
+        address rootSafe = address(0x1111);
+        MockOptimismPortalForV700 portal = new MockOptimismPortalForV700(address(0x2222));
+        MockDisputeGameFactoryForV700 factory = new MockDisputeGameFactoryForV700(rootSafe);
+        MockSystemConfigForV700 systemConfig = new MockSystemConfigForV700(address(portal), address(factory));
+        MockProxyAdminForV700 proxyAdmin = new MockProxyAdminForV700(rootSafe);
+        proxyAdmin.setProxyAdmin(address(systemConfig), address(proxyAdmin));
+
+        vm.expectRevert("OPCMUpgradeV700: OptimismPortal SuperchainConfig mismatch");
+        opcmUpgradeV700.validateContractRelationships(
+            address(systemConfig), address(0x3333), address(proxyAdmin), rootSafe, address(factory), rootSafe
+        );
+    }
+
+    function testOPCMUpgradeV700ComputesExpectedValidationErrorsInOrder() public view {
+        assertEq(
+            opcmUpgradeV700.expectedValidationErrors(true, true, true, 1),
+            "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,SYSCON-130,CKDG-NOSHAPE,PLDG-10,CKDG-10"
+        );
+        assertEq(opcmUpgradeV700.expectedValidationErrors(false, false, false, 8), "PLDG-10");
+    }
+
+    function testOPCMUpgradeV700ParsesConfigWithoutExpectedValidationErrors() public view {
+        string memory toml = "[[opcmUpgrades]]\n"
+            "cannonKonaPrestate = \"0x0000000000000000000000000000000000000000000000000000000000000000\"\n"
+            "cannonPrestate = \"0x1111111111111111111111111111111111111111111111111111111111111111\"\n"
+            "chainId = 4201234\n" "initBond = 0\n" "startingRespectedGameType = 1\n";
+        (uint256 chainId, uint32 gameType) = opcmUpgradeV700.parseUpgrade(toml);
+        assertEq(chainId, 4_201_234);
+        assertEq(gameType, 1);
+    }
+
+    function testOPCMUpgradeV700IgnoresLegacyExpectedValidationErrorsField() public view {
+        string memory toml = "[[opcmUpgrades]]\n"
+            "cannonKonaPrestate = \"0x0000000000000000000000000000000000000000000000000000000000000000\"\n"
+            "cannonPrestate = \"0x1111111111111111111111111111111111111111111111111111111111111111\"\n"
+            "chainId = 4201234\n" "expectedValidationErrors = \"legacy-value\"\n" "initBond = 0\n"
+            "startingRespectedGameType = 1\n";
+        (uint256 chainId, uint32 gameType) = opcmUpgradeV700.parseUpgrade(toml);
+        assertEq(chainId, 4_201_234);
+        assertEq(gameType, 1);
+    }
+}


### PR DESCRIPTION
## Summary

- move semantic and onchain validation from Netchef into Superchain Ops templates
- validate live ownership, Safe roots, contract relationships, game registration, and gas bounds
- derive V700 validator exceptions inside the task
- support partial batcher/signer updates while preserving legacy task behavior

## Testing

- forge test --offline --match-path test/template/SuperchainOpsPreconditions.t.sol -vv
- forge build --offline
- forge fmt --check

22 focused tests pass.