### PR TITLE
feat: enforce V800 task validation in template

### DIFF
--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -29,7 +29,6 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         Claim cannonKonaPrestate;
         Claim cannonPrestate;
         uint256 chainId;
-        string expectedValidationErrors;
         uint256 initBond;
         uint256 startingAnchorRootL2SequenceNumber;
         bytes32 startingAnchorRootRoot;
@@ -39,10 +38,10 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     /// @notice Mapping of L2 chain IDs to their respective OPCMUpgrade structs.
     uint256[] public chainsToUpgrade;
     mapping(uint256 => OPCMUpgrade) public upgrades;
+    mapping(uint256 => bool) public konaGameWasRegistered;
 
     IOPContractsManagerV800 public opcm;
     IOPContractsManagerStandardValidator public standardValidator;
-    bool public skipOPCMVersionCheck;
 
     // Game type constants (from GameTypes library in op-contracts v8.0.0-rc.2).
     // SUPER_CANNON (4) is retired: the v8 OPCM does not accept a config for it and
@@ -107,7 +106,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         require(chains.length > 0, "OPCMUpgradeV800: no chains configured");
 
         // Load upgrades from TOML
-        OPCMUpgrade[] memory _upgrades = abi.decode(tomlContent.parseRaw(".opcmUpgrades"), (OPCMUpgrade[]));
+        OPCMUpgrade[] memory _upgrades = _parseUpgrades(tomlContent);
         require(_upgrades.length == chains.length, "OPCMUpgradeV800: opcmUpgrades length mismatch");
         for (uint256 i = 0; i < _upgrades.length; i++) {
             require(_upgrades[i].chainId != 0, "OPCMUpgradeV800: chainId cannot be zero");
@@ -146,6 +145,15 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
                 superchainAddrRegistry.getAddress("SuperchainConfig", chainId) == superchainConfig,
                 "OPCMUpgradeV800: all chains must share the same SuperchainConfig"
             );
+            _validateContractRelationships(
+                superchainAddrRegistry.getAddress("SystemConfigProxy", chainId),
+                superchainAddrRegistry.getAddress("OptimismPortalProxy", chainId),
+                superchainConfig,
+                superchainAddrRegistry.getAddress("ProxyAdmin", chainId),
+                superchainAddrRegistry.getAddress("ProxyAdminOwner", chainId),
+                superchainAddrRegistry.getAddress("DisputeGameFactoryProxy", chainId),
+                rootSafe
+            );
         }
 
         // Register EthLockboxProxy for each chain. The V800 upgrade writes to EthLockboxProxy
@@ -172,6 +180,8 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         for (uint256 i = 0; i < chains.length; i++) {
             IDisputeGameFactory factory =
                 IDisputeGameFactory(superchainAddrRegistry.getAddress("DisputeGameFactoryProxy", chains[i].chainId));
+            konaGameWasRegistered[chains[i].chainId] =
+                address(factory.gameImpls(GameType.wrap(CANNON_KONA))) != address(0);
             require(
                 address(factory.gameImpls(GameType.wrap(ZK_DISPUTE_GAME))) == address(0),
                 "OPCMUpgradeV800: chains with a registered ZK_DISPUTE_GAME are not supported"
@@ -181,11 +191,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         // OPCM from TOML; must be the op-contracts/v8.0.0 release (version 8.0.x).
         opcm = IOPContractsManagerV800(tomlContent.readAddress(".addresses.OPCM"));
         OPCM_TARGETS.push(address(opcm));
-        skipOPCMVersionCheck =
-            tomlContent.keyExists(".skipOPCMVersionCheck") && tomlContent.readBool(".skipOPCMVersionCheck");
-        if (!skipOPCMVersionCheck) {
-            require(opcm.version().startsWith("8.0."), "Incorrect OPCM major/minor version");
-        }
+        require(opcm.version().startsWith("8.0."), "Incorrect OPCM major/minor version");
         vm.label(address(opcm), "OPCM");
 
         // Fetch the validator directly from OPCM so it doesn't need to be configured in TOML
@@ -193,6 +199,134 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         require(address(standardValidator) != address(0), "OPCM returned zero validator");
         require(address(standardValidator).code.length > 0, "Validator has no code");
         vm.label(address(standardValidator), "OPCMStandardValidator");
+    }
+
+    /// @notice Parses only fields consumed by this template so legacy TOML fields are harmless.
+    function _parseUpgrades(string memory toml) internal view returns (OPCMUpgrade[] memory parsed) {
+        uint256 count;
+        while (toml.keyExists(string.concat(".opcmUpgrades[", vm.toString(count), "].chainId"))) {
+            count++;
+        }
+
+        parsed = new OPCMUpgrade[](count);
+        for (uint256 i = 0; i < count; i++) {
+            string memory base = string.concat(".opcmUpgrades[", vm.toString(i), "]");
+            uint256 startingRespectedGameType = toml.readUint(string.concat(base, ".startingRespectedGameType"));
+            require(
+                startingRespectedGameType <= type(uint32).max,
+                "OPCMUpgradeV800: startingRespectedGameType exceeds uint32"
+            );
+            parsed[i] = OPCMUpgrade({
+                cannonKonaPrestate: Claim.wrap(toml.readBytes32(string.concat(base, ".cannonKonaPrestate"))),
+                cannonPrestate: Claim.wrap(toml.readBytes32(string.concat(base, ".cannonPrestate"))),
+                chainId: toml.readUint(string.concat(base, ".chainId")),
+                initBond: toml.readUint(string.concat(base, ".initBond")),
+                startingAnchorRootL2SequenceNumber: toml.readUint(
+                    string.concat(base, ".startingAnchorRootL2SequenceNumber")
+                ),
+                startingAnchorRootRoot: toml.readBytes32(string.concat(base, ".startingAnchorRootRoot")),
+                startingRespectedGameType: uint32(startingRespectedGameType)
+            });
+        }
+    }
+
+    /// @notice Ensures registry inputs describe contracts controlled by the task's signing Safe.
+    function _validateContractRelationships(
+        address systemConfig,
+        address optimismPortal,
+        address superchainConfig,
+        address proxyAdmin,
+        address proxyAdminOwner,
+        address disputeGameFactory,
+        address rootSafe
+    ) internal view {
+        require(systemConfig != address(0), "OPCMUpgradeV800: SystemConfig is zero address");
+        require(optimismPortal != address(0), "OPCMUpgradeV800: OptimismPortal is zero address");
+        require(superchainConfig != address(0), "OPCMUpgradeV800: SuperchainConfig is zero address");
+        require(proxyAdmin != address(0), "OPCMUpgradeV800: ProxyAdmin is zero address");
+        require(proxyAdminOwner != address(0), "OPCMUpgradeV800: ProxyAdminOwner is zero address");
+        require(disputeGameFactory != address(0), "OPCMUpgradeV800: DisputeGameFactory is zero address");
+        require(rootSafe == proxyAdminOwner, "OPCMUpgradeV800: rootSafe is not ProxyAdminOwner");
+        require(rootSafe.code.length > 0, "OPCMUpgradeV800: rootSafe has no code");
+        require(IGnosisSafeView(rootSafe).getOwners().length > 0, "OPCMUpgradeV800: rootSafe has no owners");
+
+        require(
+            IOptimismPortalV800(optimismPortal).superchainConfig() == superchainConfig,
+            "OPCMUpgradeV800: OptimismPortal SuperchainConfig mismatch"
+        );
+        require(
+            IOptimismPortalV800(optimismPortal).systemConfig() == systemConfig,
+            "OPCMUpgradeV800: OptimismPortal SystemConfig mismatch"
+        );
+        require(
+            ISystemConfigV800(systemConfig).disputeGameFactory() == disputeGameFactory,
+            "OPCMUpgradeV800: SystemConfig DisputeGameFactory mismatch"
+        );
+        require(
+            IProxyAdminV800(proxyAdmin).getProxyAdmin(payable(systemConfig)) == proxyAdmin,
+            "OPCMUpgradeV800: SystemConfig ProxyAdmin mismatch"
+        );
+        require(
+            ISuperchainConfigV800(superchainConfig).guardian() != address(0),
+            "OPCMUpgradeV800: guardian is zero address"
+        );
+        require(IOwnedV800(proxyAdmin).owner() == rootSafe, "OPCMUpgradeV800: ProxyAdmin owner mismatch");
+        require(
+            IOwnedV800(disputeGameFactory).owner() == proxyAdminOwner,
+            "OPCMUpgradeV800: DisputeGameFactory owner mismatch"
+        );
+    }
+
+    /// @notice Derives the standard-validator exceptions from live roles and pre-upgrade Kona support.
+    /// @dev Ordering matches validator output and the former Netchef inspector.
+    struct ValidationErrorInputs {
+        address challenger;
+        bool konaWasRegistered;
+        address proxyAdminOwner;
+        uint32 startingRespectedGameType;
+        address standardChallenger;
+        address standardL1PAO;
+        address standardSuperchainConfig;
+        address superchainConfig;
+    }
+
+    function _expectedValidationErrors(ValidationErrorInputs memory inputs)
+        internal
+        pure
+        returns (string memory errors)
+    {
+        if (inputs.proxyAdminOwner != inputs.standardL1PAO) {
+            errors = _appendValidationError(errors, "OVERRIDES-L1PAOMULTISIG");
+        }
+        if (inputs.challenger != inputs.standardChallenger) {
+            errors = _appendValidationError(errors, "OVERRIDES-CHALLENGER");
+        }
+        if (inputs.superchainConfig != inputs.standardSuperchainConfig) {
+            errors = _appendValidationError(errors, "SYSCON-130");
+        }
+        if (inputs.startingRespectedGameType == SUPER_PERMISSIONED && !inputs.konaWasRegistered) {
+            errors = _appendValidationError(errors, "SCKDG-SHAPE");
+            errors = _appendValidationError(errors, "SCKDG-10");
+        }
+    }
+
+    function _expectedValidationErrorsForChain(uint256 chainId) internal view returns (string memory) {
+        return _expectedValidationErrors(
+            ValidationErrorInputs({
+                challenger: superchainAddrRegistry.getAddress("Challenger", chainId),
+                konaWasRegistered: konaGameWasRegistered[chainId],
+                proxyAdminOwner: superchainAddrRegistry.getAddress("ProxyAdminOwner", chainId),
+                startingRespectedGameType: upgrades[chainId].startingRespectedGameType,
+                standardChallenger: standardValidator.challenger(),
+                standardL1PAO: standardValidator.l1PAOMultisig(),
+                standardSuperchainConfig: standardValidator.superchainConfig(),
+                superchainConfig: superchainAddrRegistry.getAddress("SuperchainConfig", chainId)
+            })
+        );
+    }
+
+    function _appendValidationError(string memory errors, string memory next) private pure returns (string memory) {
+        return bytes(errors).length == 0 ? next : string.concat(errors, ",", next);
     }
 
     /// @notice Returns whether a dispute game should be enabled based on the existing factory state.
@@ -395,7 +529,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
                 errors = standardValidator.validate({_input: input, _allowFailure: true});
             }
 
-            string memory expErrors = upgrades[chainId].expectedValidationErrors;
+            string memory expErrors = _expectedValidationErrorsForChain(chainId);
             require(errors.eq(expErrors), string.concat("Unexpected errors: ", errors, "; expected: ", expErrors));
         }
     }
@@ -481,6 +615,7 @@ interface IOPContractsManagerStandardValidator {
     }
 
     function validate(ValidationInputDev memory _input, bool _allowFailure) external view returns (string memory);
+    function superchainConfig() external view returns (address);
     function l1PAOMultisig() external view returns (address);
     function challenger() external view returns (address);
     function validateWithOverrides(
@@ -496,6 +631,27 @@ interface ISuperchainConfig {}
 
 interface IDisputeGameFactory {
     function gameImpls(GameType gameType) external view returns (address);
+}
+
+interface IOwnedV800 {
+    function owner() external view returns (address);
+}
+
+interface IProxyAdminV800 {
+    function getProxyAdmin(address payable proxy) external view returns (address);
+}
+
+interface IGnosisSafeView {
+    function getOwners() external view returns (address[] memory);
+}
+
+interface ISuperchainConfigV800 {
+    function guardian() external view returns (address);
+}
+
+interface IOptimismPortalV800 {
+    function superchainConfig() external view returns (address);
+    function systemConfig() external view returns (address);
 }
 
 /// @notice Read-only AnchorStateRegistry accessor. `getStartingAnchorRoot` returns a
@@ -523,6 +679,7 @@ interface ISystemConfig {
 /// It is kept here for callers that read the pre-upgrade SystemConfig (e.g. tests).
 interface ISystemConfigV800 {
     function owner() external view returns (address);
+    function disputeGameFactory() external view returns (address);
     function unsafeBlockSigner() external view returns (address);
     function batchInbox() external view returns (address);
     function batcherHash() external view returns (bytes32);

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -9,15 +9,6 @@ import {IDisputeGameFactory, IOPContractsManagerV800, OPCMUpgradeV800} from "src
 import {SuperchainAddressRegistry} from "src/SuperchainAddressRegistry.sol";
 import {Action} from "src/libraries/MultisigTypes.sol";
 
-interface IProxyAdmin {
-    function owner() external view returns (address);
-}
-
-interface ISystemConfigExt {
-    function proxyAdmin() external view returns (address);
-    function superchainConfig() external view returns (address);
-}
-
 contract OPCMUpgradeV800SetupHarness is OPCMUpgradeV800 {
     function setupForTest(string memory configPath) external {
         superchainAddrRegistry = new SuperchainAddressRegistry(configPath);
@@ -60,9 +51,8 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         chainA = chains[0].chainId;
         chainB = chains[1].chainId;
         superchainConfig = superchainAddrRegistry.getAddress("SuperchainConfig", chainA);
-        _templateSetup(configTomlPath, address(0));
-        address systemConfig = superchainAddrRegistry.getAddress("SystemConfigProxy", chainA);
-        rootSafe = IProxyAdmin(ISystemConfigExt(systemConfig).proxyAdmin()).owner();
+        rootSafe = superchainAddrRegistry.getAddress("ProxyAdminOwner", chainA);
+        _templateSetup(configTomlPath, rootSafe);
     }
 
     function test_load_data() public view {
@@ -105,11 +95,12 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
             upgrades[chainA].startingAnchorRootRoot, 0xdead000000000000000000000000000000000000000000000000000000000000
         );
         assertEq(upgrades[chainA].startingAnchorRootL2SequenceNumber, 1786000000);
-        assertEq(upgrades[chainA].expectedValidationErrors, "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,SYSCON-130");
+        assertTrue(konaGameWasRegistered[chainA]);
 
         assertEq(Claim.unwrap(upgrades[chainB].cannonPrestate), cannonPrestate);
         assertEq(Claim.unwrap(upgrades[chainB].cannonKonaPrestate), cannonKonaPrestate);
         assertEq(upgrades[chainB].startingRespectedGameType, 5);
+        assertFalse(konaGameWasRegistered[chainB]);
 
         // sepolia-devnet-3 is permissioned-only: no CANNON_KONA impl in its factory, so
         // SUPER_CANNON_KONA (9) stays disabled and only SUPER_PERMISSIONED (5) is enabled.

--- a/test/tasks/example/sep/035-opcm-upgrade-v800/config.toml
+++ b/test/tasks/example/sep/035-opcm-upgrade-v800/config.toml
@@ -29,7 +29,6 @@ l2chains = [
 ]
 
 templateName = "OPCMUpgradeV800"
-skipOPCMVersionCheck = false
 
 [[opcmUpgrades]]
 chainId = 420130015
@@ -44,10 +43,6 @@ cannonKonaPrestate = "0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403
 # a real task MUST supply an honest super root for the chain (set).
 startingAnchorRootRoot = "0xdead000000000000000000000000000000000000000000000000000000000000"
 startingAnchorRootL2SequenceNumber = 1786000000
-# Live validator output captured during simulation against the v8.0.0-rc.2 OPCM.
-# OVERRIDES-* are informational (devnet's non-standard ProxyAdminOwner and Challenger);
-# SYSCON-130 is the devnet's non-standard SystemConfig gas limit (60M).
-expectedValidationErrors = "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,SYSCON-130"
 initBond = 80000000000000000
 startingRespectedGameType = 9 # SUPER_CANNON_KONA
 
@@ -59,11 +54,6 @@ cannonKonaPrestate = "0x03e3a42cf9a1d116f414206c465c6cdb74556136090e7c9556329403
 # honest super root for the chain (set).
 startingAnchorRootRoot = "0xdead000000000000000000000000000000000000000000000000000000000000"
 startingAnchorRootL2SequenceNumber = 1786000000
-# Live validator output captured during simulation. In addition to the devnet deviations
-# shared with sepolia-devnet-2, SCKDG-SHAPE and SCKDG-10 report that no SUPER_CANNON_KONA
-# game is registered post-upgrade — expected for this permissioned-only chain, which has
-# no CANNON_KONA impl to carry over and rotates to SUPER_PERMISSIONED instead.
-expectedValidationErrors = "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,SYSCON-130,SCKDG-SHAPE,SCKDG-10"
 # No bonded game is enabled for this chain: SUPER_PERMISSIONED's initBond is forced to
 # zero by the v8 OPCM and SUPER_CANNON_KONA stays disabled (no CANNON_KONA impl).
 initBond = 80000000000000000

--- a/test/template/OPCMUpgradeV800Preconditions.t.sol
+++ b/test/template/OPCMUpgradeV800Preconditions.t.sol
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {Test} from "forge-std/Test.sol";
+
+import {OPCMUpgradeV800} from "src/template/OPCMUpgradeV800.sol";
+
+contract MockV800SystemConfig {
+    address internal immutable _disputeGameFactory;
+
+    constructor(address disputeGameFactory_) {
+        _disputeGameFactory = disputeGameFactory_;
+    }
+
+    function disputeGameFactory() external view returns (address) {
+        return _disputeGameFactory;
+    }
+}
+
+contract MockV800SuperchainConfig {
+    address internal immutable _guardian;
+
+    constructor(address guardian_) {
+        _guardian = guardian_;
+    }
+
+    function guardian() external view returns (address) {
+        return _guardian;
+    }
+}
+
+contract MockV800Portal {
+    address internal immutable _superchainConfig;
+    address internal immutable _systemConfig;
+
+    constructor(address superchainConfig_, address systemConfig_) {
+        _superchainConfig = superchainConfig_;
+        _systemConfig = systemConfig_;
+    }
+
+    function superchainConfig() external view returns (address) {
+        return _superchainConfig;
+    }
+
+    function systemConfig() external view returns (address) {
+        return _systemConfig;
+    }
+}
+
+contract MockV800Owned {
+    address internal immutable _owner;
+
+    constructor(address owner_) {
+        _owner = owner_;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}
+
+contract MockV800ProxyAdmin {
+    address internal immutable _owner;
+    mapping(address => address) internal _admins;
+
+    constructor(address owner_) {
+        _owner = owner_;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    function setProxyAdmin(address proxy, address admin) external {
+        _admins[proxy] = admin;
+    }
+
+    function getProxyAdmin(address payable proxy) external view returns (address) {
+        return _admins[proxy];
+    }
+}
+
+contract MockV800Safe {
+    function getOwners() external pure returns (address[] memory owners) {
+        owners = new address[](1);
+        owners[0] = address(0x1234);
+    }
+}
+
+contract OPCMUpgradeV800PreconditionsHarness is OPCMUpgradeV800 {
+    function parseUpgrade(string memory toml)
+        external
+        view
+        returns (uint256 chainId, uint32 startingRespectedGameType)
+    {
+        OPCMUpgrade[] memory parsed = _parseUpgrades(toml);
+        return (parsed[0].chainId, parsed[0].startingRespectedGameType);
+    }
+
+    function validateRelationships(
+        address systemConfig,
+        address optimismPortal,
+        address superchainConfig,
+        address proxyAdmin,
+        address proxyAdminOwner,
+        address disputeGameFactory,
+        address rootSafe
+    ) external view {
+        _validateContractRelationships(
+            systemConfig, optimismPortal, superchainConfig, proxyAdmin, proxyAdminOwner, disputeGameFactory, rootSafe
+        );
+    }
+
+    function expectedValidationErrors(
+        address proxyAdminOwner,
+        address challenger,
+        address superchainConfig,
+        address standardL1PAO,
+        address standardChallenger,
+        address standardSuperchainConfig,
+        bool konaWasRegistered,
+        uint32 startingRespectedGameType
+    ) external pure returns (string memory) {
+        return _expectedValidationErrors(
+            ValidationErrorInputs({
+                challenger: challenger,
+                konaWasRegistered: konaWasRegistered,
+                proxyAdminOwner: proxyAdminOwner,
+                startingRespectedGameType: startingRespectedGameType,
+                standardChallenger: standardChallenger,
+                standardL1PAO: standardL1PAO,
+                standardSuperchainConfig: standardSuperchainConfig,
+                superchainConfig: superchainConfig
+            })
+        );
+    }
+}
+
+contract OPCMUpgradeV800PreconditionsTest is Test {
+    address internal constant GUARDIAN = address(0x3333);
+    address internal constant CHALLENGER = address(0x4444);
+
+    OPCMUpgradeV800PreconditionsHarness internal harness;
+    MockV800Safe internal rootSafe;
+    MockV800ProxyAdmin internal proxyAdmin;
+    MockV800Owned internal disputeGameFactory;
+    MockV800SuperchainConfig internal superchainConfig;
+    MockV800SystemConfig internal systemConfig;
+    MockV800Portal internal optimismPortal;
+
+    function setUp() public {
+        harness = new OPCMUpgradeV800PreconditionsHarness();
+        rootSafe = new MockV800Safe();
+        proxyAdmin = new MockV800ProxyAdmin(address(rootSafe));
+        disputeGameFactory = new MockV800Owned(address(rootSafe));
+        superchainConfig = new MockV800SuperchainConfig(GUARDIAN);
+        systemConfig = new MockV800SystemConfig(address(disputeGameFactory));
+        proxyAdmin.setProxyAdmin(address(systemConfig), address(proxyAdmin));
+        optimismPortal = new MockV800Portal(address(superchainConfig), address(systemConfig));
+    }
+
+    function _validate(address sysCfg, address portal, address sc, address pa, address pao, address dgf, address root)
+        internal
+        view
+    {
+        harness.validateRelationships(sysCfg, portal, sc, pa, pao, dgf, root);
+    }
+
+    function test_validateContractRelationships_acceptsAuthorizedRootSafe() public view {
+        _validate(
+            address(systemConfig),
+            address(optimismPortal),
+            address(superchainConfig),
+            address(proxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsWrongPortalSuperchainConfig() public {
+        MockV800Portal wrong = new MockV800Portal(address(0xdead), address(systemConfig));
+        vm.expectRevert("OPCMUpgradeV800: OptimismPortal SuperchainConfig mismatch");
+        _validate(
+            address(systemConfig),
+            address(wrong),
+            address(superchainConfig),
+            address(proxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsWrongSystemConfigDisputeGameFactory() public {
+        MockV800SystemConfig wrong = new MockV800SystemConfig(address(0xdead));
+        MockV800Portal matchingPortal = new MockV800Portal(address(superchainConfig), address(wrong));
+        vm.expectRevert("OPCMUpgradeV800: SystemConfig DisputeGameFactory mismatch");
+        _validate(
+            address(wrong),
+            address(matchingPortal),
+            address(superchainConfig),
+            address(proxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsUnauthorizedRootSafe() public {
+        vm.expectRevert("OPCMUpgradeV800: rootSafe is not ProxyAdminOwner");
+        _validate(
+            address(systemConfig),
+            address(optimismPortal),
+            address(superchainConfig),
+            address(proxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(0xbeef)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsWrongProxyAdminOwner() public {
+        MockV800ProxyAdmin wrongProxyAdmin = new MockV800ProxyAdmin(address(0xdead));
+        wrongProxyAdmin.setProxyAdmin(address(systemConfig), address(wrongProxyAdmin));
+        vm.expectRevert("OPCMUpgradeV800: ProxyAdmin owner mismatch");
+        _validate(
+            address(systemConfig),
+            address(optimismPortal),
+            address(superchainConfig),
+            address(wrongProxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsWrongSystemConfigProxyAdmin() public {
+        MockV800ProxyAdmin wrongProxyAdmin = new MockV800ProxyAdmin(address(rootSafe));
+        wrongProxyAdmin.setProxyAdmin(address(systemConfig), address(0xdead));
+        vm.expectRevert("OPCMUpgradeV800: SystemConfig ProxyAdmin mismatch");
+        _validate(
+            address(systemConfig),
+            address(optimismPortal),
+            address(superchainConfig),
+            address(wrongProxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsWrongDisputeGameFactoryOwner() public {
+        MockV800Owned wrongFactory = new MockV800Owned(address(0xdead));
+        MockV800SystemConfig matchingSystemConfig = new MockV800SystemConfig(address(wrongFactory));
+        MockV800Portal matchingPortal = new MockV800Portal(address(superchainConfig), address(matchingSystemConfig));
+        proxyAdmin.setProxyAdmin(address(matchingSystemConfig), address(proxyAdmin));
+        vm.expectRevert("OPCMUpgradeV800: DisputeGameFactory owner mismatch");
+        _validate(
+            address(matchingSystemConfig),
+            address(matchingPortal),
+            address(superchainConfig),
+            address(proxyAdmin),
+            address(rootSafe),
+            address(wrongFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_validateContractRelationships_rejectsZeroGuardian() public {
+        MockV800SuperchainConfig wrongSuperchainConfig = new MockV800SuperchainConfig(address(0));
+        MockV800Portal matchingPortal = new MockV800Portal(address(wrongSuperchainConfig), address(systemConfig));
+        vm.expectRevert("OPCMUpgradeV800: guardian is zero address");
+        _validate(
+            address(systemConfig),
+            address(matchingPortal),
+            address(wrongSuperchainConfig),
+            address(proxyAdmin),
+            address(rootSafe),
+            address(disputeGameFactory),
+            address(rootSafe)
+        );
+    }
+
+    function test_expectedValidationErrors_preservesInspectorOrderingAndPermissionedKonaErrors() public view {
+        string memory errors = harness.expectedValidationErrors(
+            address(rootSafe),
+            CHALLENGER,
+            address(superchainConfig),
+            address(0xaaaa),
+            address(0xbbbb),
+            address(0xcccc),
+            false,
+            5
+        );
+        assertEq(errors, "OVERRIDES-L1PAOMULTISIG,OVERRIDES-CHALLENGER,SYSCON-130,SCKDG-SHAPE,SCKDG-10");
+    }
+
+    function test_expectedValidationErrors_omitsKonaErrorsWhenKonaWasRegistered() public view {
+        string memory errors = harness.expectedValidationErrors(
+            address(rootSafe),
+            CHALLENGER,
+            address(superchainConfig),
+            address(rootSafe),
+            CHALLENGER,
+            address(superchainConfig),
+            true,
+            5
+        );
+        assertEq(errors, "");
+    }
+
+    function test_expectedValidationErrors_omitsKonaErrorsForSuperCannonKonaTarget() public view {
+        string memory errors = harness.expectedValidationErrors(
+            address(rootSafe),
+            CHALLENGER,
+            address(superchainConfig),
+            address(rootSafe),
+            CHALLENGER,
+            address(superchainConfig),
+            false,
+            9
+        );
+        assertEq(errors, "");
+    }
+
+    function test_parseUpgrades_ignoresLegacyValidationAndVersionSkipFields() public view {
+        string memory toml = "skipOPCMVersionCheck = true\n" "[[opcmUpgrades]]\n"
+            "cannonKonaPrestate = \"0x2222222222222222222222222222222222222222222222222222222222222222\"\n"
+            "cannonPrestate = \"0x1111111111111111111111111111111111111111111111111111111111111111\"\n"
+            "chainId = 4201234\n" "expectedValidationErrors = \"legacy-value\"\n" "initBond = 0\n"
+            "startingAnchorRootL2SequenceNumber = 1\n"
+            "startingAnchorRootRoot = \"0x3333333333333333333333333333333333333333333333333333333333333333\"\n"
+            "startingRespectedGameType = 5\n";
+        (uint256 chainId, uint32 gameType) = harness.parseUpgrade(toml);
+        assertEq(chainId, 4_201_234);
+        assertEq(gameType, 5);
+    }
+}


### PR DESCRIPTION
## Summary

- enforce OPCM 8.0.x and reject pre-registered ZK game type
- validate Portal, SystemConfig, SuperchainConfig, ProxyAdmin, DGF, guardian, and root Safe relationships
- derive expected validator errors from live state
- ignore obsolete Netchef validation fields for legacy TOML compatibility

## Stack

Stacked on #1528 because V800 template does not exist on main yet. This patch must land before Netchef removes V800 inspection.

## Testing

- forge test --offline --match-path test/template/OPCMUpgradeV800Preconditions.t.sol -vv
- forge fmt --check

12 focused tests pass.