### PR TITLE
fix(ci): restore internal OP Sepolia RPC

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -29,10 +29,7 @@ deny_warnings = true
 [profile.ci.rpc_endpoints]
 mainnet = "${OP_CI_MAINNET_L1_ARCHIVE_RPC_URL}"
 sepolia = "${OP_CI_SEPOLIA_L1_ARCHIVE_RPC_URL}"
-# The OP_CI_SEPOLIA_L2_RPC_URL node prunes state after a few hours, which breaks every pinned
-# OP Sepolia fork (Regression.t.sol SetFeeVaultConfigPinnedL2Fork, test/tasks/example/opsep/*).
-# The public endpoint serves historical state, so CI uses it directly.
-opSepolia = "https://sepolia.optimism.io"
+opSepolia = "${OP_CI_SEPOLIA_L2_RPC_URL}"
 opMainnet = "${OP_CI_MAINNET_L2_RPC_URL}"
 
 [profile.default.rpc_endpoints]


### PR DESCRIPTION
Restores `OP_CI_SEPOLIA_L2_RPC_URL` for the CI `opSepolia` alias and removes the public-RPC workaround from #1541. Mainnet CI already uses `OP_CI_MAINNET_L2_RPC_URL`.

Merge after ethereum-optimism/k8s#13160 is deployed: that change makes the existing shared L2 consensus pools archive-only.

No pinned blocks need updating. The OP Sepolia L2 fixtures use block `48,340,828`; historical balance, code, storage and `optimism_outputAtBlock` reads succeeded against every selected backend during the prerequisite review. No pinned OP Mainnet L2 forks were found in the CI tests. Mainnet history remains incomplete: all three selected backends served `145,229,149`, while `145,229,148` returned a pruned-state error.

Validation: TOML comparison confirms only the CI Sepolia alias changes; Forge 1.1.0 parses both internal CI aliases; `git diff --check` passes. Direct CI endpoint requests return HTTP 403 from this workstation, and local Forge tests could not compile without the worktree submodules. The PR CI runs are the end-to-end validation; require `forge_test` and `template_regression_tests` to pass after the routing deployment.
