### PR TITLE
Update task 105 106 sep status

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -29,7 +29,10 @@ deny_warnings = true
 [profile.ci.rpc_endpoints]
 mainnet = "${OP_CI_MAINNET_L1_ARCHIVE_RPC_URL}"
 sepolia = "${OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL}"
-opSepolia = "${OP_CI_SEPOLIA_L2_RPC_URL}"
+# The OP_CI_SEPOLIA_L2_RPC_URL node prunes state after a few hours, which breaks every pinned
+# OP Sepolia fork (Regression.t.sol SetFeeVaultConfigPinnedL2Fork, test/tasks/example/opsep/*).
+# The public endpoint serves historical state, so CI uses it directly.
+opSepolia = "https://sepolia.optimism.io"
 opMainnet = "${OP_CI_MAINNET_L2_RPC_URL}"
 
 [profile.default.rpc_endpoints]

--- a/src/tasks/sep/105-mmzd-l1-ownership-transfers/README.md
+++ b/src/tasks/sep/105-mmzd-l1-ownership-transfers/README.md
@@ -1,6 +1,6 @@
 # 105-mmzd-l1-ownership-transfers
 
-Status: [READY TO SIGN]
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x8c22169b916f8823f676da5a12426737fc9beeb49bca88fa9fe35f5613e2096b)
 
 ## Objective
 

--- a/src/tasks/sep/106-mmzd-l2pao-transfer/README.md
+++ b/src/tasks/sep/106-mmzd-l2pao-transfer/README.md
@@ -1,6 +1,6 @@
 # 106-mmzd-l2pao-transfer
 
-Status: [READY TO SIGN]
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x75f08552c25869942dab85ea45e9eb97db56407d993eefeac728fd1b0f9d5230)
 
 ## Objective
 

--- a/test/tasks/example/sep/041-set-fee-vault-config/config.toml
+++ b/test/tasks/example/sep/041-set-fee-vault-config/config.toml
@@ -31,8 +31,8 @@ networks             = [0]   # 0 = WithdrawalNetwork.L1
 minWithdrawalAmounts = [0]
 
 # REQUIRED: L2 RPC per chain (same order as l2chains) for the ProxyAdmin-owner preflight,
-# version gate, and setter dry-run. "opSepolia" is a foundry.toml RPC alias (the CI
-# endpoint under the ci profile; public https://sepolia.optimism.io locally).
+# version gate, and setter dry-run. "opSepolia" is a foundry.toml RPC alias (the public
+# https://sepolia.optimism.io endpoint under both the default and ci profiles).
 l2RpcUrls = ["opSepolia"]
 
 [addresses]


### PR DESCRIPTION
Marks sep/105 and sep/106 as EXECUTED with their Sepolia execution transactions.

This also carries the CI fix for the red `forge_test` and `template_regression_tests` jobs, which have failed on `main` since this morning with:

```
error code -32603: state at block #48340829 is pruned
```

The node behind `OP_CI_SEPOLIA_L2_RPC_URL` keeps only a few hours of state. The public `https://sepolia.optimism.io` endpoint does serve historical state, at the current pin and at the July pin 46429711, so the ci profile now uses it, matching what the default profile already uses locally. The pinned blocks are unchanged.