### PR TITLE
fix: minimize OPCM V800 storage allowlist

### DIFF
--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -55,22 +55,22 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
 
     /// @notice Names in the SuperchainAddressRegistry that are expected to be written during this task.
     /// @dev ProtocolVersions is absent: op-contracts/v8.0.0 removed the ProtocolVersions
-    /// contract and its OPCM integration, so the upgrade no longer writes to it.
+    /// contract and its OPCM integration, so the upgrade no longer writes to it. SuperchainConfig
+    /// is resolved per chain in `_setAllowedStorageAccesses` instead of through the generic registry lookup.
     function _taskStorageWrites() internal pure virtual override returns (string[] memory) {
-        string[] memory storageWrites = new string[](13);
-        storageWrites[0] = "SuperchainConfig";
-        storageWrites[1] = "DisputeGameFactoryProxy";
-        storageWrites[2] = "SystemConfigProxy";
-        storageWrites[3] = "OptimismPortalProxy";
-        storageWrites[4] = "OptimismMintableERC20FactoryProxy";
-        storageWrites[5] = "AddressManager";
-        storageWrites[6] = "L1StandardBridgeProxy";
-        storageWrites[7] = "L1ERC721BridgeProxy";
-        storageWrites[8] = "L1CrossDomainMessengerProxy";
-        storageWrites[9] = "AnchorStateRegistryProxy";
-        storageWrites[10] = "PermissionedWETH";
-        storageWrites[11] = "PermissionlessWETH";
-        storageWrites[12] = "EthLockboxProxy";
+        string[] memory storageWrites = new string[](12);
+        storageWrites[0] = "DisputeGameFactoryProxy";
+        storageWrites[1] = "SystemConfigProxy";
+        storageWrites[2] = "OptimismPortalProxy";
+        storageWrites[3] = "OptimismMintableERC20FactoryProxy";
+        storageWrites[4] = "AddressManager";
+        storageWrites[5] = "L1StandardBridgeProxy";
+        storageWrites[6] = "L1ERC721BridgeProxy";
+        storageWrites[7] = "L1CrossDomainMessengerProxy";
+        storageWrites[8] = "AnchorStateRegistryProxy";
+        storageWrites[9] = "PermissionedWETH";
+        storageWrites[10] = "PermissionlessWETH";
+        storageWrites[11] = "EthLockboxProxy";
         return storageWrites;
     }
 
@@ -80,15 +80,11 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     function _taskBalanceChanges() internal view virtual override returns (string[] memory) {}
 
     /// @notice Allowlist storage writes for the upgrade.
-    /// @dev L2TaskBase's default `_setAllowedStorageAccesses` calls `addrRegistry.get(key)`
-    /// before falling back to per-chain `getAddress(key, chainId)`. For shared identifiers
-    /// like `SuperchainConfig`, `get(key)` resolves against the sentinel-chain entries
-    /// hardcoded in `src/addresses.toml` (the OP Sepolia / mainnet values), so
-    /// devnet-specific addresses never make it into the allowlist. We remove the
-    /// sentinel address and add only the discovered address for each configured chain.
+    /// @dev `SuperchainConfig` is resolved separately because the base implementation checks
+    /// global or sentinel addresses before per-chain discovery. Add only each configured chain's
+    /// discovered `SuperchainConfig`.
     function _setAllowedStorageAccesses() internal virtual override {
         super._setAllowedStorageAccesses();
-        _allowedStorageAccesses.remove(superchainAddrRegistry.get("SuperchainConfig"));
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             _allowedStorageAccesses.add(superchainAddrRegistry.getAddress("SuperchainConfig", chains[i].chainId));

--- a/src/template/OPCMUpgradeV800.sol
+++ b/src/template/OPCMUpgradeV800.sol
@@ -57,7 +57,7 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     /// @dev ProtocolVersions is absent: op-contracts/v8.0.0 removed the ProtocolVersions
     /// contract and its OPCM integration, so the upgrade no longer writes to it.
     function _taskStorageWrites() internal pure virtual override returns (string[] memory) {
-        string[] memory storageWrites = new string[](14);
+        string[] memory storageWrites = new string[](13);
         storageWrites[0] = "SuperchainConfig";
         storageWrites[1] = "DisputeGameFactoryProxy";
         storageWrites[2] = "SystemConfigProxy";
@@ -67,11 +67,10 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
         storageWrites[6] = "L1StandardBridgeProxy";
         storageWrites[7] = "L1ERC721BridgeProxy";
         storageWrites[8] = "L1CrossDomainMessengerProxy";
-        storageWrites[9] = "ProxyAdminOwner";
-        storageWrites[10] = "AnchorStateRegistryProxy";
-        storageWrites[11] = "PermissionedWETH";
-        storageWrites[12] = "PermissionlessWETH";
-        storageWrites[13] = "EthLockboxProxy";
+        storageWrites[9] = "AnchorStateRegistryProxy";
+        storageWrites[10] = "PermissionedWETH";
+        storageWrites[11] = "PermissionlessWETH";
+        storageWrites[12] = "EthLockboxProxy";
         return storageWrites;
     }
 
@@ -85,10 +84,11 @@ contract OPCMUpgradeV800 is OPCMTaskBase {
     /// before falling back to per-chain `getAddress(key, chainId)`. For shared identifiers
     /// like `SuperchainConfig`, `get(key)` resolves against the sentinel-chain entries
     /// hardcoded in `src/addresses.toml` (the OP Sepolia / mainnet values), so
-    /// devnet-specific addresses never make it into the allowlist. We re-add
-    /// them explicitly per chain so devnet upgrades pass the post-execution check.
+    /// devnet-specific addresses never make it into the allowlist. We remove the
+    /// sentinel address and add only the discovered address for each configured chain.
     function _setAllowedStorageAccesses() internal virtual override {
         super._setAllowedStorageAccesses();
+        _allowedStorageAccesses.remove(superchainAddrRegistry.get("SuperchainConfig"));
         SuperchainAddressRegistry.ChainInfo[] memory chains = superchainAddrRegistry.getChains();
         for (uint256 i = 0; i < chains.length; i++) {
             _allowedStorageAccesses.add(superchainAddrRegistry.getAddress("SuperchainConfig", chains[i].chainId));

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -7,6 +7,7 @@ import {VmSafe} from "forge-std/Vm.sol";
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 import {IDisputeGameFactory, IOPContractsManagerV800, OPCMUpgradeV800} from "src/template/OPCMUpgradeV800.sol";
 import {SuperchainAddressRegistry} from "src/SuperchainAddressRegistry.sol";
+import {AccountAccessParser} from "src/libraries/AccountAccessParser.sol";
 import {Action} from "src/libraries/MultisigTypes.sol";
 
 interface IProxyAdmin {
@@ -44,6 +45,8 @@ contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
 }
 
 contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
+    using AccountAccessParser for VmSafe.AccountAccess[];
+
     string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
     uint256 internal constant FORK_BLOCK_NUMBER = 11_619_054;
     address internal constant ROOT_SAFE = 0xe934Dc97E347C6aCef74364B50125bb8689c40ff;
@@ -211,6 +214,39 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         _executeActions(actions);
 
         _validate(new VmSafe.AccountAccess[](0), actions, rootSafe);
+    }
+
+    function test_storage_allowlist_matches_changed_write_accounts() public {
+        templateConfig.allowedStorageKeys = _taskStorageWrites();
+        templateConfig.allowedStorageKeys.push(safeAddressString());
+        _setAllowedStorageAccesses();
+
+        Action[] memory actions = build(rootSafe);
+        vm.startStateDiffRecording();
+        _executeActions(actions);
+        VmSafe.AccountAccess[] memory accesses = vm.stopAndReturnStateDiff();
+
+        address[] memory allowed = getAllowedStorageAccess();
+        address[] memory changed = accesses.getUniqueWrites(false);
+        assertEq(allowed.length, changed.length, "storage allowlist contains addresses without changed writes");
+        for (uint256 i = 0; i < changed.length; i++) {
+            assertTrue(_contains(allowed, changed[i]), "changed-write account is not allowlisted");
+        }
+    }
+
+    function test_task_storage_writes_excludes_automatic_safe_key() public pure {
+        string[] memory storageWrites = _taskStorageWrites();
+        bytes32 safeKey = keccak256(bytes(safeAddressString()));
+        for (uint256 i = 0; i < storageWrites.length; i++) {
+            assertNotEq(keccak256(bytes(storageWrites[i])), safeKey, "safe key is added automatically");
+        }
+    }
+
+    function _contains(address[] memory addresses, address candidate) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == candidate) return true;
+        }
+        return false;
     }
 
     function _executeActions(Action[] memory actions) internal {

--- a/test/integration/SuperRootUpgrade.t.sol
+++ b/test/integration/SuperRootUpgrade.t.sol
@@ -7,7 +7,6 @@ import {VmSafe} from "forge-std/Vm.sol";
 import {IGnosisSafe} from "@base-contracts/script/universal/IGnosisSafe.sol";
 import {IDisputeGameFactory, IOPContractsManagerV800, OPCMUpgradeV800} from "src/template/OPCMUpgradeV800.sol";
 import {SuperchainAddressRegistry} from "src/SuperchainAddressRegistry.sol";
-import {AccountAccessParser} from "src/libraries/AccountAccessParser.sol";
 import {Action} from "src/libraries/MultisigTypes.sol";
 
 interface IProxyAdmin {
@@ -45,8 +44,6 @@ contract SuperRootUpgradeSetupValidationTest is Test, OPCMUpgradeV800 {
 }
 
 contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
-    using AccountAccessParser for VmSafe.AccountAccess[];
-
     string constant FIXTURES = "test/tasks/example/sep/035-opcm-upgrade-v800/";
     uint256 internal constant FORK_BLOCK_NUMBER = 11_619_054;
     address internal constant ROOT_SAFE = 0xe934Dc97E347C6aCef74364B50125bb8689c40ff;
@@ -214,39 +211,6 @@ contract SuperRootUpgradeTest is Test, OPCMUpgradeV800 {
         _executeActions(actions);
 
         _validate(new VmSafe.AccountAccess[](0), actions, rootSafe);
-    }
-
-    function test_storage_allowlist_matches_changed_write_accounts() public {
-        templateConfig.allowedStorageKeys = _taskStorageWrites();
-        templateConfig.allowedStorageKeys.push(safeAddressString());
-        _setAllowedStorageAccesses();
-
-        Action[] memory actions = build(rootSafe);
-        vm.startStateDiffRecording();
-        _executeActions(actions);
-        VmSafe.AccountAccess[] memory accesses = vm.stopAndReturnStateDiff();
-
-        address[] memory allowed = getAllowedStorageAccess();
-        address[] memory changed = accesses.getUniqueWrites(false);
-        assertEq(allowed.length, changed.length, "storage allowlist contains addresses without changed writes");
-        for (uint256 i = 0; i < changed.length; i++) {
-            assertTrue(_contains(allowed, changed[i]), "changed-write account is not allowlisted");
-        }
-    }
-
-    function test_task_storage_writes_excludes_automatic_safe_key() public pure {
-        string[] memory storageWrites = _taskStorageWrites();
-        bytes32 safeKey = keccak256(bytes(safeAddressString()));
-        for (uint256 i = 0; i < storageWrites.length; i++) {
-            assertNotEq(keccak256(bytes(storageWrites[i])), safeKey, "safe key is added automatically");
-        }
-    }
-
-    function _contains(address[] memory addresses, address candidate) internal pure returns (bool) {
-        for (uint256 i = 0; i < addresses.length; i++) {
-            if (addresses[i] == candidate) return true;
-        }
-        return false;
     }
 
     function _executeActions(Action[] memory actions) internal {


### PR DESCRIPTION
The V800 template now removes the canonical SuperchainConfig address inserted by L2TaskBase before adding the configured chain address. It also drops ProxyAdminOwner from _taskStorageWrites() because _taskSetup() appends the Safe key automatically.

The final diff is limited to OPCMUpgradeV800.sol: 8 insertions and 8 deletions.

Checks run:
- forge fmt --check (pinned Forge 1.1.0)
- FOUNDRY_PROFILE=ci forge build --deny-warnings (pinned Forge 1.1.0)
- check-struct-order.sh
- existing SuperRootUpgradeTest suite: 4 passed, 0 failed