### PR TITLE
OPCMUpgradeV800: Remove the unused cannonPrestate input

### DIFF
--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -27,7 +27,6 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     /// meaningless to super-root games.
     struct OPCMUpgrade {
         Claim cannonKonaPrestate;
-        Claim cannonPrestate;
         uint256 chainId;
         string expectedValidationErrors;
         uint256 initBond;
@@ -112,7 +111,6 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         for (uint256 i = 0; i < _upgrades.length; i++) {
             require(_upgrades[i].chainId != 0, "OPCMUpgradeV800: chainId cannot be zero");
             require(upgrades[_upgrades[i].chainId].chainId == 0, "OPCMUpgradeV800: duplicate chain config");
-            require(Claim.unwrap(_upgrades[i].cannonPrestate) != bytes32(0), "OPCMUpgradeV800: cannonPrestate is zero");
             require(
                 Claim.unwrap(_upgrades[i].cannonKonaPrestate) != bytes32(0),
                 "OPCMUpgradeV800: cannonKonaPrestate is zero"
@@ -225,10 +223,12 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     /// @notice Builds a single DisputeGameConfig entry.
     /// @dev SUPER_PERMISSIONED (gt=5) uses the simplified v8 game: proposer-only args
     /// (no prestate, no challenger) and the OPCM requires its initBond to be zero.
+    /// SUPER_CANNON_KONA (gt=9) is the only other game type this template can enable, so
+    /// the Kona prestate is the only prestate ever encoded. The OPCM ignores the game args
+    /// of a disabled config, so the retired Cannon game types need no prestate at all.
     function _buildOneGameConfig(
         GameConfigAddrs memory a,
         uint32 gt,
-        bytes32 cannonPre,
         bytes32 cannonKonaPre,
         uint256 bond,
         uint32 startingRespectedGameType
@@ -236,12 +236,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         bool enabled = _isGameTypeEnabled(a.factory, gt, startingRespectedGameType);
         bytes memory gameArgs;
         if (enabled) {
-            if (gt == SUPER_PERMISSIONED) {
-                gameArgs = abi.encode(a.proposer);
-            } else {
-                bool isKona = gt == CANNON_KONA || gt == SUPER_CANNON_KONA;
-                gameArgs = abi.encode(isKona ? cannonKonaPre : cannonPre);
-            }
+            gameArgs = gt == SUPER_PERMISSIONED ? abi.encode(a.proposer) : abi.encode(cannonKonaPre);
         }
         return IOPContractsManagerV800.DisputeGameConfig({
             enabled: enabled,
@@ -251,7 +246,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         });
     }
 
-    /// @notice Builds DisputeGameConfig[] for a chain from registry addresses and config prestates.
+    /// @notice Builds DisputeGameConfig[] for a chain from registry addresses and the Kona prestate.
     /// @dev The v8 OPCM requires exactly these six game configs, in exactly this order.
     function _buildGameConfigs(uint256 chainId)
         internal
@@ -263,7 +258,6 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
             proposer: superchainAddrRegistry.getAddress("Proposer", chainId)
         });
 
-        bytes32 cannonPre = Claim.unwrap(upgrades[chainId].cannonPrestate);
         bytes32 cannonKonaPre = Claim.unwrap(upgrades[chainId].cannonKonaPrestate);
         uint256 bond = upgrades[chainId].initBond;
         uint32 startingRespectedGameType = upgrades[chainId].startingRespectedGameType;
@@ -272,7 +266,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         uint32[6] memory gts =
             [CANNON, PERMISSIONED_CANNON, CANNON_KONA, SUPER_PERMISSIONED, SUPER_CANNON_KONA, ZK_DISPUTE_GAME];
         for (uint256 i = 0; i < 6; i++) {
-            cfgs[i] = _buildOneGameConfig(a, gts[i], cannonPre, cannonKonaPre, bond, startingRespectedGameType);
+            cfgs[i] = _buildOneGameConfig(a, gts[i], cannonKonaPre, bond, startingRespectedGameType);
         }
         return cfgs;
     }
@@ -368,7 +362,9 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
             IOPContractsManagerStandardValidator.ValidationInputDev memory input = IOPContractsManagerStandardValidator
                 .ValidationInputDev({
                 sysCfg: ISystemConfig(superchainAddrRegistry.getAddress("SystemConfigProxy", chainId)),
-                cannonPrestate: Claim.unwrap(upgrades[chainId].cannonPrestate),
+                // The validator only reads cannonPrestate on its non-super path. This template
+                // always leaves the chain respecting a super game type, so the value is unused.
+                cannonPrestate: bytes32(0),
                 cannonKonaPrestate: Claim.unwrap(upgrades[chainId].cannonKonaPrestate),
                 l2ChainID: chainId,
                 proposer: superchainAddrRegistry.getAddress("Proposer", chainId)

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -93,11 +93,8 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
             superchainAddrRegistry.getAddress("SystemConfigProxy", chainB), 0x66dac055c7cD3B3a043760521dCa840cB3E8F3FF
         );
 
-        // op-contracts/v8.0.0-rc.2 standard prestates: cannon 1.9.0 `interop` and
-        // kona 1.6.0 `cannon64-kona-interop`.
-        bytes32 cannonPrestate = 0x03b985a286da46ca88c0a965a53942daade9ffe1ae6b854a8f2d083df1cfaf59;
+        // op-contracts/v8.0.0-rc.2 standard prestate: kona 1.6.0 `cannon64-kona-interop`.
         bytes32 cannonKonaPrestate = 0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f;
-        assertEq(Claim.unwrap(upgrades[chainA].cannonPrestate), cannonPrestate);
         assertEq(Claim.unwrap(upgrades[chainA].cannonKonaPrestate), cannonKonaPrestate);
         assertEq(upgrades[chainA].initBond, 0.08 ether);
         assertEq(upgrades[chainA].startingRespectedGameType, 9);
@@ -107,7 +104,6 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         assertEq(upgrades[chainA].startingAnchorRootL2SequenceNumber, 1786000000);
         assertEq(upgrades[chainA].expectedValidationErrors, "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,SYSCON-130");
 
-        assertEq(Claim.unwrap(upgrades[chainB].cannonPrestate), cannonPrestate);
         assertEq(Claim.unwrap(upgrades[chainB].cannonKonaPrestate), cannonKonaPrestate);
         assertEq(upgrades[chainB].startingRespectedGameType, 5);
 
@@ -146,8 +142,6 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
                 continue;
             }
 
-            bool isKona = gameType == 8 || gameType == 9;
-
             if (gameType == 5) {
                 // SUPER_PERMISSIONED does not use bonds; the v8 OPCM requires initBond == 0.
                 assertEq(config.initBond, 0);
@@ -155,13 +149,11 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
                 address proposer = abi.decode(config.gameArgs, (address));
                 assertEq(proposer, superchainAddrRegistry.getAddress("Proposer", chainA));
             } else {
+                // SUPER_CANNON_KONA (gt=9) is the only other game type that can be enabled.
+                assertEq(gameType, 9);
                 assertEq(config.initBond, upgrades[chainA].initBond);
                 bytes32 prestate = abi.decode(config.gameArgs, (bytes32));
-                if (isKona) {
-                    assertEq(prestate, Claim.unwrap(upgrades[chainA].cannonKonaPrestate));
-                } else {
-                    assertEq(prestate, Claim.unwrap(upgrades[chainA].cannonPrestate));
-                }
+                assertEq(prestate, Claim.unwrap(upgrades[chainA].cannonKonaPrestate));
             }
         }
     }

--- a/test/tasks/example/sep/035-opcm-upgrade-v800/config.toml
+++ b/test/tasks/example/sep/035-opcm-upgrade-v800/config.toml
@@ -33,9 +33,7 @@ skipOPCMVersionCheck = false
 
 [[opcmUpgrades]]
 chainId = 420130015
-# op-contracts/v8.0.0-rc.2 standard prestates (superchain-registry standard-prestates.toml):
-# cannon 1.9.0 `interop` and kona 1.6.0 `cannon64-kona-interop`.
-cannonPrestate = "0x03b985a286da46ca88c0a965a53942daade9ffe1ae6b854a8f2d083df1cfaf59"
+# op-contracts/v8.0.0-rc.2 standard prestate: kona 1.6.0 `cannon64-kona-interop`.
 cannonKonaPrestate = "0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f"
 # The honest super root (and its timestamp) the AnchorStateRegistry is re-anchored to via
 # the `overrides.cfg.startingAnchorRoot` instruction. The pre-upgrade anchor is an output
@@ -53,7 +51,6 @@ startingRespectedGameType = 9 # SUPER_CANNON_KONA
 
 [[opcmUpgrades]]
 chainId = 420130018
-cannonPrestate = "0x03b985a286da46ca88c0a965a53942daade9ffe1ae6b854a8f2d083df1cfaf59"
 cannonKonaPrestate = "0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403da0f310f"
 # Placeholder super-root anchor, same caveat as above: a real task MUST supply an
 # honest super root for the chain (set).


### PR DESCRIPTION
Stacked on #1502. Independent of #1532 — the two touch disjoint files and can merge in any order.

`OPCMUpgradeV800` requires a non-zero `cannonPrestate` per chain, but nothing reads it.

The template builds six game configs. Only `SUPER_PERMISSIONED` (5) and `SUPER_CANNON_KONA` (9) can be enabled: `_isGameTypeEnabled` returns false for the Cannon game types, `_templateSetup` rejects chains with a ZK game, and `startingRespectedGameType` must be 5 or 9. Game type 5 encodes the proposer. Game type 9 encodes the Kona prestate. The v8 OPCM never decodes the game args of a disabled config, so the retired Cannon types need no prestate.

The StandardValidator ignores the value too. The upgrade always leaves the chain on a super respected game type, so the validator takes its super path. There `cannonPrestate` goes to `assertValidPermissionedDisputeGame`, which returns immediately to `assertValidSuperPermissionedDisputeGame`. That function takes no prestate.

This change removes the field from the `OPCMUpgrade` struct, the require, `_buildOneGameConfig` and the `035` fixture. The validator input keeps the field, which is part of the validator ABI, and now passes `bytes32(0)`.

A required field that nothing reads makes operators source a real Cannon prestate for U20 that has no effect.
