### PR TITLE
ci: fork OP Sepolia from an archive-capable endpoint

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -29,7 +29,10 @@ deny_warnings = true
 [profile.ci.rpc_endpoints]
 mainnet = "${OP_CI_MAINNET_L1_ARCHIVE_RPC_URL}"
 sepolia = "${OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL}"
-opSepolia = "${OP_CI_SEPOLIA_L2_RPC_URL}"
+# The OP_CI_SEPOLIA_L2_RPC_URL node prunes state after a few hours, which breaks every pinned
+# OP Sepolia fork (Regression.t.sol SetFeeVaultConfigPinnedL2Fork, test/tasks/example/opsep/*).
+# The public endpoint serves historical state, so CI uses it directly.
+opSepolia = "https://sepolia.optimism.io"
 opMainnet = "${OP_CI_MAINNET_L2_RPC_URL}"
 
 [profile.default.rpc_endpoints]

--- a/test/tasks/example/sep/041-set-fee-vault-config/config.toml
+++ b/test/tasks/example/sep/041-set-fee-vault-config/config.toml
@@ -31,8 +31,8 @@ networks             = [0]   # 0 = WithdrawalNetwork.L1
 minWithdrawalAmounts = [0]
 
 # REQUIRED: L2 RPC per chain (same order as l2chains) for the ProxyAdmin-owner preflight,
-# version gate, and setter dry-run. "opSepolia" is a foundry.toml RPC alias (the CI
-# endpoint under the ci profile; public https://sepolia.optimism.io locally).
+# version gate, and setter dry-run. "opSepolia" is a foundry.toml RPC alias (the public
+# https://sepolia.optimism.io endpoint under both the default and ci profiles).
 l2RpcUrls = ["opSepolia"]
 
 [addresses]


### PR DESCRIPTION
Since #1540 landed this morning, `forge_test` and `template_regression_tests` are red on `main` and on every open PR. Both fail with the same error from the OP Sepolia fork:

```
error code -32603: state at block #48340829 is pruned
```

The node behind `OP_CI_SEPOLIA_L2_RPC_URL`, which the ci profile resolves the `opSepolia` alias to, keeps only a few hours of state. #1540 pinned `SetFeeVaultConfigPinnedL2Fork` and the `opsep/001` example to finalized block 48340828 at 02:33 UTC; `main` passed at 02:45 and 04:28 and has failed every run since 08:31. Any pin will rot on that node within the same day, so refreshing the block is not a fix.

The public `https://sepolia.optimism.io` endpoint does serve historical state. It answers `eth_getCode`, `eth_getBalance` and `eth_getStorageAt` at the current pin and at the previous pin 46429711 from July. This PR points the ci profile's `opSepolia` alias at it, matching what the default profile already uses locally, and updates the fixture comment that described the two profiles as using different endpoints.

Verified locally under `FOUNDRY_PROFILE=ci` with a public L1 archive endpoint standing in for the L1 secret:

```
forge test --match-test testRegressionCallDataMatches_SetFeeVaultConfig   # PASS
src/script/simulate-task.sh test/tasks/example/opsep/001-set-eip1967-impl TestFakeCouncil "" opsep   # Script ran successfully
```

If infra would rather keep a private endpoint in CI, rotating `OP_CI_SEPOLIA_L2_RPC_URL` to an archive node and reverting this one line is equivalent. The pinned blocks themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)