### PR TITLE
sep/107: mark EXECUTED; honor FORK_BLOCK_NUMBER in getRootSafe helper calls

### DIFF
--- a/src/justfile
+++ b/src/justfile
@@ -195,7 +195,7 @@ sign-stack NETWORK="" TASK="" CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2
     elif [ "$child_safe_depth_1" != "$ZERO_ADDRESS" ]; then
         target_safe="$child_safe_depth_1"
     else
-        target_safe=$(forge script TaskManager --sig "getRootSafe(string)" "${root_dir}/src/tasks/{{NETWORK}}/{{TASK}}/config.toml" --fork-url $ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} --json | jq -r '.returns["0"].value')
+        target_safe=$(forge script TaskManager --sig "getRootSafe(string)" "${root_dir}/src/tasks/{{NETWORK}}/{{TASK}}/config.toml" --fork-url $ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} ${fork_block_args} --json | jq -r '.returns["0"].value')
     fi
 
     # Validate that signer is an owner on the target safe
@@ -286,15 +286,17 @@ simulate CHILD_SAFE_NAME_DEPTH_1="" CHILD_SAFE_NAME_DEPTH_2="":
     ETH_RPC_URL=$("$root_dir"/src/script/get-rpc-url.sh "$network")
     HD_PATH=${HD_PATH:-0}
 
+    # Get fork block arguments first: every forge invocation below (root-safe lookup, signer
+    # resolution, simulation) must read the same pinned state, otherwise FORK_BLOCK_NUMBER
+    # only applies to the final simulation while the helpers fork at the latest block.
+    fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
+
     # Get function signature and arguments using helper
     eval "$(just --justfile "$root_just_file" _build-simulate-args "$TASK_PATH" "$config_path" "{{CHILD_SAFE_NAME_DEPTH_1}}" "{{CHILD_SAFE_NAME_DEPTH_2}}")"
-    
+
     # Configure signer for simulation
     signer=$(just --justfile "$root_just_file" _get-simulation-signer "$config_path" "$ETH_RPC_URL" "$child_safe_depth_1" "$child_safe_depth_2")
-    
-    # Get fork block arguments
-    fork_block_args=$(just --justfile "$root_just_file" _get-fork-block-args)
-    
+
     echo -e "⏳ Simulating task: $task_name for network: '$network' on $target_safe\n"
     forge script ${script_name} --sig "$sig" "${args[@]}" --ffi --fork-url $ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} --sender ${signer} ${fork_block_args}
 
@@ -508,7 +510,11 @@ _get-simulation-signer CONFIG_PATH ETH_RPC_URL CHILD_SAFE_DEPTH_1 CHILD_SAFE_DEP
         elif [ "{{CHILD_SAFE_DEPTH_1}}" != "$ZERO_ADDRESS" ]; then
             safe_for_signer="{{CHILD_SAFE_DEPTH_1}}" 
         else
-            safe_for_signer=$(forge script TaskManager --sig "getRootSafe(string)" "{{CONFIG_PATH}}" --fork-url "{{ETH_RPC_URL}}" --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}}  --json | jq -r '.returns["0"].value')
+            # Honor FORK_BLOCK_NUMBER: getRootSafe builds the SuperchainAddressRegistry, whose on-chain
+            # discovery must read the same pinned state as the simulation that follows.
+            fork_block_args=$(just --justfile "$(git rev-parse --show-toplevel)/src/justfile" _get-fork-block-args)
+            # shellcheck disable=SC2086  # fork_block_args must word-split ("--fork-block-number <n>" or empty)
+            safe_for_signer=$(forge script TaskManager --sig "getRootSafe(string)" "{{CONFIG_PATH}}" --fork-url "{{ETH_RPC_URL}}" --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} ${fork_block_args} --json | jq -r '.returns["0"].value')
         fi
         signer=$(cast call ${safe_for_signer} "getOwners()(address[])" -r "{{ETH_RPC_URL}}" | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
         echo "Simulating without ledger using first owner from safe ${safe_for_signer}: ${signer}" >&2
@@ -566,7 +572,9 @@ _build-simulate-args TASK_DIR_PATH CONFIG_PATH CHILD_SAFE_NAME_DEPTH_1 CHILD_SAF
         echo "sig=\"simulate(string)\""
         echo "args=(\"{{CONFIG_PATH}}\")"
         echo "target_safe=\"default safes\""
-        echo "target_safe_for_validation=\"\$(forge script TaskManager --sig 'getRootSafe(string)' '{{CONFIG_PATH}}' --fork-url \$ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} --json | jq -r '.returns[\"0\"].value')\""
+        # fork_block_args is defined by callers that pin a block (simulate); callers that must run
+        # against the latest block (sign) leave it unset, hence the :- default.
+        echo "target_safe_for_validation=\"\$(forge script TaskManager --sig 'getRootSafe(string)' '{{CONFIG_PATH}}' --fork-url \$ETH_RPC_URL --fork-retries {{forge_fork_retries}} --fork-retry-backoff {{forge_fork_retry_backoff}} \${fork_block_args:-} --json | jq -r '.returns[\"0\"].value')\""
     fi
 
 [no-cd]

--- a/src/tasks/sep/107-U20-sepolia-devnet-2-3/README.md
+++ b/src/tasks/sep/107-U20-sepolia-devnet-2-3/README.md
@@ -1,6 +1,6 @@
 # 107-U20-sepolia-devnet-2-3
 
-Status: [READY TO SIGN]
+Status: [EXECUTED](https://sepolia.etherscan.io/tx/0x8e8ed3d668f06a1430db793eff681849c837597ae5aa6358009d57c0a2bc61b4)
 
 ## Objective
 


### PR DESCRIPTION
`stacked_simulation_sep` and `template_regression_tests` are failing on main with:

```
Error: script failed: SuperchainAddressRegistry: zero address for PermissionedDisputeGame
```

**sep/107** (U20 on sepolia devnets) has been executed ([tx 0x8e8ed3d6…](https://sepolia.etherscan.io/tx/0x8e8ed3d668f06a1430db793eff681849c837597ae5aa6358009d57c0a2bc61b4)). 

The upgrade cleared the CANNON (0), PERMISSIONED_CANNON (1) and CANNON_KONA (8) impls on both devnet `DisputeGameFactory`s and installed SUPER_PERMISSIONED (5) / SUPER_CANNON_KONA (9). 

`SuperchainAddressRegistry._saveDisputeGameEntries` requires `gameImpls(1) != 0`. 

Live discovery for those two chains now reverts.

## Changes

1. **sep/107 → EXECUTED.** Empties the sep stack, fixing `stacked_simulation_sep`.

2. **Pin the `getRootSafe` helper calls to `FORK_BLOCK_NUMBER`.** 

- The failing fixture in `template_regression_tests` is `test/tasks/example/sep/035-opcm-upgrade-v800`, pinned to block 11619054 where game type 1 still exists. 

- The pin was applied to the `isNestedTask` check and the final `forge script`, but not to the `getRootSafe` lookups in `_get-simulation-signer` and `_build-simulate-args`, which forked at the latest block and constructed the registry there. 

- The CI log shows this: task 035 prints "Using fork block number" once, every other pinned task prints it twice. `simulate` now computes `fork_block_args` before the helpers and passes it to every `getRootSafe` call (`simulate`, `_get-simulation-signer`, `_build-simulate-args`, `sign-stack`). 

- `sign` still runs at the latest block; the emitted command defaults the variable to empty there.

## Verification

- `bash src/script/simulate-task.sh test/tasks/example/sep/035-opcm-upgrade-v800 "" "" sep` with `OVERRIDE_RPC_URL` set to an archive Sepolia endpoint: prints the pin for all three forge invocations, resolves the root Safe, and completes.
- `just list-stack sep`: "No non-terminal tasks found for network: sep".
- `bash src/script/check-task-statuses.sh`: passes.

## Follow-up (not in this PR)

Any new task on sepolia-devnet-2/3 at the latest block will still fail registry discovery until `SuperchainAddressRegistry` understands super-games chains (fall back to game type 5 when game type 1 is empty). The v8 SUPER_PERMISSIONED `gameArgs` are proposer-only, so Challenger/ASR/WETH need another source.
